### PR TITLE
add scroll bars to editor pages for non code-mirror elements

### DIFF
--- a/packages/composer-playground/package.json
+++ b/packages/composer-playground/package.json
@@ -176,6 +176,7 @@
     "mocha": "^3.2.0",
     "ng2-bootstrap": "^1.1.16-11",
     "ng2-codemirror": "^1.0.1",
+    "ngx-perfect-scrollbar": "^4.3.0",
     "node-sass": "^4.5.0",
     "parse5": "^3.0.1",
     "protractor": "^5.1.1",

--- a/packages/composer-playground/src/app/app.module.ts
+++ b/packages/composer-playground/src/app/app.module.ts
@@ -54,6 +54,7 @@ import { ViewCertificateComponent } from './view-certificate';
 import { FileDragDropDirective } from './directives/file-drag-drop';
 import { CheckOverFlowDirective } from './directives/check-overflow';
 import { FocusHereDirective } from './directives/focus-here';
+import { PerfectScrollbarModule } from 'ngx-perfect-scrollbar';
 
 import { AdminService } from './services/admin.service';
 import { ClientService } from './services/client.service';
@@ -158,6 +159,7 @@ type StoreType = {
         HttpModule,
         RouterModule.forRoot(ROUTES, {useHash: false, preloadingStrategy: PreloadAllModules}),
         CodemirrorModule,
+        PerfectScrollbarModule,
         ModalModule.forRoot(),
         TooltipModule.forRoot(),
         NgbModule.forRoot(),

--- a/packages/composer-playground/src/app/editor-file/editor-file.component.html
+++ b/packages/composer-playground/src/app/editor-file/editor-file.component.html
@@ -1,5 +1,5 @@
-<div class="readme" *ngIf="editorType === 'readme'" [innerHTML]="editorContent">
-</div>
+<perfect-scrollbar class="readme" *ngIf="editorType === 'readme'" [innerHTML]="editorContent">
+</perfect-scrollbar>
 
 <codemirror name="editorCodeMirror" *ngIf="editorType === 'code'" [(ngModel)]="editorContent" [config]="codeConfig"
             (ngModelChange)="onCodeChanged()" width="100%" height="100%" ngDefaultControl>

--- a/packages/composer-playground/src/app/editor-file/editor-file.component.scss
+++ b/packages/composer-playground/src/app/editor-file/editor-file.component.scss
@@ -30,7 +30,7 @@ editor-file {
     padding: $space-large;
     min-height: 63vh;
     max-height: 63vh;
-    overflow-y: auto;
+    overflow-y: scroll;
   }
 }
 
@@ -42,4 +42,9 @@ editor-file {
 .CodeMirror, .CodeMirror-scroll {
   min-height: 63vh;
   max-height: 63vh;
+}
+
+.ps.ps--active-x>.ps__scrollbar-x-rail,
+.ps.ps--active-y>.ps__scrollbar-y-rail{
+    opacity: 0.6;
 }

--- a/packages/composer-playground/src/app/editor/editor.component.html
+++ b/packages/composer-playground/src/app/editor/editor.component.html
@@ -1,7 +1,7 @@
 <section class="side-bar">
   <div class="files">
     <span>Files</span>
-    <div class="side-bar-nav">
+    <perfect-scrollbar class="side-bar-nav">
       <ul>
         <li *ngFor="let file of files" [class.active]="file.id === currentFile.id" (click)="setCurrentFile(file)">
             <div class="flex-container">
@@ -21,7 +21,7 @@
           </div>
         </li>
       </ul>
-    </div>
+    </perfect-scrollbar>
     <div class="add-file">
       <button class="action" type="button" (click)="openAddFileModal()">+ Add a file...</button>
     </div>

--- a/packages/composer-playground/src/app/editor/editor.component.scss
+++ b/packages/composer-playground/src/app/editor/editor.component.scss
@@ -24,7 +24,8 @@ app-editor {
 
       .side-bar-nav {
         padding: 0;
-
+        max-height: 25rem;
+        overflow-y: scroll;
         .error {
             color: $first-warning;
         }
@@ -121,4 +122,10 @@ app-editor {
       min-height:63vh;
       max-height:63vh;
     }
+
+  .ps.ps--active-x>.ps__scrollbar-x-rail,
+  .ps.ps--active-y>.ps__scrollbar-y-rail{
+      opacity: 0.6;
+  }
+
 }

--- a/packages/composer-playground/src/app/import/import.component.html
+++ b/packages/composer-playground/src/app/import/import.component.html
@@ -90,14 +90,14 @@
             </div>
           </div>
         </div>
-        <div *ngIf="!gitHubInProgress" class="sample-network-list-container">
+        <perfect-scrollbar *ngIf="!gitHubInProgress" class="sample-network-list-container">
           <div class="sample-network-list" *ngFor=" let sampleNetwork of sampleNetworks; let networkIndex=index">
             <input id="sampleNetwork{{networkIndex}}" type="radio" name="sampleNetwork" [(ngModel)]="chosenNetwork"
                    value="{{sampleNetwork.name}}">
             <label class="radio-label" for="sampleNetwork{{networkIndex}}">{{sampleNetwork.name}}</label>
             <div class="description">{{sampleNetwork.description}}</div>
           </div>
-        </div>
+        </perfect-scrollbar>
       </div>
     </div>
   </section>

--- a/packages/composer-playground/src/app/import/import.component.scss
+++ b/packages/composer-playground/src/app/import/import.component.scss
@@ -83,7 +83,7 @@ import-modal {
 
       .sample-network-list-container {
         max-height: 200px;
-        overflow-y: auto;
+        overflow-y: scroll;
         margin-top: $space-medium;
       }
 
@@ -120,5 +120,10 @@ import-modal {
 
       width: 100%;
     }
+  }
+
+  .ps.ps--active-x>.ps__scrollbar-x-rail,
+  .ps.ps--active-y>.ps__scrollbar-y-rail{
+      opacity: 0.6;
   }
 }


### PR DESCRIPTION
Scrollbar addition and styling for #828 

## Design of the fix
 - Add ngx-perfect-scroll to package
 - Use above package to provide scrollbars with styling to editor file list and readme page

## Validation of the fix
Tested on Ubuntu Chrome and Firefox

