### PR TITLE
Switch identities without requiring a browser refresh

### DIFF
--- a/packages/composer-playground/src/app/services/admin.service.spec.ts
+++ b/packages/composer-playground/src/app/services/admin.service.spec.ts
@@ -137,7 +137,7 @@ describe('AdminService', () => {
             alertMock.errorStatus$.next.should.have.been.called;
         })));
 
-        it('should connect even if connected if forced', fakeAsync(inject([AdminService], (service: AdminService) => {
+        it('should always connect when forced', fakeAsync(inject([AdminService], (service: AdminService) => {
             service['isConnected'] = true;
             let connectMock = sinon.stub(service, 'connect').returns(Promise.resolve());
             service.ensureConnected(true);

--- a/packages/composer-playground/src/app/services/client.service.ts
+++ b/packages/composer-playground/src/app/services/client.service.ts
@@ -154,20 +154,11 @@ export class ClientService {
         let connectionProfile = this.connectionProfileService.getCurrentConnectionProfile();
         console.log('Connecting to connection profile', connectionProfile);
         let userID;
-        this.connectingPromise = this.adminService.ensureConnected()
+        this.connectingPromise = this.adminService.ensureConnected(force)
         .then(() => {
-            return this.identityService.getUserID();
-        })
-        .then((userId) => {
-            userID = userId;
-            return this.identityService.getUserSecret();
-        })
-        .then((userSecret) => {
-            return this.getBusinessNetworkConnection().connect(connectionProfile, 'org.acme.biznet', userID, userSecret);
+            return this.refresh();
         })
         .then(() => {
-            // this.busyStatus$.next(null);
-            console.log('Connected');
             this.isConnected = true;
             this.connectingPromise = null;
         })

--- a/packages/composer-playground/src/app/services/identity.service.spec.ts
+++ b/packages/composer-playground/src/app/services/identity.service.spec.ts
@@ -6,7 +6,6 @@ import { TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
 import { IdentityService } from './identity.service';
 import { LocalStorageService } from 'angular-2-local-storage';
 import { ConnectionProfileService } from './connectionprofile.service';
-import { ClientService } from './client.service';
 import { WalletService } from './wallet.service';
 import * as sinon from 'sinon';
 import { FileWallet } from 'composer-common';

--- a/packages/composer-playground/src/app/services/initialization.service.spec.ts
+++ b/packages/composer-playground/src/app/services/initialization.service.spec.ts
@@ -134,6 +134,22 @@ describe('InitializationService', () => {
             mockAdminService.isInitialDeploy.should.be.called;
 
         })));
+
+        it('should handle errors and revert to uninitialized state', fakeAsync(inject([InitializationService], (service: InitializationService) => {
+
+            let loadConfigStub = sinon.stub(service, 'loadConfig').throws();
+
+            mockAlertService.busyStatus$ = {next: sinon.stub()};
+            mockAlertService.errorStatus$ = {next: sinon.stub()};
+
+            service.initialize();
+            tick();
+
+            mockAlertService.errorStatus$.next.should.be.called;
+            service['initialized'].should.be.false;
+
+            sinon.restore(service.loadConfig);
+        })));
     });
 
     describe('loadConfig', () => {

--- a/packages/composer-playground/src/app/switch-identity/switch-identity.component.spec.ts
+++ b/packages/composer-playground/src/app/switch-identity/switch-identity.component.spec.ts
@@ -19,7 +19,6 @@ import { SwitchIdentityComponent } from './switch-identity.component';
 import { ConnectionProfileService } from '../services/connectionprofile.service';
 import { WalletService } from '../services/wallet.service';
 import { ClientService } from '../services/client.service';
-import { AdminService } from '../services/admin.service';
 import { IdentityService } from '../services/identity.service';
 
 describe('SwitchIdentityComponent', () => {
@@ -29,7 +28,6 @@ describe('SwitchIdentityComponent', () => {
     let mockActiveModal = sinon.createStubInstance(NgbActiveModal);
     let mockConnectionProfileService = sinon.createStubInstance(ConnectionProfileService);
     let mockWalletService = sinon.createStubInstance(WalletService);
-    let mockAdminService = sinon.createStubInstance(AdminService);
     let mockClientService = sinon.createStubInstance(ClientService);
     let mockIdentityService = sinon.createStubInstance(IdentityService);
 
@@ -41,7 +39,6 @@ describe('SwitchIdentityComponent', () => {
                 {provide: NgbActiveModal, useValue: mockActiveModal},
                 {provide: ConnectionProfileService, useValue: mockConnectionProfileService},
                 {provide: WalletService, useValue: mockWalletService},
-                {provide: AdminService, useValue: mockAdminService},
                 {provide: ClientService, useValue: mockClientService},
                 {provide: IdentityService, useValue: mockIdentityService}
             ]
@@ -97,9 +94,7 @@ describe('SwitchIdentityComponent', () => {
             component['connectionProfileName'] = 'myProfile';
             component['chosenIdentity'] = 'bob';
 
-            mockAdminService.ensureConnected.returns(Promise.resolve());
             mockClientService.ensureConnected.returns(Promise.resolve());
-            mockClientService.refresh.returns(Promise.resolve());
 
             component.switchIdentity();
 
@@ -109,9 +104,7 @@ describe('SwitchIdentityComponent', () => {
 
             mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('myProfile');
             mockIdentityService.setCurrentIdentity.should.have.been.calledWith('bob');
-            mockAdminService.ensureConnected.should.have.been.calledWith(true);
             mockClientService.ensureConnected.should.have.been.calledWith(true);
-            mockClientService.refresh.should.have.been.called;
 
             component['switchInProgress'].should.equal(false);
             mockActiveModal.close.should.have.been.called;
@@ -130,9 +123,7 @@ describe('SwitchIdentityComponent', () => {
 
             mockWalletService.getWallet.returns(mockWallet);
 
-            mockAdminService.ensureConnected.returns(Promise.resolve());
             mockClientService.ensureConnected.returns(Promise.resolve());
-            mockClientService.refresh.returns(Promise.resolve());
 
             component.switchIdentity();
 
@@ -146,9 +137,7 @@ describe('SwitchIdentityComponent', () => {
 
             mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('myProfile');
             mockIdentityService.setCurrentIdentity.should.have.been.calledWith('bob');
-            mockAdminService.ensureConnected.should.have.been.calledWith(true);
             mockClientService.ensureConnected.should.have.been.calledWith(true);
-            mockClientService.refresh.should.have.been.called;
 
             component['switchInProgress'].should.equal(false);
             mockActiveModal.close.should.have.been.called;
@@ -167,9 +156,7 @@ describe('SwitchIdentityComponent', () => {
 
             mockWalletService.getWallet.returns(mockWallet);
 
-            mockAdminService.ensureConnected.returns(Promise.resolve());
             mockClientService.ensureConnected.returns(Promise.resolve());
-            mockClientService.refresh.returns(Promise.resolve());
 
             component.switchIdentity();
 
@@ -183,9 +170,7 @@ describe('SwitchIdentityComponent', () => {
 
             mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('myProfile');
             mockIdentityService.setCurrentIdentity.should.have.been.calledWith('bob');
-            mockAdminService.ensureConnected.should.have.been.calledWith(true);
             mockClientService.ensureConnected.should.have.been.calledWith(true);
-            mockClientService.refresh.should.have.been.called;
 
             component['switchInProgress'].should.equal(false);
             mockActiveModal.close.should.have.been.called;
@@ -195,8 +180,6 @@ describe('SwitchIdentityComponent', () => {
             component['showWalletView'] = true;
             component['connectionProfileName'] = 'myProfile';
             component['chosenUser'] = 'bob';
-
-            mockAdminService.ensureConnected.returns(Promise.reject('some error'));
 
             component.switchIdentity();
 

--- a/packages/composer-playground/src/app/switch-identity/switch-identity.component.ts
+++ b/packages/composer-playground/src/app/switch-identity/switch-identity.component.ts
@@ -4,7 +4,6 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { ConnectionProfileService } from '../services/connectionprofile.service';
 import { WalletService } from '../services/wallet.service';
 import { IdentityService } from '../services/identity.service';
-import { AdminService } from '../services/admin.service';
 import { ClientService } from '../services/client.service';
 
 @Component({
@@ -29,7 +28,6 @@ export class SwitchIdentityComponent implements OnInit {
                 private walletService: WalletService,
                 private activeModal: NgbActiveModal,
                 private identityService: IdentityService,
-                private adminService: AdminService,
                 private clientService: ClientService) {
 
     }
@@ -75,13 +73,7 @@ export class SwitchIdentityComponent implements OnInit {
             this.connectionProfileService.setCurrentConnectionProfile(this.connectionProfileName);
             this.identityService.setCurrentIdentity(chosenUser);
 
-            return this.adminService.ensureConnected(true);
-        })
-        .then(() => {
             return this.clientService.ensureConnected(true);
-        })
-        .then(() => {
-            return this.clientService.refresh();
         })
         .then(() => {
             this.switchInProgress = false;


### PR DESCRIPTION
Fixes item 4 in #839

Signed-off-by: James Taylor <jamest@uk.ibm.com>
