### PR TITLE
fix(docs): missing single space at beginning of comment for license

### DIFF
--- a/packages/composer-website/jekylldocs/tutorials/developer-guide.md
+++ b/packages/composer-website/jekylldocs/tutorials/developer-guide.md
@@ -85,8 +85,8 @@ As an example, we're going to replace the entire contents of the file 'sample.ct
 
 ```
 /**
-* My commodity trading network
-*/
+ * My commodity trading network
+ */
 namespace org.acme.mynetwork
 asset Commodity identified by tradingSymbol {
     o String tradingSymbol
@@ -120,24 +120,24 @@ Now replace the entire contents of `logic.js` with the function below (including
 
 ```
 /*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /**
-* Track the trade of a commodity from one trader to another
-* @param {org.acme.mynetwork.Trade} trade - the trade to be processed
-* @transaction
-*/
+ * Track the trade of a commodity from one trader to another
+ * @param {org.acme.mynetwork.Trade} trade - the trade to be processed
+ * @transaction
+ */
 function tradeCommodity(trade) {
     trade.commodity.owner = trade.newOwner;
     return getAssetRegistry('org.acme.mynetwork.Commodity')
@@ -155,8 +155,8 @@ The file `permissions.acl` defines the access control rules for the business net
 
 ```
 /**
-* Access control rules for mynetwork
-*/
+ * Access control rules for mynetwork
+ */
 rule Default {
     description: "Allow all participants access to all resources"
     participant: "ANY"
@@ -210,18 +210,18 @@ The test code below will replace the namespace, types and logic of the unit test
 
 ```
 /*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict';
 


### PR DESCRIPTION
Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
