### PR TITLE
Undef conditioning and test support

### DIFF
--- a/packages/composer-common/lib/businessnetworkdefinition.js
+++ b/packages/composer-common/lib/businessnetworkdefinition.js
@@ -275,7 +275,7 @@ class BusinessNetworkDefinition {
         zip.file('models/', null, Object.assign({}, options, { dir: true }));
         modelFiles.forEach(function(file) {
             let fileName;
-            if (file.fileName === 'UNKNOWN'  || file.fileName === null) {
+            if (file.fileName === 'UNKNOWN'  || file.fileName === null || !file.fileName) {
                 fileName = file.namespace + '.cto';
             } else {
                 let fileIdentifier = file.fileName;

--- a/packages/composer-systests/systest/accesscontrols.js
+++ b/packages/composer-systests/systest/accesscontrols.js
@@ -38,6 +38,7 @@ describe('Access control system tests', () => {
     let aliceCar, bobCar;
 
     before(function () {
+        // In this systest we are fully specifying the model file with a fileName and content
         const modelFiles = [
             { fileName: 'models/accesscontrols.cto', contents: fs.readFileSync(path.resolve(__dirname, 'data/accesscontrols.cto'), 'utf8')}
         ];

--- a/packages/composer-systests/systest/assets.js
+++ b/packages/composer-systests/systest/assets.js
@@ -33,8 +33,9 @@ describe('Asset system tests', function () {
     let client;
 
     before(function () {
+        // In this systest we are intentionally not fully specifying the model file with a fileName, but supplying "UNKNOWN"
         const modelFiles = [
-            { fileName: 'models/assets.cto', contents:fs.readFileSync(path.resolve(__dirname, 'data/assets.cto'), 'utf8') }
+            { fileName: 'UNKNOWN', contents:fs.readFileSync(path.resolve(__dirname, 'data/assets.cto'), 'utf8') }
         ];
         businessNetworkDefinition = new BusinessNetworkDefinition('systest.assets@0.0.1', 'The network for the asset system tests');
         modelFiles.forEach((modelFile) => {

--- a/packages/composer-systests/systest/events.js
+++ b/packages/composer-systests/systest/events.js
@@ -32,6 +32,7 @@ describe('Event system tests', function () {
     let client;
 
     before(function () {
+        // In this systest we are intentionally not fully specifying the model file with a fileName, and supplying no value in model creation
         const modelFiles = [
             { fileName: 'models/events.cto', contents: fs.readFileSync(path.resolve(__dirname, 'data/events.cto'), 'utf8') }
         ];
@@ -40,7 +41,7 @@ describe('Event system tests', function () {
         ];
         businessNetworkDefinition = new BusinessNetworkDefinition('systest.events@0.0.1', 'The network for the event system tests');
         modelFiles.forEach((modelFile) => {
-            businessNetworkDefinition.getModelManager().addModelFile(modelFile.contents, modelFile.fileName);
+            businessNetworkDefinition.getModelManager().addModelFile(modelFile.contents);
         });
         scriptFiles.forEach((scriptFile) => {
             let scriptManager = businessNetworkDefinition.getScriptManager();

--- a/packages/composer-systests/systest/identities.js
+++ b/packages/composer-systests/systest/identities.js
@@ -35,8 +35,9 @@ describe('Identity system tests', () => {
     let participant;
 
     before(function () {
+        // In this systest we are intentionally not fully specifying the model file with a fileName, and supplying null as the value
         const modelFiles = [
-            { fileName: 'models/identities.cto', contents: fs.readFileSync(path.resolve(__dirname, 'data/identities.cto'), 'utf8') }
+            { fileName: null, contents: fs.readFileSync(path.resolve(__dirname, 'data/identities.cto'), 'utf8') }
         ];
         const scriptFiles = [
             { identifier: 'identities.js', contents: fs.readFileSync(path.resolve(__dirname, 'data/identities.js'), 'utf8') }

--- a/packages/composer-systests/systest/participants.js
+++ b/packages/composer-systests/systest/participants.js
@@ -32,8 +32,9 @@ describe('Participant system tests', function () {
     let client;
 
     before(function () {
+        // In this systest we are intentionally not fully specifying the model file with a fileName, and supplying undefined as the value
         const modelFiles = [
-            { fileName: 'models/participants.cto', contents: fs.readFileSync(path.resolve(__dirname, 'data/participants.cto'), 'utf8') }
+            { fileName: undefined, contents: fs.readFileSync(path.resolve(__dirname, 'data/participants.cto'), 'utf8') }
         ];
         businessNetworkDefinition = new BusinessNetworkDefinition('systest.participants@0.0.1', 'The network for the participant system tests');
         modelFiles.forEach((modelFile) => {


### PR DESCRIPTION
If running sample installation via npm, model files do not have filenames and this will result in import failures. It is necessary to condition for undefined filename values and conditionally use namespaces instead.