### PR TITLE
Enable namespace changes to model files via composer

### DIFF
--- a/packages/composer-common/lib/modelmanager.js
+++ b/packages/composer-common/lib/modelmanager.js
@@ -62,6 +62,26 @@ class ModelManager {
     }
 
     /**
+     * Validates a Composer file (as a string) to the ModelManager.
+     * Composer files have a single namespace.
+     *
+     * Note that if there are dependencies between multiple files the files
+     * must be added in dependency order, or the addModelFiles method can be
+     * used to add a set of files irrespective of dependencies.
+     * @param {string} modelFile - The Composer file as a string
+     * @param {string} fileName - an optional file name to associate with the model file
+     * @throws {IllegalModelException}
+     */
+    validateModelFile(modelFile, fileName) {
+        if (typeof modelFile === 'string') {
+            let m = new ModelFile(this, modelFile, fileName);
+            m.validate();
+        } else {
+            modelFile.validate();
+        }
+    }
+
+    /**
      * Adds a Composer file (as a string) to the ModelManager.
      * Composer files have a single namespace. If a Composer file with the
      * same namespace has already been added to the ModelManager then it

--- a/packages/composer-common/test/modelmanager.js
+++ b/packages/composer-common/test/modelmanager.js
@@ -32,6 +32,7 @@ describe('ModelManager', () => {
     let modelBase = fs.readFileSync('./test/data/model/model-base.cto', 'utf8');
     let farm2fork = fs.readFileSync('./test/data/model/farm2fork.cto', 'utf8');
     let concertoModel = fs.readFileSync('./test/data/model/concerto.cto', 'utf8');
+    let invalidModel = fs.readFileSync('./test/data/model/invalid.cto', 'utf8');
     let modelManager;
 
     beforeEach(() => {
@@ -49,6 +50,26 @@ describe('ModelManager', () => {
             sinon.assert.calledWith(visitor.visit, modelManager, ['some', 'args']);
         });
 
+    });
+
+    describe('#validateModelFile', () => {
+
+        it('should validate model files from strings', () => {
+            modelBase.should.not.be.null;
+            modelManager.validateModelFile(modelBase);
+        });
+
+        it('should validate model files from objects', () => {
+            modelBase.should.not.be.null;
+            modelManager.validateModelFile(modelBase, 'model-base.cto');
+        });
+
+        it('should fail validation of invalid model files from objects', () => {
+            invalidModel.should.not.be.null;
+            (() => {
+                modelManager.validateModelFile(invalidModel);
+            }).should.throw();
+        });
     });
 
     describe('#addModelFile', () => {

--- a/packages/composer-playground/src/app/add-file/add-file.component.spec.ts
+++ b/packages/composer-playground/src/app/add-file/add-file.component.spec.ts
@@ -295,7 +295,7 @@ describe('AddFileComponent', () => {
 namespace org.acme.model`],
                 {type: 'text/plain'}
             );
-            let file = new File([b], 'lib/org.acme.model.cto');
+            let file = new File([b], 'org.acme.model.cto');
             let dataBuffer = new Buffer(`/**
  * New model file
  */
@@ -307,7 +307,7 @@ namespace org.acme.model`);
             component.businessNetwork = mockBusinessNetwork;
 
             component.changeCurrentFileType();
-            component.currentFileName.should.equal('lib/org.acme.model.cto');
+            component.currentFileName.should.equal('org.acme.model.cto');
             component.currentFile.should.deep.equal(mockModel);
 
         }));
@@ -322,7 +322,7 @@ namespace org.acme.model`);
 namespace org.acme.model`],
                 {type: 'text/plain'}
             );
-            let file = new File([b], 'lib/org.acme.model.cto');
+            let file = new File([b], 'org.acme.model.cto');
             let dataBuffer = new Buffer(`/**
  * New model file
  */
@@ -337,8 +337,45 @@ namespace org.acme.model`);
             component.businessNetwork = mockBusinessNetwork;
 
             component.changeCurrentFileType();
-            component.currentFileName.should.equal('lib/org.acme.model1.cto');
+            component.currentFileName.should.equal('org.acme.model0.cto');
         });
+
+        it('should fill in template model name indices for a cto file name', async(() => {
+            let mockFile = sinon.createStubInstance(ModelFile);
+            mockFile.getNamespace.returns('org.acme.model');
+            let mockFile0 = sinon.createStubInstance(ModelFile);
+            mockFile0.getNamespace.returns('org.acme.model0');
+            let mockFile1 = sinon.createStubInstance(ModelFile);
+            mockFile1.getNamespace.returns('org.acme.model1');
+            let mockFile3 = sinon.createStubInstance(ModelFile);
+            mockFile3.getNamespace.returns('org.acme.model3');
+            let mockFile4 = sinon.createStubInstance(ModelFile);
+            mockFile4.getNamespace.returns('org.acme.model4');
+            mockModelManager.getModelFiles.returns([mockFile, mockFile0, mockFile1, mockFile3, mockFile4]);
+
+            let b = new Blob(
+                [`/**
+ * New model file
+ */
+
+namespace org.acme.model`],
+                {type: 'text/plain'}
+            );
+            let file = new File([b], 'org.acme.model.cto');
+            let dataBuffer = new Buffer(`/**
+ * New model file
+ */
+
+namespace org.acme.model`);
+
+            let mockModel = new ModelFile(mockModelManager, dataBuffer.toString(), file.name);
+
+            component.fileType = 'cto';
+            component.businessNetwork = mockBusinessNetwork;
+
+            component.changeCurrentFileType();
+            component.currentFileName.should.equal('org.acme.model2.cto');
+        }));
     });
 
     describe('#removeFile', () => {

--- a/packages/composer-playground/src/app/add-file/add-file.component.ts
+++ b/packages/composer-playground/src/app/add-file/add-file.component.ts
@@ -115,14 +115,16 @@ export class AddFileComponent {
  */`;
             let scriptManager = this.businessNetwork.getScriptManager();
             let existingScripts = scriptManager.getScripts();
-            let filteredScripts = existingScripts.filter((script) => {
-                let pattern = new RegExp(this.addScriptFileName + '\\d*' + this.addScriptFileExtension);
-                return pattern.test(script.getIdentifier());
-            });
+            let increment = 0;
 
-            let numScripts;
-            numScripts = filteredScripts.length === 0 ? '' : filteredScripts.length;
-            this.currentFile = scriptManager.createScript(this.addScriptFileName + numScripts + this.addScriptFileExtension, 'JS', code);
+            let scriptName = this.addScriptFileName;
+
+            while ( existingScripts.findIndex((file) => file.getIdentifier() === scriptName) !== -1 ) {
+                scriptName = this.addScriptFileName + increment;
+                increment++;
+            }
+
+            this.currentFile = scriptManager.createScript(scriptName, 'JS', code);
             this.currentFileName = this.currentFile.getIdentifier();
         } else {
             let modelManager = this.businessNetwork.getModelManager();

--- a/packages/composer-playground/src/app/add-file/add-file.component.ts
+++ b/packages/composer-playground/src/app/add-file/add-file.component.ts
@@ -127,21 +127,22 @@ export class AddFileComponent {
         } else {
             let modelManager = this.businessNetwork.getModelManager();
             let existingModels = modelManager.getModelFiles();
-            let filteredModels = existingModels.filter((model) => {
-                let pattern = new RegExp(this.addModelFileName + '\\d*' + this.addModelFileExtension);
-                return pattern.test(model.getName());
-            });
+            let increment = 0;
 
-            let numModels = filteredModels.length === 0 ? '' : filteredModels.length;
+            let newModelNamespace = this.addModelNamespace;
+            while ( existingModels.findIndex((file) => file.getNamespace() === newModelNamespace) !== -1 ) {
+                newModelNamespace = this.addModelNamespace + increment;
+                increment++;
+            }
 
             let code =
                 `/**
  * New model file
  */
 
-namespace ${this.addModelNamespace + numModels}`;
+namespace ${newModelNamespace}`;
 
-            this.currentFile = new ModelFile(modelManager, code, this.addModelFileName + numModels + this.addModelFileExtension);
+            this.currentFile = new ModelFile(modelManager, code, newModelNamespace + this.addModelFileExtension);
             this.currentFileName = this.currentFile.getFileName();
         }
     }

--- a/packages/composer-playground/src/app/editor/editor.component.html
+++ b/packages/composer-playground/src/app/editor/editor.component.html
@@ -4,12 +4,21 @@
     <div class="side-bar-nav">
       <ul>
         <li *ngFor="let file of files" [class.active]="file.id === currentFile.id" (click)="setCurrentFile(file)">
-          <h3 *ngIf="file.package">Package Details</h3>
-          <h3 *ngIf="file.model">Model File</h3>
-          <h3 *ngIf="file.script">Script File</h3>
-          <h3 *ngIf="file.acl">Access Control</h3>
-          <h3 *ngIf="file.readme">About</h3>
-          <div title="{{file.displayID}}">{{file.displayID}}</div>
+            <div class="flex-container">
+                <div class="flex">
+                    <h3 [class.error]="file.invalid" *ngIf="file.package">Package Details</h3>
+                    <h3 [class.error]="file.invalid" *ngIf="file.model">Model File</h3>
+                    <h3 [class.error]="file.invalid" *ngIf="file.script">Script File</h3>
+                    <h3 [class.error]="file.invalid" *ngIf="file.acl">Access Control</h3>
+                    <h3 [class.error]="file.invalid" *ngIf="file.readme">About</h3>
+                    <div [class.error]="file.invalid" title="{{file.displayID}}">{{file.displayID}}</div>
+                </div>
+                <div *ngIf="file.invalid" class="error_dot">
+                    <svg class="ibm-icon" aria-hidden="true">
+                        <use xlink:href="#icon-error_dot"></use>
+                    </svg>
+                </div>
+          </div>
         </li>
       </ul>
     </div>

--- a/packages/composer-playground/src/app/editor/editor.component.scss
+++ b/packages/composer-playground/src/app/editor/editor.component.scss
@@ -6,6 +6,12 @@ app-editor {
   width: 100%;
 
   .side-bar {
+    display: flex;
+
+    .error_dot {
+        align-self: center;
+    }
+
     .files {
       & > * {
         padding: $space-medium $space-large;
@@ -18,6 +24,10 @@ app-editor {
 
       .side-bar-nav {
         padding: 0;
+
+        .error {
+            color: $first-warning;
+        }
       }
     }
 

--- a/packages/composer-playground/src/app/editor/editor.component.spec.ts
+++ b/packages/composer-playground/src/app/editor/editor.component.spec.ts
@@ -35,7 +35,7 @@ class MockEditorFileDirective {
     public editorFile;
 }
 
-fdescribe('EditorComponent', () => {
+describe('EditorComponent', () => {
     let component: EditorComponent;
     let fixture: ComponentFixture<EditorComponent>;
 
@@ -411,11 +411,26 @@ fdescribe('EditorComponent', () => {
             let mockUpdateFiles = sinon.stub(component, 'updateFiles');
             let mockSetCurrentFile = sinon.stub(component, 'setCurrentFile');
 
+            let mockModelFile0 = sinon.createStubInstance(ModelFile);
+            mockModelFile0.getNamespace.returns('namespace0');
+            mockModelFile0.id = 'namespace0';
+
+            let mockModelFile1 = sinon.createStubInstance(ModelFile);
+            mockModelFile1.getNamespace.returns('namespace1');
+            mockModelFile1.id = 'namespace1';
+
+            let mockModelFile2 = sinon.createStubInstance(ModelFile);
+            mockModelFile2.getNamespace.returns('namespace2');
+            mockModelFile2.id = 'namespace2';
+
             component['addModelNamespace'] = 'namespace';
-            component['files'] = [{id: 'random'}, {id: 'namespace0'}];
+            component['files'] = [mockModelFile, mockModelFile0, mockModelFile1, mockModelFile2];
+
+            mockModelFile.getNamespace.returns('namespace');
+            mockModelFile.id = 'namespace';
 
             let modelManagerMock = {
-                addModelFile: sinon.stub().returns({fileName: 'new-file'});
+                addModelFile: sinon.stub().returns(mockModelFile)
             };
 
             mockClientService.getBusinessNetwork.returns({
@@ -428,10 +443,10 @@ fdescribe('EditorComponent', () => {
   * New model file
   */
 
-  namespace namespace`);
+  namespace namespace3`);
             mockUpdateFiles.should.have.been.called;
 
-            mockSetCurrentFile.should.have.been.called;
+            mockSetCurrentFile.should.have.been.calledWith({id: 'namespace'});
             component['dirty'].should.equal(true);
         });
 
@@ -440,10 +455,11 @@ fdescribe('EditorComponent', () => {
             let mockSetCurrentFile = sinon.stub(component, 'setCurrentFile');
 
             component['addModelNamespace'] = 'namespace';
-            component['files'] = [{id: 'random'}, {id: 'namespace'}];
+            component['files'] = [{id: 'random'}, {id: 'namespace0'}];
 
+            mockModelFile.getNamespace.returns('namespace0');
             let modelManagerMock = {
-                addModelFile: sinon.stub().returns({fileName: 'new-file'});
+                addModelFile: sinon.stub().returns(mockModelFile)
             };
 
             mockClientService.getBusinessNetwork.returns({
@@ -455,7 +471,7 @@ fdescribe('EditorComponent', () => {
             modelManagerMock.addModelFile.should.have.been.calledWith('my code');
             mockUpdateFiles.should.have.been.called;
 
-            mockSetCurrentFile.should.have.been.called;
+            mockSetCurrentFile.should.have.been.calledWith({id: 'namespace0'});
             component['dirty'].should.equal(true);
         });
     });
@@ -465,12 +481,27 @@ fdescribe('EditorComponent', () => {
             let mockUpdateFiles = sinon.stub(component, 'updateFiles');
             let mockSetCurrentFile = sinon.stub(component, 'setCurrentFile');
 
+            let mockScript0 = sinon.createStubInstance(Script);
+            mockScript0.getIdentifier.returns('script');
+            mockScript0.id = 'script';
+
+            let mockScript1 = sinon.createStubInstance(Script);
+            mockScript1.getIdentifier.returns('script0');
+            mockScript1.id = 'script0';
+
+            let mockScript2 = sinon.createStubInstance(Script);
+            mockScript2.getIdentifier.returns('script2');
+            mockScript2.id = 'script2';
+
             component['addScriptFileName'] = 'script';
-            component['files'] = [{id: 'random'}, {id: 'script'}];
+            component['files'] = [mockScript0, mockScript1, mockScript2];
+
+            mockScriptFile.getIdentifier.returns('script');
 
             let scriptManagerMock = {
-                createScript: sinon.stub(),
-                addScript: sinon.stub()
+                createScript: sinon.stub().returns(mockScriptFile),
+                addScript: sinon.stub(),
+                getScripts: sinon.stub().returns([mockScript0, mockScript1, mockScript2]),
             };
 
             mockClientService.getBusinessNetwork.returns({
@@ -479,7 +510,7 @@ fdescribe('EditorComponent', () => {
 
             component.addScriptFile();
 
-            scriptManagerMock.createScript.should.have.been.calledWith('script', 'JS', `/**
+            scriptManagerMock.createScript.should.have.been.calledWith('script1', 'JS', `/**
   * New script file
   */`);
 
@@ -497,16 +528,19 @@ fdescribe('EditorComponent', () => {
             component['addScriptFileName'] = 'script';
             component['files'] = [{id: 'random'}, {id: 'script'}];
 
+            mockScriptFile.getIdentifier.returns('script');
+
             let scriptManagerMock = {
-                createScript: sinon.stub(),
-                addScript: sinon.stub()
+                createScript: sinon.stub().returns(mockScriptFile),
+                addScript: sinon.stub(),
+                getScripts: sinon.stub().returns([]),
             };
 
             mockClientService.getBusinessNetwork.returns({
                 getScriptManager: sinon.stub().returns(scriptManagerMock)
             });
 
-            component.addScriptFile('my script');
+            component.addScriptFile(mockScriptFile);
 
             scriptManagerMock.createScript.should.not.have.been.called;
 

--- a/packages/composer-playground/src/app/editor/editor.component.ts
+++ b/packages/composer-playground/src/app/editor/editor.component.ts
@@ -154,7 +154,7 @@ export class EditorComponent implements OnInit {
             });
         });
         newModelFiles.sort((a, b) => {
-            return a.displayID.localeCompare(b.displayID);
+        return a.displayID.localeCompare(b.displayID);
         });
         newFiles.push.apply(newFiles, newModelFiles);
 
@@ -200,15 +200,15 @@ export class EditorComponent implements OnInit {
         let businessNetworkDefinition = this.clientService.getBusinessNetwork();
         let modelManager = businessNetworkDefinition.getModelManager();
         let code;
-        let newModelNamespace = this.addModelNamespace;
-        let increment = 1;
-
-        while ( this.files.findIndex((file) => file.id === newModelNamespace) !== -1) {
-            newModelNamespace = this.addModelNamespace + increment;
-            increment++;
-        }
 
         if (!contents) {
+            let newModelNamespace = this.addModelNamespace;
+            let increment = 0;
+            while ( this.files.findIndex((file) => file.id === newModelNamespace) !== -1) {
+                newModelNamespace = this.addModelNamespace + increment;
+                increment++;
+            }
+
             code =
                 `/**
   * New model file
@@ -221,8 +221,7 @@ export class EditorComponent implements OnInit {
 
         let newFile = modelManager.addModelFile(code);
         this.updateFiles();
-        let index = this.files.findIndex((file) => file.id === newFile.fileName);
-        console.log('setting via:', this.files[index]);
+        let index = this.files.findIndex((file) => file.id === newFile.getNamespace());
         this.setCurrentFile(this.files[index]);
         this.dirty = true;
     }
@@ -230,25 +229,31 @@ export class EditorComponent implements OnInit {
     addScriptFile(scriptFile = null) {
         let businessNetworkDefinition = this.clientService.getBusinessNetwork();
         let scriptManager = businessNetworkDefinition.getScriptManager();
+        let existingScripts = scriptManager.getScripts();
         let code;
         let script;
+
         if (!scriptFile) {
+            let increment = 0;
+            let scriptName = this.addScriptFileName;
+            while ( existingScripts.findIndex((file) => file.getIdentifier() === scriptName) !== -1 ) {
+                scriptName = this.addScriptFileName + increment;
+                increment++;
+            }
+
             code =
                 `/**
   * New script file
   */`;
-            script = scriptManager.createScript(this.addScriptFileName, 'JS', code);
+            script = scriptManager.createScript(scriptName, 'JS', code);
         } else {
             script = scriptFile;
         }
 
         scriptManager.addScript(script);
         this.updateFiles();
-        this.files.forEach((file) => {
-            if (file.id === this.addScriptFileName) {
-                this.setCurrentFile(file);
-            }
-        });
+        let index = this.files.findIndex((file) => file.id === script.getIdentifier());
+        this.setCurrentFile(this.files[index]);
         this.dirty = true;
     }
 
@@ -398,8 +403,6 @@ export class EditorComponent implements OnInit {
                 // remove file from list view
                 let index = this.files.findIndex((x) => { return x.displayID === deleteFile.displayID; });
                 this.files.splice(index, 1);
-
-                this.updateFiles();
 
                 // Make sure we set a file to remove the deleted file from the view
                 this.setInitialFile();

--- a/packages/composer-playground/src/assets/svg/other/error_dot.svg
+++ b/packages/composer-playground/src/assets/svg/other/error_dot.svg
@@ -1,0 +1,8 @@
+<svg width="7px" height="7px" viewBox="0 0 7 7" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs></defs>
+    <g id="v4.1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Error-dot" transform="translate(-224.000000, -358.000000)" fill="#E62325">
+            <circle id="Oval-5" cx="227.5" cy="361.5" r="3.5"></circle>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Code delivery for #389

## Design of the fix
Namespace change enabled:
- user may change namespace of file
- namespace collision detection will prevent overwriting of existing model files
- new Behaviour subject for file name changes
- invalidation of acl files will be indicated visually and user will not be able to deploy broken BND
- updated add model file and script file logic for new file additions
- added tests for all 

## Validation of the fix
Initial manual testing, supported with automated tests

