### PR TITLE
Add missing method for HLFv1 connector and ping in establishment of admin connection

### DIFF
--- a/packages/composer-admin/lib/adminconnection.js
+++ b/packages/composer-admin/lib/adminconnection.js
@@ -88,7 +88,12 @@ class AdminConnection {
             })
             .then((securityContext) => {
                 this.securityContext = securityContext;
-                return Promise.resolve('connected');
+                if (businessNetworkIdentifier) {
+                    return this.connection.ping(this.securityContext);
+                }
+            })
+            .then(() => {
+
             });
     }
 

--- a/packages/composer-admin/test/adminconnection.js
+++ b/packages/composer-admin/test/adminconnection.js
@@ -113,11 +113,23 @@ describe('AdminConnection', () => {
 
     describe('#connect', () => {
 
-        it('should return connected connection', () => {
-            return adminConnection.connect('testprofile', 'testnetwork', 'WebAppAdmin', 'DJY27pEnl16d')
-            .then((res) => {
-                res.should.equal('connected');
-            });
+        it('should connect, login and ping if business network specified', () => {
+            return adminConnection.connect('testprofile', 'WebAppAdmin', 'DJY27pEnl16d', 'testnetwork')
+                .then(() => {
+                    sinon.assert.calledOnce(mockConnection.login);
+                    sinon.assert.calledWith(mockConnection.login, 'WebAppAdmin', 'DJY27pEnl16d');
+                    sinon.assert.calledOnce(mockConnection.ping);
+                    sinon.assert.calledWith(mockConnection.ping, mockSecurityContext);
+                });
+        });
+
+        it('should connect and login if business network not specified', () => {
+            return adminConnection.connect('testprofile', 'WebAppAdmin', 'DJY27pEnl16d')
+                .then(() => {
+                    sinon.assert.calledOnce(mockConnection.login);
+                    sinon.assert.calledWith(mockConnection.login, 'WebAppAdmin', 'DJY27pEnl16d');
+                    sinon.assert.notCalled(mockConnection.ping);
+                });
         });
 
     });

--- a/packages/composer-connector-hlfv1/lib/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/lib/hlfconnection.js
@@ -714,9 +714,28 @@ class HLFConnection extends Connection {
      * business network identifiers, or rejected with an error.
      */
     list(securityContext) {
+        const method = 'list';
+        LOG.entry(method, securityContext);
 
-        // We do not want to persist the list of business networks client side if possible.
-        return Promise.reject(new Error('unimplemented function called'));
+        // Check that a valid security context has been specified.
+        HLFUtil.securityCheck(securityContext);
+
+        // Query all instantiated chaincodes.
+        return this.chain.queryInstantiatedChaincodes()
+            .then((queryResults) => {
+                LOG.debug(method, 'Queried instantiated chaincodes', queryResults);
+                const result = queryResults.chaincodes.filter((chaincode) => {
+                    return chaincode.path === 'composer';
+                }).map((chaincode) => {
+                    return chaincode.name;
+                });
+                LOG.exit(method, result);
+                return result;
+            })
+            .catch((error) => {
+                LOG.error(method, error);
+                throw error;
+            });
 
     }
 

--- a/packages/composer-connector-hlfv1/test/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/test/hlfconnection.js
@@ -1176,9 +1176,50 @@ describe('HLFConnection', () => {
 
     describe('#list', () => {
 
-        it('should throw an error as not implemented yet', () => {
+        it('should return an empty array if no instantiated chaincodes', () => {
+            mockChain.queryInstantiatedChaincodes.resolves({
+                chaincodes: []
+            });
             return connection.list(mockSecurityContext)
-                .should.be.rejectedWith(/unimplemented function called/);
+                .should.eventually.be.deep.equal([]);
+        });
+
+        it('should return an array of chaincode names for all instantiated chaincodes', () => {
+            mockChain.queryInstantiatedChaincodes.resolves({
+                chaincodes: [{
+                    name: 'org.acme.biznet1',
+                    version: '1.0.0',
+                    path: 'composer'
+                }, {
+                    name: 'org.acme.biznet2',
+                    version: '1.2.0',
+                    path: 'composer'
+                }]
+            });
+            return connection.list(mockSecurityContext)
+                .should.eventually.be.deep.equal(['org.acme.biznet1', 'org.acme.biznet2']);
+        });
+
+        it('should filter out any non-composer instantiated chaincodes', () => {
+            mockChain.queryInstantiatedChaincodes.resolves({
+                chaincodes: [{
+                    name: 'org.acme.biznet1',
+                    version: '1.0.0',
+                    path: 'composer'
+                }, {
+                    name: 'org.acme.biznet2',
+                    version: '1.2.0',
+                    path: 'dogecc'
+                }]
+            });
+            return connection.list(mockSecurityContext)
+                .should.eventually.be.deep.equal(['org.acme.biznet1']);
+        });
+
+        it('should handle any errors querying instantiated chaincodes', () => {
+            mockChain.queryInstantiatedChaincodes.rejects(new Error('such error'));
+            return connection.list(mockSecurityContext)
+                .should.be.rejectedWith(/such error/);
         });
 
     });


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [x]  A link to the issue/user story that the pull request relates to
 - [x]  How to recreate the problem without the fix
 - [x]  Design of the fix
 - [x]  How to prove that the fix works
 - [x]  Automated tests that prove the fix keeps on working
 - [x]  Documentation - any JSDoc, website, or Stackoverflow answers?

## Issue/User story
<!--- What issue / user story is this for -->
#877 Cannot connect to HLFv1 using playground connection profiles 

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1. Create a HLFv1.0 connection profile
2. Attempt to use HLFv1.0 connection profile
3. Witness errors

## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
The HLFv1 connector has an abstract list() method which means we cannot determine which business networks have been deployed to the specified Hyperledger Fabric instance. I have implemented it to use the queryInstantiatedChaincodes() function from `fabric-client`.  Handily we can use the `path` property for each instantiated chaincode to test for Composer business networks.

The admin connection code has been extended to ping() the business network on connection, if a business network was specified. Before, for HLFv0.6, we tested the presence of the business network in the connection profile, but since we aren't recording the business network -> chaincode ID mapping anymore this check was not run for HLFv1.0. By using ping(), we can validate that the business network is deployed and running.

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->
Tested locally against both HLFv0.6 and HLFv1.0.

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->
Unit tests added to cover code changes.

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->