### PR TITLE
Fix issue 1392

### DIFF
--- a/packages/composer-common/lib/acl/aclrule.js
+++ b/packages/composer-common/lib/acl/aclrule.js
@@ -16,7 +16,9 @@
 
 const IllegalModelException = require('../introspect/illegalmodelexception');
 const ModelBinding = require('./modelbinding');
+const ParticipantDeclaration = require('../introspect/participantdeclaration');
 const Predicate = require('./predicate');
+const TransactionDeclaration = require('../introspect/transactiondeclaration');
 
 /**
  * AclRule captures the details of an Access Control Rule. It is defined in terms of
@@ -121,7 +123,7 @@ class AclRule {
             this.participant.validate();
 
             let participantClassDeclaration = this.participant.getClassDeclaration();
-            if (participantClassDeclaration && participantClassDeclaration.constructor.name !== 'ParticipantDeclaration') {
+            if (participantClassDeclaration && !(participantClassDeclaration instanceof ParticipantDeclaration)) {
                 throw new IllegalModelException(`The participant '${participantClassDeclaration.getName()}' must be a participant`);
             }
         }
@@ -130,7 +132,7 @@ class AclRule {
             this.transaction.validate();
 
             let transactionClassDeclaration = this.transaction.getClassDeclaration();
-            if (transactionClassDeclaration && transactionClassDeclaration.constructor.name !== 'TransactionDeclaration') {
+            if (transactionClassDeclaration && !(transactionClassDeclaration instanceof TransactionDeclaration)) {
                 throw new IllegalModelException(`The transaction '${transactionClassDeclaration.getName()}' must be a transaction`);
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->
This fixes #1392 by stopping the use of `thing.constructor.name` which when webpacked in production mode will not work because webpack/uglify changes the name of the classes. It's an evil way to check the type anyway, so just use `instanceof` instead.

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->
Cannot create ACL file in playground #1392

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->