### PR TITLE
Need unstable playground to use unstable basic sample network

### DIFF
--- a/packages/composer-playground/package.json
+++ b/packages/composer-playground/package.json
@@ -127,7 +127,7 @@
     "babel-loader": "^6.2.10",
     "babel-polyfill": "^6.23.0",
     "babel-preset-latest": "^6.24.1",
-    "basic-sample-network": "latest",
+    "basic-sample-network": "^0.1.0-0",
     "bootstrap": "4.0.0-alpha.5",
     "browserfs": "^1.1.0",
     "buffer-loader": "0.0.1",


### PR DESCRIPTION
Due to breaking changes in 0.9.0

This should eventually be fixed but needs to stay in for this
release

Signed-off-by: James Taylor <jamest@uk.ibm.com>
