### PR TITLE
Condition for no filename on model file

### DIFF
--- a/packages/composer-common/lib/businessnetworkdefinition.js
+++ b/packages/composer-common/lib/businessnetworkdefinition.js
@@ -274,8 +274,13 @@ class BusinessNetworkDefinition {
         let modelFiles = modelManager.getModelFiles();
         zip.file('models/', null, Object.assign({}, options, { dir: true }));
         modelFiles.forEach(function(file) {
-            let fileIdentifier = file.fileName;
-            let fileName = fsPath.parse(fileIdentifier).base;
+            let fileName;
+            if (file.fileName === 'UNKNOWN'  || file.fileName === null) {
+                fileName = file.namespace + '.cto';
+            } else {
+                let fileIdentifier = file.fileName;
+                fileName = fsPath.parse(fileIdentifier).base;
+            }
             zip.file('models/' + fileName, file.definitions, options);
         });
 


### PR DESCRIPTION
If importing from github, model files do not have filenames and this will result in import failures. It is necessary to condition for null filename values and conditionally use namespaces instead.

This was a defect found against #387 during manual test validation script running