### PR TITLE
Fix package edit and add test coverage for fix

### DIFF
--- a/packages/composer-playground/src/app/editor-file/editor-file.component.html
+++ b/packages/composer-playground/src/app/editor-file/editor-file.component.html
@@ -1,9 +1,8 @@
 <div class="readme" *ngIf="editorType === 'readme'" [innerHTML]="editorContent">
 </div>
 
-<codemirror *ngIf="editorType === 'code'" [(ngModel)]="editorContent" [config]="codeConfig"
-            (ngModelChange)="onCodeChanged()" width="100%"
-            height="100%">
+<codemirror name="editorCodeMirror" *ngIf="editorType === 'code'" [(ngModel)]="editorContent" [config]="codeConfig"
+            (ngModelChange)="onCodeChanged()" width="100%" height="100%" ngDefaultControl>
 </codemirror>
 
 <div class="alert-area" role="alert" *ngIf="currentError">

--- a/packages/composer-playground/src/app/editor/editor.component.html
+++ b/packages/composer-playground/src/app/editor/editor.component.html
@@ -63,16 +63,16 @@
     </div>
     <div *ngIf="editActive" class="business-network-details">
       <label class="edit-label margin-right" for="editName">Name</label>
-      <input class="margin-right" id="editName" type="text" focusHere (blur)="editPackageName()" [(ngModel)]="inputPackageName">
+      <input class="margin-right" id="editName" type="text" (blur)="editPackageName()" [(ngModel)]="inputPackageName">
       <label class="edit-label margin-right" for="editVersion">Version</label>
       <input class="margin-right" id="editVersion" type="text" (blur)="editPackageVersion()"
              [(ngModel)]="inputPackageVersion">
       <div class="edit-package-text margin-right">
         <button type="button" class="action" (click)="setCurrentFile({
-      package: true,
-      id: 'package',
-      displayID: 'package.json'
-    });hideEdit();">View/edit full metadata in package.json
+          package: true,
+          id: 'package',
+          displayID: 'package.json'
+        });hideEdit();">View/edit full metadata in package.json
         </button>
       </div>
     </div>

--- a/packages/composer-playground/src/app/editor/editor.component.html
+++ b/packages/composer-playground/src/app/editor/editor.component.html
@@ -54,7 +54,7 @@
       <div style="flex-shrink:1;align-self:center" class="business-network-version small">{{deployedPackageVersion}}
       </div>
       <div style="flex-shrink:1;align-self:center">
-        <button type="button" class="action" style="padding-top:4px;" (click)="toggleEditActive()">
+        <button id="editFileButton" type="button" class="action" style="padding-top:4px;" (click)="toggleEditActive()">
           <svg class="ibm-icon vertical-top" aria-hidden="true">
             <use xlink:href="#icon-edit_24"></use>
           </svg>
@@ -68,7 +68,7 @@
       <input class="margin-right" id="editVersion" type="text" (blur)="editPackageVersion()"
              [(ngModel)]="inputPackageVersion">
       <div class="edit-package-text margin-right">
-        <button type="button" class="action" (click)="setCurrentFile({
+        <button id="editPackageButton" type="button" class="action" (click)="setCurrentFile({
           package: true,
           id: 'package',
           displayID: 'package.json'

--- a/packages/composer-playground/src/app/editor/editor.component.spec.ts
+++ b/packages/composer-playground/src/app/editor/editor.component.spec.ts
@@ -630,6 +630,75 @@ describe('EditorComponent', () => {
 
       component['editActive'].should.equal(true);
     });
+
+    it('should make edit fields visible when true', () => {
+      component['editActive'] = false;
+      component['editingPackage'] = false;
+      component['deployedPackageName'] = 'TestPackageName';
+      component['deployedPackageVersion'] = '1.0.0';
+      fixture.detectChanges();
+      
+      // Expect to see "deployedPackageName" visible within class="business-network-details"
+      // Expect to have "edit" option available within class="business-network-details"
+      let element = fixture.debugElement.query(By.css('.business-network-details')).nativeElement; 
+      element.textContent.should.contain('TestPackageName');
+      element.innerHTML.should.contain('id="editFileButton"');
+
+      // Flip editActive boolean
+      component['editActive'] = true;
+      fixture.detectChanges();
+
+      // Expect three visible edit fields:
+      // 1) Name (input text)
+      // 2) Version (input text)
+      // 3) Full package (button)      
+      element = fixture.debugElement.query(By.css('.business-network-details')).nativeElement; 
+      element.innerHTML.should.not.contain('id="editFileButton"');
+      element.innerHTML.should.contain('id="editPackageButton"');
+      element.textContent.should.contain('Name');
+      element.textContent.should.contain('Version');
+      element.textContent.should.contain('View/edit full metadata in package.json');
+
+    });
+
+    it('should make edit fields interactable when true', () => {
+      component['editActive'] = true;
+
+      fixture.detectChanges();
+
+      // Expect edit fields:
+      // 1) Name & Version (input text) should not be editable (focused)
+      // 3) Full package (button) to be enabled
+
+      let editItem = fixture.debugElement.query(By.css('#editName')).nativeElement;
+      (editItem as HTMLInputElement).isContentEditable.should.be.false;      
+
+      editItem = fixture.debugElement.query(By.css('#editVersion')).nativeElement;
+      (editItem as HTMLInputElement).isContentEditable.should.be.false;
+
+      editItem = fixture.debugElement.query(By.css('#editPackageButton')).nativeElement; 
+      (editItem as HTMLButtonElement).disabled.should.be.false;
+
+    });
+
+    it('should only show package information if editingPackage==true', () => {
+      component['editingPackage'] = true;
+      component['deployedPackageName'] = 'TestPackageName';
+
+      fixture.detectChanges();
+
+      // Grab element
+      let element = fixture.debugElement.query(By.css('.business-network-details')).nativeElement; 
+      
+      // Should contain package name edit only
+      element.textContent.should.contain('Editing package.json');
+
+      // Should not contain any buttons/text entry      
+      should.not.exist(fixture.debugElement.query(By.css('#editName')));
+      should.not.exist(fixture.debugElement.query(By.css('#editVersion')));
+      should.not.exist(fixture.debugElement.query(By.css('#editPackageButton')));
+    });
+
   });
 
   describe('editPackageName', () => {
@@ -657,13 +726,14 @@ describe('EditorComponent', () => {
   });
 
   describe('hide edit', () => {
-    it('should hide edit', () => {
-      let mockToggleEdit = sinon.stub(component, 'toggleEditActive');
+    it('should set editActive false, and editingPackage true', () => {      
+      component['editingPackage'] = false;
+      component['editActive'] = true;
 
       component.hideEdit();
 
-      mockToggleEdit.should.have.been.called;
       component['editingPackage'].should.equal(true);
+      component['editActive'].should.equal(false);
     });
   });
 });

--- a/packages/composer-playground/src/app/editor/editor.component.ts
+++ b/packages/composer-playground/src/app/editor/editor.component.ts
@@ -75,10 +75,8 @@ export class EditorComponent implements OnInit {
         this.updateFiles();
 
         if(this.editorService.getCurrentFile() !== null) {
-          // console.log('A: ', this.editorService.getCurrentFile());
           this.currentFile = this.editorService.getCurrentFile();
         } else {
-          // console.log('B');
           if (this.files.length) {
             let initialFile = this.files.find((file) => {
               return file.readme;
@@ -93,7 +91,7 @@ export class EditorComponent implements OnInit {
   }
 
   updatePackageInfo() {
-    this.deployedPackageName = this.clientService.getMetaData().getName(); // Set Name
+  this.deployedPackageName = this.clientService.getMetaData().getName(); // Set Name
     this.deployedPackageVersion = this.clientService.getMetaData().getVersion(); // Set Version
     this.deployedPackageDescription = this.clientService.getMetaData().getDescription(); // Set Description
     this.inputPackageName = this.clientService.getMetaData().getName();
@@ -101,12 +99,12 @@ export class EditorComponent implements OnInit {
   }
 
   setCurrentFile(file) {
-    if (this.editingPackage) {
+  if (this.editingPackage) {
       this.updatePackageInfo();
       this.editingPackage = false;
     }
 
-    this.editorService.setCurrentFile(file);
+  this.editorService.setCurrentFile(file);
     this.currentFile = file;
   }
 
@@ -143,6 +141,7 @@ export class EditorComponent implements OnInit {
     });
     newFiles.push.apply(newFiles, newScriptFiles);
 
+    // deal with acl files
     let aclFile = this.clientService.getAclFile();
     if (aclFile) {
       newFiles.push({
@@ -152,6 +151,7 @@ export class EditorComponent implements OnInit {
       });
     }
 
+    // deal with readme
     let readme = this.clientService.getMetaData().getREADME();
     if (readme) {
       //add it first so it appears at the top of the list
@@ -307,8 +307,8 @@ export class EditorComponent implements OnInit {
    */
   editPackageName() {
     this.deployedPackageName = this.inputPackageName;
-
-    this.clientService.setBusinessNetworkName(this.deployedPackageName);
+    
+  this.clientService.setBusinessNetworkName(this.deployedPackageName);
 
     this.editActive = false;
   }

--- a/packages/composer-playground/src/app/editor/editor.component.ts
+++ b/packages/composer-playground/src/app/editor/editor.component.ts
@@ -91,20 +91,22 @@ export class EditorComponent implements OnInit {
   }
 
   updatePackageInfo() {
-  this.deployedPackageName = this.clientService.getMetaData().getName(); // Set Name
+    this.deployedPackageName = this.clientService.getMetaData().getName(); // Set Name
     this.deployedPackageVersion = this.clientService.getMetaData().getVersion(); // Set Version
     this.deployedPackageDescription = this.clientService.getMetaData().getDescription(); // Set Description
     this.inputPackageName = this.clientService.getMetaData().getName();
     this.inputPackageVersion = this.clientService.getMetaData().getVersion();
   }
 
-  setCurrentFile(file) {
-  if (this.editingPackage) {
+  setCurrentFile(file) {    
+    if (this.editingPackage) {
       this.updatePackageInfo();
       this.editingPackage = false;
     }
-
-  this.editorService.setCurrentFile(file);
+    // Reset editActive
+    this.editActive = false;
+    // Set selected file
+    this.editorService.setCurrentFile(file);
     this.currentFile = file;
   }
 
@@ -308,9 +310,7 @@ export class EditorComponent implements OnInit {
   editPackageName() {
     this.deployedPackageName = this.inputPackageName;
     
-  this.clientService.setBusinessNetworkName(this.deployedPackageName);
-
-    this.editActive = false;
+    this.clientService.setBusinessNetworkName(this.deployedPackageName);
   }
 
   /*
@@ -320,12 +320,10 @@ export class EditorComponent implements OnInit {
     this.deployedPackageVersion = this.inputPackageVersion;
 
     this.clientService.setBusinessNetworkVersion(this.deployedPackageVersion);
-
-    this.editActive = false;
   }
 
   hideEdit() {
-    this.toggleEditActive();
+    this.editActive = false;
     this.editingPackage = true;
   }
 }

--- a/packages/composer-playground/src/app/services/client.service.ts
+++ b/packages/composer-playground/src/app/services/client.service.ts
@@ -152,14 +152,18 @@ export class ClientService {
     let oldBusinessNetwork = this.getBusinessNetwork();
 
     this.currentBusinessNetwork = this.createBusinessNetwork(name + '@' + version, description, packageJson, readme);
-    this.currentBusinessNetwork.getModelManager().addModelFiles(oldBusinessNetwork.getModelManager().getModelFiles());
+  this.currentBusinessNetwork.getModelManager().addModelFiles(oldBusinessNetwork.getModelManager().getModelFiles());
 
     oldBusinessNetwork.getScriptManager().getScripts().forEach((script) => {
       this.currentBusinessNetwork.getScriptManager().addScript(script);
     });
 
-    this.currentBusinessNetwork.getAclManager().setAclFile(oldBusinessNetwork.getAclManager().getAclFile());
+    if (oldBusinessNetwork.getAclManager().getAclFile()) {
+      this.currentBusinessNetwork.getAclManager().setAclFile(oldBusinessNetwork.getAclManager().getAclFile());
+    }
+  
     this.businessNetworkChanged$.next(true);
+    
   }
 
   ensureConnected(): Promise<any> {


### PR DESCRIPTION
Fix required to enable package edit in #683 


## Steps to Reproduce
Open an instance of composer (either on bluemix or local), open a file (LHS)
-> if no ACL present, errors will be shown inthe console

Do above, select edit, select "edit package". This will result in the inability to edit the package.


## Design of the fix
Condition use of acl file during project import
Edit html to enable package edit click action
Edit component file to change logic behind view/navigation operations

## Validation of the fix
Manual testing and extended automated testing

## Automated Tests
Automated testing is included as part of fix


