### PR TITLE
Throw error for multiple ACL rules with the same name

### DIFF
--- a/packages/composer-common/lib/acl/aclfile.js
+++ b/packages/composer-common/lib/acl/aclfile.js
@@ -101,10 +101,15 @@ class AclFile {
      * @private
      */
     validate() {
-        for(let n=0; n < this.rules.length; n++) {
-            let aclRule = this.rules[n];
+        const aclRules = {};
+        this.rules.forEach((aclRule) => {
             aclRule.validate();
-        }
+            let name = aclRule.getName();
+            if (aclRules[name]){
+                throw new Error(`Found two or more ACL rules with the name '${name}'`);
+            }
+            aclRules[name] = aclRule;
+        });
     }
 
     /**
@@ -123,29 +128,6 @@ class AclFile {
         return this.definitions;
     }
 
-    /**
-     * Convert the specified JSON into an instance of an ACL file.
-     * @param {ModelManager} modelManager - the ModelManager that manages this
-     * ModelFile
-     * @param {Object} aclFile - A serialized instance of an AclFile.
-     * @param {string} aclFile.definitions - The definitions for the AclFile.
-     * @return {AclFile} An instance of an AclFile.
-     */
-    static fromJSON(modelManager, aclFile) {
-        return new AclFile(aclFile.identifier, modelManager, aclFile.definitions);
-    }
-
-    /**
-     * Convert this ACL file into an object that is suitable for converting
-     * into a JSON string for serialization purposes.
-     * @return {Object} An object suitable for converting into a JSON string.
-     */
-    toJSON() {
-        return {
-            identifier: this.identifier,
-            definitions: this.definitions,
-        };
-    }
 }
 
 module.exports = AclFile;

--- a/packages/composer-common/test/acl/aclfile.js
+++ b/packages/composer-common/test/acl/aclfile.js
@@ -42,18 +42,6 @@ describe('AclFile', () => {
         sandbox.restore();
     });
 
-    describe('#fromJSON', () => {
-
-        it('should round trip the model file', () => {
-            let aclFile1 = new AclFile( 'test', modelManager, testAcl);
-            let json = JSON.stringify(aclFile1);
-            let aclFile2 = AclFile.fromJSON(modelManager, JSON.parse(json));
-            aclFile2.should.deep.equal(aclFile1);
-            aclFile1.getIdentifier().should.equal(aclFile2.getIdentifier());
-        });
-
-    });
-
     describe('#constructor', () => {
 
         it('should throw when null definitions provided', () => {
@@ -335,6 +323,29 @@ describe('AclFile', () => {
             const aclFile = new AclFile( 'test', modelManager, testAcl);
             aclFile.validate();
         });
+
+        it('should throw for duplicate rule names', () => {
+            const aclContents = `rule R1 {
+                description: "some rule"
+                participant: "ANY"
+                operation: ALL
+                resource: "org.acme"
+                action: ALLOW
+            }
+
+            rule R1 {
+                description: "some rule"
+                participant: "ANY"
+                operation: ALL
+                resource: "org.acme"
+                action: ALLOW
+            }`;
+            const aclFile = new AclFile('test.acl', modelManager, aclContents);
+            (() => {
+                aclFile.validate();
+            }).should.throw(/Found two or more ACL rules with the name/);
+        });
+
     });
 
     describe('#accept', () => {

--- a/packages/composer-runtime/test/accesscontroller.js
+++ b/packages/composer-runtime/test/accesscontroller.js
@@ -185,7 +185,7 @@ describe('AccessController', () => {
             setAclFile(
                 'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: CREATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}' +
                 'rule R2 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: UPDATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}' +
-                'rule R2 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n'
+                'rule R3 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n'
             );
             let spy = sinon.spy(controller, 'checkRule');
             controller.check(asset, 'READ');
@@ -195,8 +195,8 @@ describe('AccessController', () => {
         it('should not throw if there is two non-matching DENY access control rules followed by one matching ALLOW access control rule', () => {
             setAclFile(
                 'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: CREATE resource: "org.acme.test.TestAsset#A1234" action: DENY}' +
-                'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: UPDATE resource: "org.acme.test.TestAsset#A1234" action: DENY}\n' +
-                'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n'
+                'rule R2 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: UPDATE resource: "org.acme.test.TestAsset#A1234" action: DENY}\n' +
+                'rule R3 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n'
             );
             let spy = sinon.spy(controller, 'checkRule');
             controller.check(asset, 'READ');
@@ -206,8 +206,8 @@ describe('AccessController', () => {
         it('should throw if there is two non-matching ALLOW access control rules followed by one matching DENY access control rule', () => {
             setAclFile(
                 'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: CREATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}' +
-                'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: UPDATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n' +
-                'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: DENY}\n'
+                'rule R2 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: UPDATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n' +
+                'rule R3 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: DENY}\n'
             );
             let spy = sinon.spy(controller, 'checkRule');
             (() => {
@@ -219,8 +219,8 @@ describe('AccessController', () => {
         it('should not throw if there is one matching ALLOW access control rule followed by two non-matching ALLOW access control rules', () => {
             setAclFile(
                 'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}' +
-                'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: CREATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n' +
-                'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: UPDATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n'
+                'rule R2 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: CREATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n' +
+                'rule R3 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: UPDATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n'
             );
             let spy = sinon.spy(controller, 'checkRule');
             controller.check(asset, 'READ');
@@ -230,8 +230,8 @@ describe('AccessController', () => {
         it('should not throw if there is one matching ALLOW access control rule followed by two non-matching DENY access control rules', () => {
             setAclFile(
                 'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}' +
-                'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: CREATE resource: "org.acme.test.TestAsset#A1234" action: DENY}\n' +
-                'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: UPDATE resource: "org.acme.test.TestAsset#A1234" action: DENY}\n'
+                'rule R2 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: CREATE resource: "org.acme.test.TestAsset#A1234" action: DENY}\n' +
+                'rule R3 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: UPDATE resource: "org.acme.test.TestAsset#A1234" action: DENY}\n'
             );
             let spy = sinon.spy(controller, 'checkRule');
             controller.check(asset, 'READ');
@@ -241,8 +241,8 @@ describe('AccessController', () => {
         it('should throw if there is one matching DENY access control rule followed by two non-matching ALLOW access control rules', () => {
             setAclFile(
                 'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: DENY}' +
-                'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: CREATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n' +
-                'rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: UPDATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n'
+                'rule R2 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: CREATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n' +
+                'rule R3 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: UPDATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n'
             );
             let spy = sinon.spy(controller, 'checkRule');
             (() => {


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->
ACL rules may have duplicate names #1123

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->