### PR TITLE
condition for undef fileNames

### DIFF
--- a/packages/composer-common/lib/businessnetworkdefinition.js
+++ b/packages/composer-common/lib/businessnetworkdefinition.js
@@ -275,7 +275,7 @@ class BusinessNetworkDefinition {
         zip.file('models/', null, Object.assign({}, options, { dir: true }));
         modelFiles.forEach(function(file) {
             let fileName;
-            if (file.fileName === 'UNKNOWN'  || file.fileName === null) {
+            if (file.fileName === 'UNKNOWN'  || file.fileName === null || !file.fileName) {
                 fileName = file.namespace + '.cto';
             } else {
                 let fileIdentifier = file.fileName;


### PR DESCRIPTION
If running sample installation via npm, model files do not have filenames and this will result in import failures. It is necessary to condition for null filename values and conditionally use namespaces instead.

This was a defect found against #387 during manual test validation