### PR TITLE
Remove error message on file load and add test to support this oepration

### DIFF
--- a/packages/composer-playground/src/app/editor-file/editor-file.component.spec.ts
+++ b/packages/composer-playground/src/app/editor-file/editor-file.component.spec.ts
@@ -218,6 +218,15 @@ describe('EditorFileComponent', () => {
       should.not.exist(component['editorType']);
     });
 
+    it('should set currentError to null', () => {
+      component['_editorFile'] = {};
+      component['currentError'] = 'Test error message';
+
+      component.loadFile();
+
+      should.not.exist(component['currentError']);
+    });
+
   });
 
   describe('setCurrentCode', () => {

--- a/packages/composer-playground/src/app/editor-file/editor-file.component.ts
+++ b/packages/composer-playground/src/app/editor-file/editor-file.component.ts
@@ -61,6 +61,7 @@ export class EditorFileComponent {
 
   loadFile() {
     this.changingCurrentFile = true;
+    this.currentError = null;
     if (this._editorFile.model) {
       let modelFile = this.clientService.getModelFile(this._editorFile.id);
       if (modelFile) {


### PR DESCRIPTION
#683 highlights the retaining of an error message across files opened by a user in composer. This fix addressed the persisted (and invalid) error message and includes a test to encapsulate the new behaviour.

## Issue/User story
#683 

## Steps to Reproduce
Open composer
Open a file
Make file invalid and observe error message displayed
Navigate to different file
See persisted error message

## Design of the fix
within loadFile() operation, set error message to null

## Validation of the fix
manual testing

## Automated Tests
Test added to encapsulate operation
