### PR TITLE
Add optional transaction requirements to ACL rules

### DIFF
--- a/packages/composer-common/lib/acl/aclrule.js
+++ b/packages/composer-common/lib/acl/aclrule.js
@@ -79,12 +79,16 @@ class AclRule {
         this.verb = this.ast.verb;
 
         this.participant = null;
-
         if(this.ast.participant && this.ast.participant !== 'ANY') {
             this.participant = new ModelBinding(this, this.ast.participant, this.ast.participantVariable);
         }
-        this.predicate = null;
 
+        this.transaction = null;
+        if(this.ast.transaction) {
+            this.transaction = new ModelBinding(this, this.ast.transaction.binding, this.ast.transaction.variableBinding);
+        }
+
+        this.predicate = null;
         if(this.ast.predicate) {
             this.predicate = new Predicate(this, this.ast.predicate);
         }
@@ -104,8 +108,13 @@ class AclRule {
      */
     validate() {
         this.noun.validate();
+
         if(this.participant) {
             this.participant.validate();
+        }
+
+        if(this.transaction) {
+            this.transaction.validate();
         }
 
         if(this.predicate) {
@@ -148,6 +157,16 @@ class AclRule {
      */
     getParticipant() {
         return this.participant;
+    }
+
+    /**
+     * Returns the transaction for this ACL rule. Returns null if this rule
+     * does not filter based on transaction.
+     *
+     * @return {ModelBinding} the transaction ModelBinding or null
+     */
+    getTransaction() {
+        return this.transaction;
     }
 
     /**

--- a/packages/composer-common/lib/acl/parser.pegjs
+++ b/packages/composer-common/lib/acl/parser.pegjs
@@ -1355,16 +1355,17 @@ Program
       rules: rules
     };
   }
-  
+
 AclRule
  = SimpleRule / ConditionalRule
-  
+
 SimpleRule
  = "rule" __ ruleId:RuleId __ "{" __
   	"description:" __ "\"" description:StringSequence "\"" __
     "participant:" __ "\"" participant:Participant "\"" __
     "operation:" __ verb:Verb __
     "resource:" __ "\"" noun:Noun "\"" __
+    transaction:SimpleTransactionSpecification?
     "action:" __ action:Action __
  "}" __
  {
@@ -1374,6 +1375,7 @@ SimpleRule
         noun: noun,
         verb: verb,
         participant: participant,
+        transaction: transaction,
         action: action,
         description: description,
         location: location()
@@ -1385,13 +1387,14 @@ VariableBinding
 {
   return id;
 }
- 
+
  ConditionalRule
  = "rule" __ ruleId:RuleId __ "{" __
   	"description:" __ "\"" description:StringSequence "\"" __
     "participant" __ participantVariable:VariableBinding? __ ":" __ "\"" participant:Participant "\"" __
     "operation:" __ verb:Verb __
     "resource" __ nounVariable:VariableBinding? __ ":" __ "\"" noun:Noun "\"" __
+    transaction:ConditionalTransactionSpecification?
     "condition:" __ predicate:Predicate __
     "action:" __ action:Action __
  "}" __
@@ -1404,6 +1407,7 @@ VariableBinding
         verb: verb,
         participant: participant,
         participantVariable: participantVariable,
+        transaction: transaction,
         predicate: predicate,
         action: action,
         description: description,
@@ -1431,8 +1435,21 @@ Binding
   };
 }
 
+BindingNoInstance
+  = qualifiedName:QualifiedName
+{
+  return {
+    type: "BindingNoInstance",
+    qualifiedName: qualifiedName,
+    location: location()
+  };
+}
+
 Noun
  = Binding
+
+NounNoInstance
+ = BindingNoInstance
 
 Verb
  = 'CREATE' / 'READ' / 'UPDATE' / 'ALL' / 'DELETE'
@@ -1454,3 +1471,20 @@ StringSequence "string"
     = chars:DoubleStringCharacter* {
         return chars.join("");
       }
+
+SimpleTransactionSpecification
+ = "transaction:" __ "\"" binding:BindingNoInstance "\"" __
+{
+    return {
+        binding: binding
+    };
+}
+
+ConditionalTransactionSpecification
+ = "transaction" __ variableBinding:VariableBinding? __ ":" __ "\"" binding:BindingNoInstance "\"" __
+{
+    return {
+        variableBinding: variableBinding,
+        binding: binding
+    }
+}

--- a/packages/composer-common/test/acl/aclfile.js
+++ b/packages/composer-common/test/acl/aclfile.js
@@ -95,7 +95,7 @@ describe('AclFile', () => {
 
         it('should parse correctly and preserve order', () => {
             const aclFile = new AclFile('test.acl', modelManager, testAcl);
-            aclFile.getAclRules().length.should.equal(5);
+            aclFile.getAclRules().length.should.equal(7);
             aclFile.getDefinitions().should.equal(testAcl);
 
             const r1 = aclFile.getAclRules()[0];
@@ -103,6 +103,8 @@ describe('AclFile', () => {
             const r3 = aclFile.getAclRules()[2];
             const r4 = aclFile.getAclRules()[3];
             const r5 = aclFile.getAclRules()[4];
+            const r6 = aclFile.getAclRules()[5];
+            const r7 = aclFile.getAclRules()[6];
 
             // check names
             r1.getName().should.equal('R1');
@@ -110,6 +112,8 @@ describe('AclFile', () => {
             r3.getName().should.equal('R3');
             r4.getName().should.equal('R4');
             r5.getName().should.equal('R5');
+            r6.getName().should.equal('R6');
+            r7.getName().should.equal('R7');
 
             // check nouns
             console.log('**** ' + JSON.stringify(r1));
@@ -119,6 +123,8 @@ describe('AclFile', () => {
             r3.getNoun().getFullyQualifiedName().should.equal('org.acme.Car.owner');
             r4.getNoun().getFullyQualifiedName().should.equal('org.acme.Car');
             r5.getNoun().getFullyQualifiedName().should.equal('org.acme');
+            r6.getNoun().getFullyQualifiedName().should.equal('org.acme.Car');
+            r7.getNoun().getFullyQualifiedName().should.equal('org.acme.Car');
 
             // check verbs
             r1.getVerb().should.equal('DELETE');
@@ -126,6 +132,8 @@ describe('AclFile', () => {
             r3.getVerb().should.equal('UPDATE');
             r4.getVerb().should.equal('ALL');
             r5.getVerb().should.equal('READ');
+            r6.getVerb().should.equal('ALL');
+            r7.getVerb().should.equal('ALL');
 
             // check participants
             r1.getParticipant().getFullyQualifiedName().should.equal('org.acme.Driver');
@@ -139,6 +147,19 @@ describe('AclFile', () => {
             (r4.getParticipant().getInstanceIdentifier() === null).should.be.true;
             (r4.getParticipant().getVariableName() === null).should.be.true;
             (r5.getParticipant() === null).should.be.true;
+            (r6.getParticipant() === null).should.be.true;
+            (r7.getParticipant() === null).should.be.true;
+
+            // check transactions
+            (r1.getTransaction() === null).should.be.true;
+            (r2.getTransaction() === null).should.be.true;
+            (r3.getTransaction() === null).should.be.true;
+            (r4.getTransaction() === null).should.be.true;
+            (r5.getTransaction() === null).should.be.true;
+            r6.getTransaction().getFullyQualifiedName().should.equal('org.acme.Transaction');
+            (r6.getTransaction().getVariableName() === null).should.be.true;
+            r7.getTransaction().getFullyQualifiedName().should.equal('org.acme.Transaction');
+            r7.getTransaction().getVariableName().should.equal('tx');
 
             // check predicates
             r1.getPredicate().getExpression().should.equal('true');
@@ -146,6 +167,8 @@ describe('AclFile', () => {
             r3.getPredicate().getExpression().should.equal('o == d');
             r4.getPredicate().getExpression().should.equal('true');
             r5.getPredicate().getExpression().should.equal('true');
+            r6.getPredicate().getExpression().should.equal('true');
+            r7.getPredicate().getExpression().should.equal('tx.asset.colour === \'blue\'');
 
             // check action
             r1.getAction().should.equal('ALLOW');
@@ -153,6 +176,8 @@ describe('AclFile', () => {
             r3.getAction().should.equal('ALLOW');
             r4.getAction().should.equal('ALLOW');
             r5.getAction().should.equal('ALLOW');
+            r6.getAction().should.equal('ALLOW');
+            r7.getAction().should.equal('ALLOW');
 
             // check the description
             r1.getDescription().should.equal('Fred can DELETE the car ABC123');
@@ -160,6 +185,8 @@ describe('AclFile', () => {
             r3.getDescription().should.equal('Driver can change the ownership of a car that they own');
             r4.getDescription().should.equal('regulators can perform all operations on Cars');
             r5.getDescription().should.equal('Everyone can read all resources in the org.acme namespace');
+            r6.getDescription().should.equal('Drivers can do something in a org.acme.Transaction transaction');
+            r7.getDescription().should.equal('Regulators can do something in a org.acme.Transaction transaction');
         });
     });
 

--- a/packages/composer-common/test/acl/model.cto
+++ b/packages/composer-common/test/acl/model.cto
@@ -16,3 +16,7 @@ participant Regulator identified by email {
   o String firstName
   o String lastName
 }
+
+transaction Transaction identified by transactionId {
+  o String transactionId
+}

--- a/packages/composer-common/test/acl/test.acl
+++ b/packages/composer-common/test/acl/test.acl
@@ -39,3 +39,22 @@ rule R5 {
     resource: "org.acme"
     action: ALLOW
 }
+
+rule R6 {
+    description: "Drivers can do something in a org.acme.Transaction transaction"
+    participant: "ANY"
+    operation: ALL
+    resource: "org.acme.Car"
+    transaction: "org.acme.Transaction"
+    action: ALLOW
+}
+
+rule R7 {
+    description: "Regulators can do something in a org.acme.Transaction transaction"
+    participant: "ANY"
+    operation: ALL
+    resource: "org.acme.Car"
+    transaction(tx): "org.acme.Transaction"
+    condition: (tx.asset.colour === 'blue')
+    action: ALLOW
+}

--- a/packages/composer-runtime/lib/accesscontroller.js
+++ b/packages/composer-runtime/lib/accesscontroller.js
@@ -37,6 +37,7 @@ class AccessController {
         LOG.entry(method, aclManager);
         this.aclManager = aclManager;
         this.participant = null;
+        this.transaction = null;
         LOG.exit(method);
     }
 
@@ -54,6 +55,22 @@ class AccessController {
      */
     setParticipant(participant) {
         this.participant = participant;
+    }
+
+    /**
+     * Get the current transaction.
+     * @return {Resource} The current transaction.
+     */
+    getTransaction() {
+        return this.transaction;
+    }
+
+    /**
+     * Set the current transaction.
+     * @param {Resource} transaction The current transaction.
+     */
+    setTransaction(transaction) {
+        this.transaction = transaction;
     }
 
     /**
@@ -80,6 +97,9 @@ class AccessController {
                 return;
             }
 
+            // Grab the transaction. Does not matter if this is null.
+            let transaction = this.transaction;
+
             // Check to see if an ACL file was supplied. If not, then ACL
             // enforcement is not enabled.
             if (!this.aclManager.getAclFile()) {
@@ -93,7 +113,7 @@ class AccessController {
             let aclRules = this.aclManager.getAclRules();
             let result = aclRules.some((aclRule) => {
                 LOG.debug(method, 'Processing rule', aclRule);
-                let value = this.checkRule(resource, access, participant, aclRule);
+                let value = this.checkRule(resource, access, participant, transaction, aclRule);
                 LOG.debug(method, 'Processed rule', value);
                 return value;
             });
@@ -105,7 +125,7 @@ class AccessController {
             }
 
             // Otherwise no ACL rule permitted the action.
-            throw new AccessException(resource, access, participant);
+            throw new AccessException(resource, access, participant, transaction);
 
         } catch (e) {
             LOG.error(method, e);
@@ -119,13 +139,14 @@ class AccessController {
      * @param {Resource} resource The resource.
      * @param {string} access The level of access.
      * @param {Resource} participant The participant.
+     * @param {Resource} transaction The transaction.
      * @param {AclRule} aclRule The ACL rule.
      * @returns {boolean} True if the specified ACL rule permits
      * the specified level of access to the specified resource.
      */
-    checkRule(resource, access, participant, aclRule) {
+    checkRule(resource, access, participant, transaction, aclRule) {
         const method = 'checkRule';
-        LOG.entry(method, participant.getFullyQualifiedIdentifier(), resource, access, participant, aclRule);
+        LOG.entry(method, resource, access, participant, transaction, aclRule);
 
         // Is the ACL rule relevant to the specified noun?
         if (!this.matchNoun(resource, aclRule)) {
@@ -148,8 +169,15 @@ class AccessController {
             return false;
         }
 
+        // Is the ACL rule relevant to the specified transaction?
+        if (!this.matchTransaction(transaction, aclRule)) {
+            LOG.debug(method, 'Transaction does not match');
+            LOG.exit(method, false);
+            return false;
+        }
+
         // Is the predicate met?
-        if (!this.matchPredicate(resource, access, participant, aclRule)) {
+        if (!this.matchPredicate(resource, access, participant, transaction, aclRule)) {
             LOG.debug(method, 'Predicate does not match');
             LOG.exit(method, false);
             return false;
@@ -162,7 +190,7 @@ class AccessController {
         }
 
         // This must be an explicit deny rule, so throw.
-        let e = new AccessException(resource, access, participant);
+        let e = new AccessException(resource, access, participant, transaction);
         LOG.error(method, e);
         throw e;
 
@@ -297,18 +325,64 @@ class AccessController {
     }
 
     /**
+     * Check that the specified transaction has the specified
+     * level of access to the specified resource.
+     * @param {Resource} transaction The transaction.
+     * @param {AclRule} aclRule The ACL rule.
+     * @returns {boolean} True if the specified ACL rule permits
+     * the specified level of access to the specified resource.
+     */
+    matchTransaction(transaction, aclRule) {
+        const method = 'matchTransaction';
+        LOG.entry(method, transaction ? transaction.getFullyQualifiedIdentifier() : transaction, aclRule);
+
+        // Is a transaction specified in the ACL rule?
+        let reqTransaction = aclRule.getTransaction();
+        if (!reqTransaction) {
+            LOG.exit(method, true);
+            return true;
+        }
+
+        // OK, a transaction is specified in the ACL rule, but
+        // are we executing in the scope of a transaction?
+        if (!transaction) {
+            LOG.exit(method, false);
+            return false;
+        }
+
+        // Check to see if the participant is an instance of the
+        // required participant type, or is in the required
+        // namespace.
+        let ns = transaction.getNamespace();
+        let reqFQN = reqTransaction.getFullyQualifiedName();
+        if (transaction.instanceOf(reqFQN)) {
+            // Transaction is matching type or subtype.
+        } else if (ns === reqFQN) {
+            // Transaction is matching namespace.
+        } else {
+            // Participant does not match.
+            LOG.exit(method, false);
+            return false;
+        }
+
+        LOG.exit(method, true);
+        return true;
+    }
+
+    /**
      * Check that the specified participant has the specified
      * level of access to the specified resource.
      * @param {Resource} resource The resource.
      * @param {string} access The level of access.
      * @param {Resource} participant The participant.
+     * @param {Resource} transaction The transaction.
      * @param {AclRule} aclRule The ACL rule.
      * @returns {boolean} True if the specified ACL rule permits
      * the specified level of access to the specified resource.
      */
-    matchPredicate(resource, access, participant, aclRule) {
+    matchPredicate(resource, access, participant, transaction, aclRule) {
         const method = 'matchPredicate';
-        LOG.entry(method, resource.getFullyQualifiedIdentifier(), access, participant.getFullyQualifiedIdentifier(), aclRule);
+        LOG.entry(method, resource, access, participant, transaction, aclRule);
 
         // Get the predicate from the rule.
         let predicate = aclRule.getPredicate().getExpression();
@@ -344,6 +418,16 @@ class AccessController {
             }
         }
 
+        // Check to see if the transaction needs to be bound.
+        let reqTransaction = aclRule.getTransaction();
+        if (reqTransaction) {
+            let transactionVar = aclRule.getTransaction().getVariableName();
+            if (transactionVar) {
+                argNames.push(transactionVar);
+                argValues.push(transaction);
+            }
+        }
+
         // Compile and execute the function.
         let result;
         try {
@@ -352,7 +436,7 @@ class AccessController {
             result = func.apply(null, argValues);
         } catch (e) {
             LOG.error(method, e);
-            throw new AccessException(resource, access, participant);
+            throw new AccessException(resource, access, participant, transaction);
         }
 
         // Convert the result into a boolean before returning it.

--- a/packages/composer-runtime/lib/accessexception.js
+++ b/packages/composer-runtime/lib/accessexception.js
@@ -31,9 +31,10 @@ class AccessException extends BaseException {
      * @param {Resource} resource The resource.
      * @param {string} access The level of access.
      * @param {Resource} participant The participant.
+     * @param {Resource} transaction The transaction.
      * @return {string} The exception message.
      */
-    static generateMessage(resource, access, participant) {
+    static generateMessage(resource, access, participant, transaction) {
         let resourceId = resource.getFullyQualifiedIdentifier();
         let participantId = participant.getFullyQualifiedIdentifier();
         return `Participant '${participantId}' does not have '${access}' access to resource '${resourceId}'`;
@@ -44,9 +45,10 @@ class AccessException extends BaseException {
      * @param {Resource} resource The resource.
      * @param {string} access The level of access.
      * @param {Resource} participant The participant.
+     * @param {Resource} transaction The transaction.
      */
-    constructor(resource, access, participant) {
-        super(AccessException.generateMessage(resource, access, participant));
+    constructor(resource, access, participant, transaction) {
+        super(AccessException.generateMessage(resource, access, participant, transaction));
     }
 
 }

--- a/packages/composer-runtime/lib/context.js
+++ b/packages/composer-runtime/lib/context.js
@@ -396,6 +396,7 @@ class Context {
         }
         this.transaction = transaction;
         this.transactionLogger = new TransactionLogger(this.transaction, this.getRegistryManager(), this.getSerializer());
+        this.getAccessController().setTransaction(transaction);
     }
 
     /**

--- a/packages/composer-runtime/test/accesscontroller.js
+++ b/packages/composer-runtime/test/accesscontroller.js
@@ -32,6 +32,8 @@ describe('AccessController', () => {
     let asset;
     let participant;
     let participant2;
+    let transaction;
+    let transaction2;
     let controller;
 
     beforeEach(() => {
@@ -43,11 +45,15 @@ describe('AccessController', () => {
         }
         abstract participant BaseParticipant {
             o String theValue
+        }
+        abstract transaction BaseTransaction {
+            o String theValue
         }`);
         modelManager.addModelFile(`
         namespace org.acme.test
         import org.acme.base.BaseAsset
         import org.acme.base.BaseParticipant
+        import org.acme.base.BaseTransaction
         asset TestAsset identified by assetId extends BaseAsset {
             o String assetId
         }
@@ -62,6 +68,15 @@ describe('AccessController', () => {
         }
         participant TestParticipant3 identified by participantId extends BaseParticipant {
             o String participantId
+        }
+        transaction TestTransaction identified by transactionId extends BaseTransaction {
+            o String transactionId
+        }
+        transaction TestTransaction2 extends TestTransaction {
+
+        }
+        transaction TestTransaction3 identified by transactionId extends BaseTransaction {
+            o String transactionId
         }`);
         modelManager.addModelFile(`
         namespace org.acme.test2
@@ -72,14 +87,20 @@ describe('AccessController', () => {
         }
         participant TestParticipant2 identified by participantId extends BaseParticipant {
             o String participantId
+        }
+        transaction TestTransaction2 identified by transactionId extends BaseParticipant {
+            o String transactionId
         }`);
         aclManager = new AclManager(modelManager);
         factory = new Factory(modelManager);
         asset = factory.newResource('org.acme.test', 'TestAsset', 'A1234');
         participant = factory.newResource('org.acme.test', 'TestParticipant', 'P5678');
         participant2 = factory.newResource('org.acme.test', 'TestParticipant2', 'P7890');
+        transaction = factory.newResource('org.acme.test', 'TestTransaction', 'T9012');
+        transaction2 = factory.newResource('org.acme.test', 'TestTransaction2', 'T0123');
         controller = new AccessController(aclManager);
         controller.setParticipant(participant);
+        controller.setTransaction(transaction);
     });
 
     let setAclFile = (contents) => {
@@ -101,6 +122,24 @@ describe('AccessController', () => {
             controller.participant = null;
             controller.setParticipant(participant);
             controller.participant.should.equal(participant);
+        });
+
+    });
+
+    describe('#getTransaction', () => {
+
+        it('should return the current transaction', () => {
+            controller.getTransaction().should.equal(transaction);
+        });
+
+    });
+
+    describe('#setTransaction', () => {
+
+        it('should set the current transaction', () => {
+            controller.transaction = null;
+            controller.setTransaction(transaction);
+            controller.transaction.should.equal(transaction);
         });
 
     });
@@ -219,7 +258,7 @@ describe('AccessController', () => {
         it('should return false if the noun is not matched', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A5678" action: ALLOW}');
             let spy = sinon.spy(controller, 'matchNoun');
-            controller.checkRule(asset, 'READ', participant, aclManager.getAclRules()[0])
+            controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.false;
             sinon.assert.calledOnce(spy);
         });
@@ -227,7 +266,7 @@ describe('AccessController', () => {
         it('should return false if the verb is not matched', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}');
             let spy = sinon.spy(controller, 'matchVerb');
-            controller.checkRule(asset, 'CREATE', participant, aclManager.getAclRules()[0])
+            controller.checkRule(asset, 'CREATE', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.false;
             sinon.assert.calledOnce(spy);
         });
@@ -235,7 +274,15 @@ describe('AccessController', () => {
         it('should return false if the participant is not matched', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P1234" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}');
             let spy = sinon.spy(controller, 'matchParticipant');
-            controller.checkRule(asset, 'READ', participant, aclManager.getAclRules()[0])
+            controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
+                .should.be.false;
+            sinon.assert.calledOnce(spy);
+        });
+
+        it('should return false if the transaction is not matched', () => {
+            setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction: "org.acme.test.TestTransaction3" action: ALLOW}');
+            let spy = sinon.spy(controller, 'matchTransaction');
+            controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.false;
             sinon.assert.calledOnce(spy);
         });
@@ -243,21 +290,21 @@ describe('AccessController', () => {
         it('should return false if the predicate is not matched', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" condition: (false) action: ALLOW}');
             let spy = sinon.spy(controller, 'matchPredicate');
-            controller.checkRule(asset, 'READ', participant, aclManager.getAclRules()[0])
+            controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.false;
             sinon.assert.calledOnce(spy);
         });
 
         it('should return true if the rule matches and ALLOW is specified', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" condition: (true) action: ALLOW}');
-            controller.checkRule(asset, 'READ', participant, aclManager.getAclRules()[0])
+            controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.true;
         });
 
         it('should throw if the rule matches and DENY is specified', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: DENY}');
             (() => {
-                controller.checkRule(asset, 'READ', participant, aclManager.getAclRules()[0]);
+                controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0]);
             }).should.throw(AccessException, /does not have/);
         });
 
@@ -397,72 +444,158 @@ describe('AccessController', () => {
 
     });
 
+    describe('#matchTransaction', () => {
+
+        it('should return true if the ACL rule does not specify a transaction', () => {
+            setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}');
+
+            controller.matchTransaction(transaction, aclManager.getAclRules()[0])
+                .should.be.true;
+        });
+
+        it('should return false if the ACL rule specifies a transaction but no transaction is specified', () => {
+            setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction: "org.acme.test.TestTransaction" action: ALLOW}');
+            controller.matchTransaction(null, aclManager.getAclRules()[0])
+                .should.be.false;
+        });
+
+        it('should return true if the ACL rule specifies a matching fully qualified name', () => {
+            setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction: "org.acme.test.TestTransaction" action: ALLOW}');
+            controller.matchTransaction(transaction, aclManager.getAclRules()[0])
+                .should.be.true;
+        });
+
+        it('should return true if the ACL rule specifies a matching namespace', () => {
+            setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction: "org.acme.test" action: ALLOW}');
+            controller.matchTransaction(transaction, aclManager.getAclRules()[0])
+                .should.be.true;
+        });
+
+        it('should return false if the ACL rule specifies a non-matching fully qualified name', () => {
+            setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction: "org.acme.test.TestTransaction2" action: ALLOW}');
+            controller.matchTransaction(transaction, aclManager.getAclRules()[0])
+                .should.be.false;
+        });
+
+        it('should return false if the ACL rule specifies a non-matching namespace', () => {
+            setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction: "org.acme.test2" action: ALLOW}');
+            controller.matchTransaction(transaction, aclManager.getAclRules()[0])
+                .should.be.false;
+        });
+
+        it('should return true if the ACL rule specifies a fully qualified name of a supertype', () => {
+            // Test with TestTransaction which extends BaseTransaction.
+            setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction: "org.acme.base.BaseTransaction" action: ALLOW}');
+            controller.matchTransaction(transaction, aclManager.getAclRules()[0])
+                .should.be.true;
+        });
+
+        it('should return true if the ACL rule specifies a fully qualified name of a nested supertype', () => {
+            // Test with TestTransaction2 which extends TestTransaction which extends BaseTransaction.
+            setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction: "org.acme.base.BaseTransaction" action: ALLOW}');
+            controller.matchTransaction(transaction2, aclManager.getAclRules()[0])
+                .should.be.true;
+        });
+
+        it('should return false if the ACL rule specifies a fully qualified name of a subtype', () => {
+            // Test with TestTransaction which is extended by TestTransaction3.
+            setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction: "org.acme.test.TestTransaction3" action: ALLOW}');
+            controller.matchTransaction(transaction, aclManager.getAclRules()[0])
+                .should.be.false;
+        });
+
+    });
+
     describe('#matchPredicate', () => {
 
         it('should return true if the ACL rule specifies a predicate of (true)', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}');
-            controller.matchPredicate(asset, 'READ', participant, aclManager.getAclRules()[0])
+            controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.true;
         });
 
         it('should return false if the ACL rule specifies a predicate of (false)', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" condition: (false) action: ALLOW}');
-            controller.matchPredicate(asset, 'READ', participant, aclManager.getAclRules()[0])
+            controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.false;
         });
 
         it('should return true if the ACL rule specifies a predicate that returns a truthy expression', () => {
-            setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant" operation: READ resource: "org.acme.test.TestAsset#A1234" condition: ((3 + 6) / 3 === 3) action: ALLOW}');
-            controller.matchPredicate(asset, 'READ', participant, aclManager.getAclRules()[0])
+            setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction: "org.acme.test.TestTransaction" condition: ((3 + 6) / 3 === 3) action: ALLOW}');
+            controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.true;
         });
 
         it('should return false if the ACL rule specifies a predicate that returns a falsey expression', () => {
-            setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant" operation: READ resource: "org.acme.test.TestAsset#A1234" condition: ((3 + 3) / 3 === 3) action: ALLOW}');
-            controller.matchPredicate(asset, 'READ', participant, aclManager.getAclRules()[0])
+            setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction: "org.acme.test.TestTransaction" condition: ((3 + 3) / 3 === 3) action: ALLOW}');
+            controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.false;
         });
 
         it('should return true if the ACL rule specifies a predicate that accesses the bound resource and returns a truthy expression', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource(asset): "org.acme.test.TestAsset#A1234" condition: (asset.getFullyQualifiedIdentifier() === \'org.acme.test.TestAsset#A1234\') action: ALLOW}');
-            controller.matchPredicate(asset, 'READ', participant, aclManager.getAclRules()[0])
+            controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.true;
         });
 
         it('should return false if the ACL rule specifies a predicate that accesses the bound resource and returns a falsey expression', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource(asset): "org.acme.test.TestAsset#A1234" condition: (asset.getFullyQualifiedIdentifier() !== \'org.acme.test.TestAsset#A1234\') action: ALLOW}');
-            controller.matchPredicate(asset, 'READ', participant, aclManager.getAclRules()[0])
+            controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.false;
         });
 
         it('should return true if the ACL rule specifies a predicate that accesses the bound participant and returns a truthy expression', () => {
             setAclFile('rule R1 {description: "Test R1" participant(participant): "org.acme.test.TestParticipant" operation: READ resource: "org.acme.test.TestAsset#A1234" condition: (participant.getFullyQualifiedIdentifier() === \'org.acme.test.TestParticipant#P5678\') action: ALLOW}');
-            controller.matchPredicate(asset, 'READ', participant, aclManager.getAclRules()[0])
+            controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.true;
         });
 
         it('should return false if the ACL rule specifies a predicate that accesses the bound participant and returns a falsey expression', () => {
             setAclFile('rule R1 {description: "Test R1" participant(participant): "org.acme.test.TestParticipant" operation: READ resource: "org.acme.test.TestAsset#A1234" condition: (participant.getFullyQualifiedIdentifier() !== \'org.acme.test.TestParticipant#P5678\') action: ALLOW}');
-            controller.matchPredicate(asset, 'READ', participant, aclManager.getAclRules()[0])
+            controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
+                .should.be.false;
+        });
+
+        it('should return true if the ACL rule specifies a predicate that accesses the bound transaction and returns a truthy expression', () => {
+            setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction(tx): "org.acme.test.TestTransaction" condition: (tx.getFullyQualifiedIdentifier() === \'org.acme.test.TestTransaction#T9012\') action: ALLOW}');
+            controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
+                .should.be.true;
+        });
+
+        it('should return false if the ACL rule specifies a predicate that accesses the bound transaction and returns a falsey expression', () => {
+            setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction(tx): "org.acme.test.TestTransaction" condition: (tx.getFullyQualifiedIdentifier() !== \'org.acme.test.TestTransaction#T9012\') action: ALLOW}');
+            controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.false;
         });
 
         it('should return true if the ACL rule specifies a predicate that accesses the bound resource and participant and returns a truthy expression', () => {
             setAclFile('rule R1 {description: "Test R1" participant(participant): "org.acme.test.TestParticipant" operation: READ resource(asset): "org.acme.test.TestAsset#A1234" condition: (asset.getFullyQualifiedIdentifier() !== participant.getFullyQualifiedIdentifier()) action: ALLOW}');
-            controller.matchPredicate(asset, 'READ', participant, aclManager.getAclRules()[0])
+            controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.true;
         });
 
         it('should return false if the ACL rule specifies a predicate that accesses the bound resource and participant and returns a falsey expression', () => {
             setAclFile('rule R1 {description: "Test R1" participant(participant): "org.acme.test.TestParticipant" operation: READ resource(asset): "org.acme.test.TestAsset#A1234" condition: (asset.getFullyQualifiedIdentifier() === participant.getFullyQualifiedIdentifier()) action: ALLOW}');
-            controller.matchPredicate(asset, 'READ', participant, aclManager.getAclRules()[0])
+            controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
+                .should.be.false;
+        });
+
+        it('should return true if the ACL rule specifies a predicate that accesses the bound resource, participant, and transaction and returns a truthy expression', () => {
+            setAclFile('rule R1 {description: "Test R1" participant(participant): "org.acme.test.TestParticipant" operation: READ resource(asset): "org.acme.test.TestAsset#A1234" transaction(tx): "org.acme.test.TestTransaction" condition: ((asset.getFullyQualifiedIdentifier() !== participant.getFullyQualifiedIdentifier()) && tx.getFullyQualifiedIdentifier() === \'org.acme.test.TestTransaction#T9012\') action: ALLOW}');
+            controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
+                .should.be.true;
+        });
+
+        it('should return false if the ACL rule specifies a predicate that accesses the bound resource, participant, and transaction and returns a falsey expression', () => {
+            setAclFile('rule R1 {description: "Test R1" participant(participant): "org.acme.test.TestParticipant" operation: READ resource(asset): "org.acme.test.TestAsset#A1234" transaction(tx): "org.acme.test.TestTransaction" condition: ((asset.getFullyQualifiedIdentifier() === participant.getFullyQualifiedIdentifier()) && tx.getFullyQualifiedIdentifier() !== \'org.acme.test.TestTransaction#T9012\') action: ALLOW}');
+            controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
                 .should.be.false;
         });
 
         it('should throw if the ACL rule specifies a predicate that is faulty and causes an exception to be thrown', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource(asset): "org.acme.test.TestAsset#A1234" condition: (asset.not.a.real.property = {}) action: ALLOW}');
             (() => {
-                controller.matchPredicate(asset, 'READ', participant, aclManager.getAclRules()[0]);
+                controller.matchPredicate(asset, 'READ', participant, transaction, aclManager.getAclRules()[0]);
             }).should.throw(AccessException, /does not have/);
         });
 

--- a/packages/composer-runtime/test/context.js
+++ b/packages/composer-runtime/test/context.js
@@ -515,17 +515,23 @@ describe('Context', () => {
         it('should set the current transaction and create a transaction logger', () => {
             let mockTransaction = sinon.createStubInstance(Resource);
             let mockRegistryManager = sinon.createStubInstance(RegistryManager);
+            let mockAccessController = sinon.createStubInstance(AccessController);
+            context.accessController = mockAccessController;
             sinon.stub(context, 'getRegistryManager').returns(mockRegistryManager);
             let mockSerializer = sinon.createStubInstance(Serializer);
             sinon.stub(context, 'getSerializer').returns(mockSerializer);
             context.setTransaction(mockTransaction);
             context.transaction.should.equal(mockTransaction);
             context.transactionLogger.should.be.an.instanceOf(TransactionLogger);
+            sinon.assert.calledOnce(mockAccessController.setTransaction);
+            sinon.assert.calledWith(mockAccessController.setTransaction, mockTransaction);
         });
 
         it('should throw if a transaction has already been set', () => {
             let mockTransaction = sinon.createStubInstance(Resource);
             let mockRegistryManager = sinon.createStubInstance(RegistryManager);
+            let mockAccessController = sinon.createStubInstance(AccessController);
+            context.accessController = mockAccessController;
             sinon.stub(context, 'getRegistryManager').returns(mockRegistryManager);
             let mockSerializer = sinon.createStubInstance(Serializer);
             sinon.stub(context, 'getSerializer').returns(mockSerializer);


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->
As a business network developer would like to restrict direct CRUD access to an asset, instead asset manipulations can only take place through transactions #575

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->