### PR TITLE
Condition editor define for page re-visit

### DIFF
--- a/packages/composer-playground/src/app/editor/editor.component.spec.ts
+++ b/packages/composer-playground/src/app/editor/editor.component.spec.ts
@@ -123,6 +123,8 @@ describe('EditorComponent', () => {
         it('should initialize the editor', fakeAsync(() => {
             let mockUpdatePackage = sinon.stub(component, 'updatePackageInfo');
             let mockUpdateFiles = sinon.stub(component, 'updateFiles');
+            let mockSetFile = sinon.stub(component, 'setCurrentFile');
+            let mockSetIntialFile = sinon.stub(component, 'setInitialFile');
             component.ngOnInit();
 
             tick();
@@ -132,6 +134,28 @@ describe('EditorComponent', () => {
 
             mockUpdatePackage.should.have.been.called;
             mockUpdateFiles.should.have.been.called;
+            mockSetFile.should.not.have.been.called;
+            mockSetIntialFile.should.have.been.called;
+        }));
+
+        it('should re-initialize the editor', fakeAsync(() => {
+            let mockUpdatePackage = sinon.stub(component, 'updatePackageInfo');
+            let mockUpdateFiles = sinon.stub(component, 'updateFiles');
+            let mockSetFile = sinon.stub(component, 'setCurrentFile');
+            let mockSetIntialFile = sinon.stub(component, 'setInitialFile');
+            component['editorService'].setCurrentFile('file');
+
+            component.ngOnInit();
+
+            tick();
+
+            component['noError'].should.equal(true);
+            component['dirty'].should.equal(true);
+
+            mockUpdatePackage.should.have.been.called;
+            mockUpdateFiles.should.have.been.called;
+            mockSetFile.should.have.been.called;
+            mockSetIntialFile.should.not.have.been.called;
         }));
 
         it('should open import modal', fakeAsync(() => {

--- a/packages/composer-playground/src/app/editor/editor.component.ts
+++ b/packages/composer-playground/src/app/editor/editor.component.ts
@@ -71,6 +71,7 @@ export class EditorComponent implements OnInit {
         return this.initializationService.initialize()
         .then(() => {
             this.clientService.businessNetworkChanged$.subscribe((noError) => {
+                this.updateFiles();
                 if (this.editorFilesValidate() && noError) {
                     this.noError = noError;
                     this.dirty = true;
@@ -91,7 +92,7 @@ export class EditorComponent implements OnInit {
             this.updateFiles();
 
             if (this.editorService.getCurrentFile() !== null) {
-                this.currentFile = this.editorService.getCurrentFile();
+                this.setCurrentFile(this.editorService.getCurrentFile());
             } else {
                 this.setInitialFile();
             }


### PR DESCRIPTION
Within #1091 a page revisit to the Define section was not initialising correctly, this pull request fixes that by:
- calling set page if editor service returns a set file
- ensuring the business network changed callback always works from an updated file list 

## Design of the fix
The page needed to set the current file rather than accept a file retrieved from the editor service, this is because during the file setting, additional flags are applied that indicate if it may be deleted etc.

The business network changed callback needed to ensure that it was running with the most recent file list as it had the potential to use an out of date file list during validation.

## Validation of the fix
Manual test on local build, extension of automated tests to prevent regression.
Pending memory leak tests, and that will be the subject of following PRs
