### PR TITLE
Fixing inconsistencies in error messages

### DIFF
--- a/packages/composer-common/api.txt
+++ b/packages/composer-common/api.txt
@@ -48,6 +48,7 @@ class IllegalModelException extends BaseException {
    + void constructor(string,string,string) 
    + string getModelFile() 
    + string getFileLocation() 
+   + string getShortMessage() 
 }
 class Introspector {
    + void constructor(ModelManager) 

--- a/packages/composer-common/changelog.txt
+++ b/packages/composer-common/changelog.txt
@@ -12,7 +12,10 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 0.7.5 {b2c1c30d370b04c153426500a03c3061} 2017-06-07
+Version 0.7.5 {6bfca35e65b8feb42cf3a3143f714db1} 2017-06-14
+- Added IllegalModelException.getShortMessage to return only error, without location
+
+Version 0.7.5 {6bfca35e65b8feb42cf3a3143f714db1} 2017-06-07
 - Added optional JSZip options parameter to toArchive
 
 Version 0.7.4 {ebaf2453e8e5af80aa8e2d36a7513b63} 2017-05-30

--- a/packages/composer-common/lib/introspect/illegalmodelexception.js
+++ b/packages/composer-common/lib/introspect/illegalmodelexception.js
@@ -33,20 +33,24 @@ class IllegalModelException extends BaseException {
      */
     constructor(message, modelFile, fileLocation) {
 
-        let messagePrefix = '';
+        let messageSuffix = '';
         if(modelFile && modelFile.getFileName()) {
-            messagePrefix = 'File \'' + modelFile.getFileName() + '\': ' ;
+            messageSuffix = 'File \'' + modelFile.getFileName() + '\': ' ;
         }
 
         if(fileLocation) {
-            messagePrefix = messagePrefix + 'line ' + fileLocation.start.line + ' column ' +
+            messageSuffix = messageSuffix + 'line ' + fileLocation.start.line + ' column ' +
                 fileLocation.start.column + ', to line ' + fileLocation.end.line + ' column ' +
                 fileLocation.end.column + '. ';
         }
 
-        super(messagePrefix + message);
+        // First character to be uppercase
+        messageSuffix = messageSuffix.charAt(0).toUpperCase() + messageSuffix.slice(1);
+
+        super(message + ' ' + messageSuffix);
         this.modelFile = modelFile;
         this.fileLocation = fileLocation;
+        this.shortMessage = message;
     }
 
     /**
@@ -63,6 +67,14 @@ class IllegalModelException extends BaseException {
      */
     getFileLocation() {
         return this.fileLocation;
+    }
+
+    /**
+     * Returns the error message without the location of the error
+     * @returns {string} the error message
+     */
+    getShortMessage() {
+        return this.shortMessage;
     }
 }
 


### PR DESCRIPTION
- Added `getShortMessage()` to `IllegalModelException` to allow error messages to be displayed without location information
- Place all location information at the end of an error by default