### PR TITLE
PR for #796

### DIFF
--- a/packages/composer-common/api.txt
+++ b/packages/composer-common/api.txt
@@ -26,11 +26,11 @@ class BusinessNetworkMetadata {
 }
 class Factory {
    + void constructor(ModelManager) 
-   + Resource newResource(string,string,string,Object,boolean,string) throws TypeNotFoundException
-   + Resource newConcept(string,string,Object,boolean,string) throws TypeNotFoundException
+   + Resource newResource(string,string,string,Object,boolean,string,boolean) throws TypeNotFoundException
+   + Resource newConcept(string,string,Object,boolean,string,boolean) throws TypeNotFoundException
    + Relationship newRelationship(string,string,string) throws TypeNotFoundException
-   + Resource newTransaction(string,string,string,Object,string) 
-   + Resource newEvent(string,string,string,Object,string) 
+   + Resource newTransaction(string,string,string,Object,string,boolean) 
+   + Resource newEvent(string,string,string,Object,string,boolean) 
 }
 class FileWallet extends Wallet {
    + string getHomeDirectory() 

--- a/packages/composer-common/changelog.txt
+++ b/packages/composer-common/changelog.txt
@@ -11,11 +11,13 @@
 #
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
-Version 0.9.0 {60327250ee4f059647020f8aee5ed67b} 2017-06-23
+Version 0.9.2 {60327250ee4f059647020f8aee5ed67b} 2017-07-06
+- Added includeOptionalFields option to Factory.newXXX functions
+
+Version 0.9.0 {d0b9ae5179276e20604874624fe9529d} 2017-06-23
 - Removed useless toJSON methods everywhere
 - Removed deprecated Factory.newInstance method
 - Removed deprecated ModelFile.getFileName method
-- Added includeOptionalFields option to Factory.newXXX functions
 
 Version 0.8.1 {5ac120d6a9f42683dfcd729fea3ea1c9} 2017-06-20
 - Added BaseModelException to standardise model errors

--- a/packages/composer-common/changelog.txt
+++ b/packages/composer-common/changelog.txt
@@ -11,11 +11,11 @@
 #
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
-
-Version 0.9.0 {d0b9ae5179276e20604874624fe9529d} 2017-06-23
+Version 0.9.0 {60327250ee4f059647020f8aee5ed67b} 2017-06-23
 - Removed useless toJSON methods everywhere
 - Removed deprecated Factory.newInstance method
 - Removed deprecated ModelFile.getFileName method
+- Added includeOptionalFields option to Factory.newXXX functions
 
 Version 0.8.1 {5ac120d6a9f42683dfcd729fea3ea1c9} 2017-06-20
 - Added BaseModelException to standardise model errors

--- a/packages/composer-common/lib/codegen/fromcto/loopback/loopbackvisitor.js
+++ b/packages/composer-common/lib/codegen/fromcto/loopback/loopbackvisitor.js
@@ -326,7 +326,7 @@ class LoopbackVisitor {
 
         // Add information from the class declaration into the composer section.
         if (jsonSchema.options && jsonSchema.options.composer) {
-            jsonSchema.options.composer.namespace = classDeclaration.getModelFile().getNamespace();
+            jsonSchema.options.composer.namespace = classDeclaration.getNamespace();
             jsonSchema.options.composer.name = classDeclaration.getName();
             jsonSchema.options.composer.fqn = classDeclaration.getFullyQualifiedName();
         }

--- a/packages/composer-common/lib/factory.js
+++ b/packages/composer-common/lib/factory.js
@@ -76,10 +76,11 @@ class Factory {
             if ((/^empty$/i).test(clientOptions.generate)) {
                 generateParams.valueGenerator = ValueGeneratorFactory.empty();
             } else {
+                // Allow any other value for backwards compatibility with previous (truthy) behavior
                 generateParams.valueGenerator = ValueGeneratorFactory.sample();
             }
 
-            generateParams.includeOptionalFields = false;
+            generateParams.includeOptionalFields = clientOptions.includeOptionalFields ? true : false;
 
             return generateParams;
         };
@@ -96,6 +97,8 @@ class Factory {
      * @param {string} [options.generate] - Pass one of: <dl>
      * <dt>sample</dt><dd>return a resource instance with generated sample data.</dd>
      * <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl>
+     * @param {boolean} [options.includeOptionalFields] - if <code>options.generate</code>
+     * is specified, whether optional fields should be generated.
      * @return {Resource} the new instance
      * @throws {TypeNotFoundException} if the type is not registered with the ModelManager
      */
@@ -159,6 +162,8 @@ class Factory {
      * @param {string} [options.generate] - Pass one of: <dl>
      * <dt>sample</dt><dd>return a resource instance with generated sample data.</dd>
      * <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl>
+     * @param {boolean} [options.includeOptionalFields] - if <code>options.generate</code>
+     * is specified, whether optional fields should be generated.
      * @return {Resource} the new instance
      * @throws {TypeNotFoundException} if the type is not registered with the ModelManager
      */
@@ -225,6 +230,8 @@ class Factory {
      * @param {string} [options.generate] - Pass one of: <dl>
      * <dt>sample</dt><dd>return a resource instance with generated sample data.</dd>
      * <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl>
+     * @param {boolean} [options.includeOptionalFields] - if <code>options.generate</code>
+     * is specified, whether optional fields should be generated.
      * @return {Resource} A resource for the new transaction.
      */
     newTransaction(ns, type, id, options) {
@@ -258,6 +265,8 @@ class Factory {
      * @param {string} [options.generate] - Pass one of: <dl>
      * <dt>sample</dt><dd>return a resource instance with generated sample data.</dd>
      * <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl>
+     * @param {boolean} [options.includeOptionalFields] - if <code>options.generate</code>
+     * is specified, whether optional fields should be generated.
      * @return {Resource} A resource for the new event.
      */
     newEvent(ns, type, id, options) {

--- a/packages/composer-common/lib/factory.js
+++ b/packages/composer-common/lib/factory.js
@@ -54,36 +54,6 @@ class Factory {
      */
     constructor(modelManager) {
         this.modelManager = modelManager;
-
-        this.initializeNewObject = (newObject, classDeclaration, clientOptions) => {
-            const generateParams = this.parseGenerateOptions(clientOptions);
-            if (generateParams) {
-                generateParams.stack = new TypedStack(newObject);
-                const visitor = new InstanceGenerator();
-                classDeclaration.accept(visitor, generateParams);
-            }
-        };
-
-        this.parseGenerateOptions = (clientOptions) => {
-            if (!clientOptions.generate) {
-                return null;
-            }
-
-            const generateParams = { };
-            generateParams.modelManager = this.modelManager;
-            generateParams.factory = this;
-
-            if ((/^empty$/i).test(clientOptions.generate)) {
-                generateParams.valueGenerator = ValueGeneratorFactory.empty();
-            } else {
-                // Allow any other value for backwards compatibility with previous (truthy) behavior
-                generateParams.valueGenerator = ValueGeneratorFactory.sample();
-            }
-
-            generateParams.includeOptionalFields = clientOptions.includeOptionalFields ? true : false;
-
-            return generateParams;
-        };
     }
 
     /**
@@ -287,6 +257,54 @@ class Factory {
         event.timestamp = new Date();
 
         return event;
+    }
+
+    /**
+     * PRIVATE IMPLEMENTATION. DO NOT CALL FROM OUTSIDE THIS CLASS.
+     *
+     * Initialize the state of a newly created resource
+     * @private
+     * @param {Typed} newObject - resource to initialize.
+     * @param {ClassDeclaration} classDeclaration - class declaration for the resource.
+     * @param {Object} clientOptions - field generation options supplied by the caller.
+     */
+    initializeNewObject(newObject, classDeclaration, clientOptions) {
+        const generateParams = this.parseGenerateOptions(clientOptions);
+        if (generateParams) {
+            generateParams.stack = new TypedStack(newObject);
+            const visitor = new InstanceGenerator();
+            classDeclaration.accept(visitor, generateParams);
+        }
+    }
+
+    /**
+     * PRIVATE IMPLEMENTATION. DO NOT CALL FROM OUTSIDE THIS CLASS.
+     *
+     * Parse the client-supplied field generation options and return a corresponding set of InstanceGenerator
+     * options that can be used to initialize a resource.
+     * @private
+     * @param {Object} clientOptions - field generation options supplied by the caller.
+     * @return {Object} InstanceGenerator options.
+     */
+    parseGenerateOptions(clientOptions) {
+        if (!clientOptions.generate) {
+            return null;
+        }
+
+        const generateParams = { };
+        generateParams.modelManager = this.modelManager;
+        generateParams.factory = this;
+
+        if ((/^empty$/i).test(clientOptions.generate)) {
+            generateParams.valueGenerator = ValueGeneratorFactory.empty();
+        } else {
+            // Allow any other value for backwards compatibility with previous (truthy) behavior
+            generateParams.valueGenerator = ValueGeneratorFactory.sample();
+        }
+
+        generateParams.includeOptionalFields = clientOptions.includeOptionalFields ? true : false;
+
+        return generateParams;
     }
 
 }

--- a/packages/composer-common/lib/introspect/classdeclaration.js
+++ b/packages/composer-common/lib/introspect/classdeclaration.js
@@ -231,7 +231,7 @@ class ClassDeclaration {
             // we now validate the field, however to ensure that
             // imports are resolved correctly we validate in the context
             // of the declared type of the field for non-primitives in a different namespace
-            if(field.isPrimitive() || this.isEnum() || field.getNamespace() === this.getModelFile().getNamespace() ) {
+            if(field.isPrimitive() || this.isEnum() || field.getNamespace() === this.getNamespace() ) {
                 field.validate(this);
             }
             else {
@@ -304,7 +304,7 @@ class ClassDeclaration {
      * @return {boolean} true if the class may be pointed to by a relationship
      */
     isSystemType() {
-        return ModelUtil.getSystemNamespace() === this.modelFile.getNamespace();
+        return ModelUtil.getSystemNamespace() === this.getNamespace();
     }
 
     /**
@@ -318,13 +318,21 @@ class ClassDeclaration {
     }
 
     /**
+     * Return the namespace of this class.
+     * @return {String} namespace - a namespace.
+     */
+    getNamespace() {
+        return this.modelFile.getNamespace();
+    }
+
+    /**
      * Returns the fully qualified name of this class.
      * The name will include the namespace if present.
      *
      * @return {string} the fully-qualified name of this class
      */
     getFullyQualifiedName() {
-        return this.modelFile.getNamespace() + '.' + this.name;
+        return this.getNamespace() + '.' + this.name;
     }
 
     /**

--- a/packages/composer-common/lib/introspect/property.js
+++ b/packages/composer-common/lib/introspect/property.js
@@ -156,7 +156,7 @@ class Property {
      * @return {string} the fully qualified name of this property
      */
     getFullyQualifiedName() {
-        return this.getNamespace() + '.' + this.getParent().getName() + '.' + this.getName();
+        return this.getParent().getFullyQualifiedName() + '.' + this.getName();
     }
 
     /**
@@ -164,7 +164,7 @@ class Property {
      * @return {string} the namespace of the parent of this property
      */
     getNamespace() {
-        return this.getParent().getModelFile().getNamespace();
+        return this.getParent().getNamespace();
     }
 
     /**

--- a/packages/composer-common/lib/introspect/relationshipdeclaration.js
+++ b/packages/composer-common/lib/introspect/relationshipdeclaration.js
@@ -57,7 +57,7 @@ class RelationshipDeclaration extends Property {
         if(ModelUtil.isPrimitiveType(this.getType())) {
             throw new IllegalModelException('Relationship ' + this.getName() + ' cannot be to the primitive type ' + this.getType(), classDecl.getModelFile(), this.ast.location );
         } else {
-            let namespace = this.getParent().getModelFile().getNamespace();
+            let namespace = this.getParent().getNamespace();
 
             // we first try to get the type from our own model file
             // because during validate we have not yet been added to the model manager

--- a/packages/composer-common/lib/model/typed.js
+++ b/packages/composer-common/lib/model/typed.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const Field = require('../introspect/field');
+const ModelUtil = require('../modelutil');
 
 /**
  * Object is an instance with a namespace and a type.
@@ -76,7 +77,7 @@ class Typed {
      * @return {string} The fully-qualified type name of this object
      */
     getFullyQualifiedType() {
-        return this.$namespace + '.' + this.$type;
+        return ModelUtil.getFullyQualifiedName(this.$namespace, this.$type);
     }
 
     /**

--- a/packages/composer-common/lib/modelutil.js
+++ b/packages/composer-common/lib/modelutil.js
@@ -188,7 +188,7 @@ class ModelUtil {
      */
     static getFullyQualifiedName(namespace, type) {
         if (namespace) {
-            return namespace + '.' + type;
+            return `${namespace}.${type}`;
         } else {
             return type;
         }

--- a/packages/composer-common/lib/serializer.js
+++ b/packages/composer-common/lib/serializer.js
@@ -136,15 +136,15 @@ class Serializer {
         // create a new instance, using the identifier field name as the ID.
         let resource;
         if (classDeclaration instanceof TransactionDeclaration) {
-            resource = this.factory.newTransaction( classDeclaration.getModelFile().getNamespace(),
+            resource = this.factory.newTransaction( classDeclaration.getNamespace(),
                                                     classDeclaration.getName(),
                                                     jsonObject[classDeclaration.getIdentifierFieldName()] );
         } else if (classDeclaration instanceof EventDeclaration) {
-            resource = this.factory.newEvent( classDeclaration.getModelFile().getNamespace(),
+            resource = this.factory.newEvent( classDeclaration.getNamespace(),
                                               classDeclaration.getName(),
                                               jsonObject[classDeclaration.getIdentifierFieldName()] );
         } else {
-            resource = this.factory.newResource( classDeclaration.getModelFile().getNamespace(),
+            resource = this.factory.newResource( classDeclaration.getNamespace(),
                                                  classDeclaration.getName(),
                                                  jsonObject[classDeclaration.getIdentifierFieldName()] );
         }

--- a/packages/composer-common/lib/serializer/instancegenerator.js
+++ b/packages/composer-common/lib/serializer/instancegenerator.js
@@ -189,6 +189,7 @@ class InstanceGenerator {
 
     /**
      * Generate a random ID for a given type.
+     * @private
      * @param {ClassDeclaration} classDeclaration - class declaration for a type.
      * @return {String} an ID.
      */

--- a/packages/composer-common/lib/serializer/instancegenerator.js
+++ b/packages/composer-common/lib/serializer/instancegenerator.js
@@ -123,13 +123,10 @@ class InstanceGenerator {
             return parameters.valueGenerator.getEnum(enumValues).getName();
         }
 
-        if (classDeclaration.isAbstract()) {
-            classDeclaration = this.findConcreteSubclass(classDeclaration);
-            type = classDeclaration.getName();
-        }
+        classDeclaration = this.findConcreteSubclass(classDeclaration);
 
         if (classDeclaration.isConcept()) {
-            let concept = parameters.factory.newConcept(classDeclaration.getModelFile().getNamespace(), classDeclaration.getName());
+            let concept = parameters.factory.newConcept(classDeclaration.getNamespace(), classDeclaration.getName());
             parameters.stack.push(concept);
             return classDeclaration.accept(this, parameters);
         } else {
@@ -137,19 +134,20 @@ class InstanceGenerator {
             let idx = Math.round(Math.random() * 9999).toString();
             idx = leftPad(idx, 4, '0');
             let id = `${identifierFieldName}:${idx}`;
-            let resource = parameters.factory.newResource(classDeclaration.getModelFile().getNamespace(), classDeclaration.getName(), id);
+            let resource = parameters.factory.newResource(classDeclaration.getNamespace(), classDeclaration.getName(), id);
             parameters.stack.push(resource);
             return classDeclaration.accept(this, parameters);
         }
     }
 
     /**
-     * Find a type that extends the provided abstract type and return it.
+     * Find a concrete type that extends the provided type. If the supplied type argument is
+     * not abstract then it will be returned.
      * TODO: work out whether this has to be a leaf node or whether the closest type can be used
      * It depends really since the closest type will satisfy the model but whether it satisfies
      * any transaction code which attempts to use the generated resource is another matter.
      * @param {ClassDeclaration} declaration the class declaration.
-     * @return {ClassDeclaration} the closest extending concrete class definition - null if none are found.
+     * @return {ClassDeclaration} the closest extending concrete class definition.
      * @throws {Error} if no concrete subclasses exist.
      */
     findConcreteSubclass(declaration) {
@@ -178,14 +176,15 @@ class InstanceGenerator {
      * @private
      */
     visitRelationshipDeclaration(relationshipDeclaration, parameters) {
-        const classDeclaration = parameters.modelManager.getType(relationshipDeclaration.getFullyQualifiedTypeName());
+        let classDeclaration = parameters.modelManager.getType(relationshipDeclaration.getFullyQualifiedTypeName());
+        classDeclaration = this.findConcreteSubclass(classDeclaration);
         const identifierFieldName = classDeclaration.getIdentifierFieldName();
         const factory = parameters.factory;
         const valueSupplier = () => {
             let idx = Math.round(Math.random() * 9999).toString();
             idx = leftPad(idx, 4, '0');
             const id = `${identifierFieldName}:${idx}`;
-            return factory.newRelationship(classDeclaration.getModelFile().getNamespace(), classDeclaration.getName(), id);
+            return factory.newRelationship(classDeclaration.getNamespace(), classDeclaration.getName(), id);
         };
         if (relationshipDeclaration.isArray()) {
             return parameters.valueGenerator.getArray(valueSupplier);

--- a/packages/composer-common/lib/serializer/instancegenerator.js
+++ b/packages/composer-common/lib/serializer/instancegenerator.js
@@ -130,10 +130,7 @@ class InstanceGenerator {
             parameters.stack.push(concept);
             return classDeclaration.accept(this, parameters);
         } else {
-            let identifierFieldName = classDeclaration.getIdentifierFieldName();
-            let idx = Math.round(Math.random() * 9999).toString();
-            idx = leftPad(idx, 4, '0');
-            let id = `${identifierFieldName}:${idx}`;
+            const id = this.generateRandomId(classDeclaration);
             let resource = parameters.factory.newResource(classDeclaration.getNamespace(), classDeclaration.getName(), id);
             parameters.stack.push(resource);
             return classDeclaration.accept(this, parameters);
@@ -171,19 +168,16 @@ class InstanceGenerator {
     /**
      * Visitor design pattern
      * @param {RelationshipDeclaration} relationshipDeclaration - the object being visited
-     * @param {Object} parameters  - the parameter
-     * @return {Object} the result of visiting or null
+     * @param {Object} parameters - the parameter
+     * @return {Relationship} the result of visiting
      * @private
      */
     visitRelationshipDeclaration(relationshipDeclaration, parameters) {
         let classDeclaration = parameters.modelManager.getType(relationshipDeclaration.getFullyQualifiedTypeName());
         classDeclaration = this.findConcreteSubclass(classDeclaration);
-        const identifierFieldName = classDeclaration.getIdentifierFieldName();
         const factory = parameters.factory;
         const valueSupplier = () => {
-            let idx = Math.round(Math.random() * 9999).toString();
-            idx = leftPad(idx, 4, '0');
-            const id = `${identifierFieldName}:${idx}`;
+            const id = this.generateRandomId(classDeclaration);
             return factory.newRelationship(classDeclaration.getNamespace(), classDeclaration.getName(), id);
         };
         if (relationshipDeclaration.isArray()) {
@@ -191,6 +185,18 @@ class InstanceGenerator {
         } else {
             return valueSupplier();
         }
+    }
+
+    /**
+     * Generate a random ID for a given type.
+     * @param {ClassDeclaration} classDeclaration - class declaration for a type.
+     * @return {String} an ID.
+     */
+    generateRandomId(classDeclaration) {
+        const prefix = classDeclaration.getIdentifierFieldName();
+        let index = Math.round(Math.random() * 9999).toString();
+        index = leftPad(index, 4, '0');
+        return `${prefix}:${index}`;
     }
 
 }

--- a/packages/composer-common/lib/serializer/jsonpopulator.js
+++ b/packages/composer-common/lib/serializer/jsonpopulator.js
@@ -139,12 +139,12 @@ class JSONPopulator {
 
             // if this is identifiable, then we create a resource
             if(!classDeclaration.isConcept()) {
-                subResource = parameters.factory.newResource(classDeclaration.getModelFile().getNamespace(),
+                subResource = parameters.factory.newResource(classDeclaration.getNamespace(),
               classDeclaration.getName(), jsonItem[classDeclaration.getIdentifierFieldName()] );
             }
             else {
               // otherwise we create a concept
-                subResource = parameters.factory.newConcept(classDeclaration.getModelFile().getNamespace(),
+                subResource = parameters.factory.newConcept(classDeclaration.getNamespace(),
                             classDeclaration.getName() );
             }
 
@@ -232,7 +232,7 @@ class JSONPopulator {
                     const classDeclaration = parameters.modelManager.getType(jsonItem.$class);
 
                     // create a new instance, using the identifier field name as the ID.
-                    let subResource = parameters.factory.newResource(classDeclaration.getModelFile().getNamespace(),
+                    let subResource = parameters.factory.newResource(classDeclaration.getNamespace(),
                         classDeclaration.getName(), jsonItem[classDeclaration.getIdentifierFieldName()] );
                     parameters.jsonStack.push(jsonItem);
                     parameters.resourceStack.push(subResource);
@@ -257,7 +257,7 @@ class JSONPopulator {
                 const classDeclaration = parameters.modelManager.getType(jsonObj.$class);
 
                 // create a new instance, using the identifier field name as the ID.
-                let subResource = parameters.factory.newResource(classDeclaration.getModelFile().getNamespace(),
+                let subResource = parameters.factory.newResource(classDeclaration.getNamespace(),
                     classDeclaration.getName(), jsonObj[classDeclaration.getIdentifierFieldName()] );
                 parameters.jsonStack.push(jsonObj);
                 parameters.resourceStack.push(subResource);

--- a/packages/composer-common/lib/serializer/valuegenerator.js
+++ b/packages/composer-common/lib/serializer/valuegenerator.js
@@ -107,6 +107,15 @@ class EmptyValueGenerator {
     getEnum(enumValues) {
         return enumValues[0];
     }
+
+    /**
+     * Get an array using the supplied callback to obtain array values.
+     * @param {Function} valueSupplier - callback to obtain values.
+     * @return {Array} an array
+     */
+    getArray(valueSupplier) {
+        return [ ];
+    }
 }
 
 /**
@@ -169,6 +178,15 @@ class SampleValueGenerator extends EmptyValueGenerator {
      */
     getEnum(enumValues) {
         return enumValues[Math.floor(Math.random() * enumValues.length)];
+    }
+
+    /**
+     * Get an array using the supplied callback to obtain array values.
+     * @param {Function} valueSupplier - callback to obtain values.
+     * @return {Array} an array
+     */
+    getArray(valueSupplier) {
+        return [ valueSupplier() ];
     }
 }
 

--- a/packages/composer-common/test/factory.js
+++ b/packages/composer-common/test/factory.js
@@ -117,6 +117,7 @@ describe('Factory', function() {
         });
 
         const assertEmptyFieldValues = function(resource) {
+            should.not.equal(resource.newValue, undefined);
             resource.newValue.should.be.a('String');
             resource.newValue.length.should.equal(0);
         };
@@ -132,16 +133,17 @@ describe('Factory', function() {
         });
 
         const assertSampleFieldValues = function(resource) {
+            should.not.equal(resource.newValue, undefined);
             resource.newValue.should.be.a('String');
             resource.newValue.length.should.not.equal(0);
         };
 
-        it('should not define optional fields by default with generated empty data', function() {
+        it('should not define optional fields with generated empty data if includeOptionalFields not specified', function() {
             const resource = factory.newResource(namespace, assetName, 'MY_ID_1', { generate: 'empty' });
             assertOptionalNotDefined(resource);
         });
 
-        it('should not define optional fields by default with generated sample data', function() {
+        it('should not define optional fields with generated sample data if includeOptionalFields not specified', function() {
             const resource = factory.newResource(namespace, assetName, 'MY_ID_1', { generate: 'sample' });
             assertOptionalNotDefined(resource);
         });
@@ -150,10 +152,20 @@ describe('Factory', function() {
             should.equal(resource.optionalValue, undefined);
         };
 
-        // const assertOptionalIsDefined = function(resource) {
-        //     resource.optionalValue.should.be.a('String');
-        //     resource.optionalValue.length.should.not.equal(0);
-        // };
+        it ('should define optional fields with generated empty data if includeOptionalFields is specified', function() {
+            const resource = factory.newResource(namespace, assetName, 'MY_ID_1', { generate: 'empty', includeOptionalFields: true });
+            assertOptionalIsDefined(resource);
+        });
+
+        it ('should define optional fields with generated sample data if includeOptionalFields is specified', function() {
+            const resource = factory.newResource(namespace, assetName, 'MY_ID_1', { generate: 'sample', includeOptionalFields: true });
+            assertOptionalIsDefined(resource);
+        });
+
+        const assertOptionalIsDefined = function(resource) {
+            should.not.equal(resource.optionalValue, undefined);
+            resource.optionalValue.should.be.a('String');
+        };
 
     });
 

--- a/packages/composer-common/test/factory.js
+++ b/packages/composer-common/test/factory.js
@@ -22,7 +22,7 @@ const uuid = require('uuid');
 const should = require('chai').should();
 const sinon = require('sinon');
 
-describe('Factory', () => {
+describe('Factory', function() {
     const namespace = 'org.acme.test';
     const assetName = 'MyAsset';
 
@@ -39,6 +39,9 @@ describe('Factory', () => {
         }
         concept MyConcept {
             o String newValue
+        }
+        abstract asset AbstractAsset identified by assetId {
+            o String assetId
         }
         asset MyAsset identified by assetId {
             o String assetId
@@ -63,87 +66,94 @@ describe('Factory', () => {
         sandbox.restore();
     });
 
-    describe('#newResource', () => {
-        it('should throw creating a new instance without an ID', () => {
+    describe('#newResource', function() {
+        it('should throw creating a new instance without an ID', function() {
             (() => {
                 factory.newResource(namespace, assetName, null);
             }).should.throw(/Invalid or missing identifier/);
         });
 
-        it('should throw creating a new instance with an ID that is just whitespace', () => {
+        it('should throw creating a new instance with an ID that is just whitespace', function() {
             (() => {
                 factory.newResource(namespace, assetName, '     ');
             }).should.throw(/Missing identifier/);
         });
 
-        it('should create a new instance with a specified ID', () => {
-            let resource = factory.newResource(namespace, assetName, 'MY_ID_1');
+        it('should throw creating an abstract asset', function() {
+            (() => {
+                factory.newResource(namespace, 'AbstractAsset', 'MY_ID_1');
+            }).should.throw(/AbstractAsset/);
+        });
+
+        it('should throw creating a concept', function() {
+            (() => {
+                factory.newResource(namespace, 'MyConcept', 'MY_ID_1');
+            }).should.throw(/MyConcept/);
+        });
+
+        it('should create a new instance with a specified ID', function() {
+            const resource = factory.newResource(namespace, assetName, 'MY_ID_1');
             resource.assetId.should.equal('MY_ID_1');
-            should.equal(resource.newValue, undefined);
-            should.equal(resource.optionalValue, undefined);
+        });
+
+        it('should create a new validating instance by default', function() {
+            const resource = factory.newResource(namespace, assetName, 'MY_ID_1');
             should.not.equal(resource.validate, undefined);
         });
 
-        it('should create a new non-validating instance with a specified ID', () => {
-            let resource = factory.newResource(namespace, assetName, 'MY_ID_1', { disableValidation: true });
-            resource.assetId.should.equal('MY_ID_1');
-            should.equal(resource.newValue, undefined);
-            should.equal(resource.optionalValue, undefined);
+        it('should create a new non-validating instance', function() {
+            const resource = factory.newResource(namespace, assetName, 'MY_ID_1', { disableValidation: true });
             should.equal(resource.validate, undefined);
         });
 
-        it('should create a new instance with a specified ID and generated empty data', () => {
-            let resource = factory.newResource(namespace, assetName, 'MY_ID_1', { generate: 'empty' });
-            resource.assetId.should.equal('MY_ID_1');
+        it('should not define fields if \'generate\' option is not set', function() {
+            const resource = factory.newResource(namespace, assetName, 'MY_ID_1');
+            should.equal(resource.newValue, undefined);
+        });
+
+        it('should generate empty field values', function() {
+            const resource = factory.newResource(namespace, assetName, 'MY_ID_1', { generate: 'empty' });
+            assertEmptyFieldValues(resource);
+        });
+
+        const assertEmptyFieldValues = function(resource) {
             resource.newValue.should.be.a('String');
             resource.newValue.length.should.equal(0);
-            should.equal(resource.optionalValue, undefined);
-            should.not.equal(resource.validate, undefined);
-        });
-
-        const validateSampleData = (resource) => {
-            resource.assetId.should.equal('MY_ID_1');
-            resource.newValue.should.be.a('String');
-            resource.newValue.length.should.not.equal(0);
-            resource.optionalValue.should.be.a('String');
-            resource.optionalValue.length.should.not.equal(0);
-            should.not.equal(resource.validate, undefined);
         };
 
-        it('should create a new instance with a specified ID and generated sample data', () => {
+        it('should generate sample field values', function() {
             const resource = factory.newResource(namespace, assetName, 'MY_ID_1', { generate: 'sample' });
-            validateSampleData(resource);
+            assertSampleFieldValues(resource);
         });
 
-        it('should generate sample data if \'generate\' option is a boolean', () => {
+        it('should generate sample field values if \'generate\' option is a boolean', function() {
             const resource = factory.newResource(namespace, assetName, 'MY_ID_1', { generate: true });
-            validateSampleData(resource);
+            assertSampleFieldValues(resource);
         });
 
-    });
+        const assertSampleFieldValues = function(resource) {
+            resource.newValue.should.be.a('String');
+            resource.newValue.length.should.not.equal(0);
+        };
 
-    describe('#newResource', () => {
-
-        it('should create a new instance with a specified ID', () => {
-            let resource = factory.newResource(namespace, assetName, 'MY_ID_1');
-            resource.assetId.should.equal('MY_ID_1');
-            should.equal(resource.newValue, undefined);
-            should.not.equal(resource.validate, undefined);
+        it('should not define optional fields by default with generated empty data', function() {
+            const resource = factory.newResource(namespace, assetName, 'MY_ID_1', { generate: 'empty' });
+            assertOptionalNotDefined(resource);
         });
 
-        it('should create a new non-validating instance with a specified ID', () => {
-            let resource = factory.newResource(namespace, assetName, 'MY_ID_1', { disableValidation: true });
-            resource.assetId.should.equal('MY_ID_1');
-            should.equal(resource.newValue, undefined);
-            should.equal(resource.validate, undefined);
+        it('should not define optional fields by default with generated sample data', function() {
+            const resource = factory.newResource(namespace, assetName, 'MY_ID_1', { generate: 'sample' });
+            assertOptionalNotDefined(resource);
         });
 
-        it('should create a new instance with a specified ID and generated data', () => {
-            let resource = factory.newResource(namespace, assetName, 'MY_ID_1', { generate: true });
-            resource.assetId.should.equal('MY_ID_1');
-            resource.newValue.should.be.a('string');
-            should.not.equal(resource.validate, undefined);
-        });
+        const assertOptionalNotDefined = function(resource) {
+            should.equal(resource.optionalValue, undefined);
+        };
+
+        // const assertOptionalIsDefined = function(resource) {
+        //     resource.optionalValue.should.be.a('String');
+        //     resource.optionalValue.length.should.not.equal(0);
+        // };
 
     });
 
@@ -165,6 +175,12 @@ describe('Factory', () => {
             (() => {
                 factory.newConcept(namespace, 'AbstractConcept');
             }).should.throw(/Cannot instantiate Abstract Type AbstractConcept in namespace org.acme.test/);
+        });
+
+        it('should throw creating a non-concept', function() {
+            (() => {
+                factory.newConcept(namespace, assetName);
+            }).should.throw(new RegExp(assetName));
         });
 
         it('should create a new concept', () => {

--- a/packages/composer-common/test/serializer/instancegenerator.js
+++ b/packages/composer-common/test/serializer/instancegenerator.js
@@ -18,30 +18,38 @@ const Factory = require('../../lib/factory');
 const InstanceGenerator = require('../../lib/serializer/instancegenerator');
 const ModelManager = require('../../lib/modelmanager');
 const TypedStack = require('../../lib/serializer/typedstack');
+const ValueGenerator = require('../../lib/serializer/valuegenerator');
 
 const chai = require('chai');
 const should = chai.should();
 
 describe('InstanceGenerator', () => {
-
     let factory;
     let modelManager;
     let parameters;
     let visitor;
+
+    const useEmptyGenerator = () => {
+        parameters.valueGenerator = ValueGenerator.empty();
+    };
+
+    const useSampleGenerator = () => {
+        parameters.valueGenerator = ValueGenerator.sample();
+    };
 
     beforeEach(() => {
         modelManager = new ModelManager();
         factory = new Factory(modelManager);
         parameters = {
             modelManager: modelManager,
-            factory: factory
+            factory: factory,
         };
+        useSampleGenerator();
         visitor = new InstanceGenerator();
     });
 
-    let test = (modelFile, additionalParams) => {
+    const test = (modelFile) => {
         modelManager.addModelFile(modelFile);
-        Object.assign(parameters, additionalParams);
         let resource = factory.newResource('org.acme.test', 'MyAsset', 'asset1');
         parameters.stack = new TypedStack(resource);
         let classDeclaration = resource.getClassDeclaration();
@@ -65,16 +73,25 @@ describe('InstanceGenerator', () => {
             resource.theValue.should.be.a('string');
         });
 
-        it('should generate a default value for a string array property', () => {
+        it('should generate empty array value for array property with empty generator ', () => {
+            useEmptyGenerator();
             let resource = test(`namespace org.acme.test
             asset MyAsset identified by assetId {
                 o String assetId
                 o String[] theValues
             }`);
-            resource.theValues.should.have.lengthOf(3);
-            resource.theValues[0].should.be.a('string');
-            resource.theValues[1].should.be.a('string');
-            resource.theValues[2].should.be.a('string');
+            resource.theValues.should.be.a('Array').that.is.empty;
+        });
+
+        it('should generate one default value for a string array property with sample generator ', () => {
+            useSampleGenerator();
+            let resource = test(`namespace org.acme.test
+            asset MyAsset identified by assetId {
+                o String assetId
+                o String[] theValues
+            }`);
+            resource.theValues.should.be.a('Array').and.have.lengthOf(1);
+            resource.theValues[0].should.be.a('String');
         });
 
         it('should generate a default value for a date/time property', () => {
@@ -86,16 +103,14 @@ describe('InstanceGenerator', () => {
             resource.theValue.should.be.an.instanceOf(Date);
         });
 
-        it('should generate a default value for a date/time array property', () => {
+        it('should generate one default value for a date/time array property', () => {
             let resource = test(`namespace org.acme.test
             asset MyAsset identified by assetId {
                 o String assetId
                 o DateTime[] theValues
             }`);
-            resource.theValues.should.have.lengthOf(3);
-            resource.theValues[0].should.be.an.instanceOf(Date);
-            resource.theValues[1].should.be.an.instanceOf(Date);
-            resource.theValues[2].should.be.an.instanceOf(Date);
+            resource.theValues.should.be.a('Array').and.have.lengthOf(1);
+            resource.theValues[0].should.be.a('Date');
         });
 
         it('should generate a default value for an integer property', () => {
@@ -113,10 +128,8 @@ describe('InstanceGenerator', () => {
                 o String assetId
                 o Integer[] theValues
             }`);
-            resource.theValues.should.have.lengthOf(3);
-            resource.theValues[0].should.be.a('number');
-            resource.theValues[1].should.be.a('number');
-            resource.theValues[2].should.be.a('number');
+            resource.theValues.should.be.a('Array').and.have.lengthOf(1);
+            resource.theValues[0].should.be.a('Number');
         });
 
         it('should generate a default value for a long property', () => {
@@ -134,10 +147,8 @@ describe('InstanceGenerator', () => {
                 o String assetId
                 o Long[] theValues
             }`);
-            resource.theValues.should.have.lengthOf(3);
-            resource.theValues[0].should.be.a('number');
-            resource.theValues[1].should.be.a('number');
-            resource.theValues[2].should.be.a('number');
+            resource.theValues.should.be.a('Array').and.have.lengthOf(1);
+            resource.theValues[0].should.be.a('Number');
         });
 
         it('should generate a default value for a double property', () => {
@@ -155,10 +166,8 @@ describe('InstanceGenerator', () => {
                 o String assetId
                 o Double[] theValues
             }`);
-            resource.theValues.should.have.lengthOf(3);
-            resource.theValues[0].should.be.a('number');
-            resource.theValues[1].should.be.a('number');
-            resource.theValues[2].should.be.a('number');
+            resource.theValues.should.be.a('Array').and.have.lengthOf(1);
+            resource.theValues[0].should.be.a('Number');
         });
 
         it('should generate a default value for a boolean property', () => {
@@ -176,10 +185,8 @@ describe('InstanceGenerator', () => {
                 o String assetId
                 o Boolean[] theValues
             }`);
-            resource.theValues.should.have.lengthOf(3);
-            resource.theValues[0].should.be.a('boolean');
-            resource.theValues[1].should.be.a('boolean');
-            resource.theValues[2].should.be.a('boolean');
+            resource.theValues.should.be.a('Array').and.have.lengthOf(1);
+            resource.theValues[0].should.be.a('Boolean');
         });
 
         it('should generate a default value for an enum property', () => {
@@ -207,10 +214,8 @@ describe('InstanceGenerator', () => {
                 o String assetId
                 o MyEnum[] theValues
             }`);
-            resource.theValues.should.have.lengthOf(3);
+            resource.theValues.should.be.a('Array').and.have.lengthOf(1);
             resource.theValues[0].should.be.oneOf(['ENUM_VAL1', 'ENUM_VAL2', 'ENUM_VAL3']);
-            resource.theValues[1].should.be.oneOf(['ENUM_VAL1', 'ENUM_VAL2', 'ENUM_VAL3']);
-            resource.theValues[2].should.be.oneOf(['ENUM_VAL1', 'ENUM_VAL2', 'ENUM_VAL3']);
         });
 
         it('should generate a default value for a relationship property', () => {
@@ -228,10 +233,8 @@ describe('InstanceGenerator', () => {
                 o String assetId
                 --> MyAsset[] theValues
             }`);
-            resource.theValues.should.have.lengthOf(3);
+            resource.theValues.should.be.a('Array').and.have.lengthOf(1);
             resource.theValues[0].getIdentifier().should.match(/^assetId:\d{4}$/);
-            resource.theValues[1].getIdentifier().should.match(/^assetId:\d{4}$/);
-            resource.theValues[2].getIdentifier().should.match(/^assetId:\d{4}$/);
         });
 
         it('should generate a default value for a resource property', () => {
@@ -258,13 +261,9 @@ describe('InstanceGenerator', () => {
                 o String assetId
                 o MyInnerAsset[] theValues
             }`);
-            resource.theValues.should.have.lengthOf(3);
+            resource.theValues.should.be.a('Array').and.have.lengthOf(1);
             resource.theValues[0].getIdentifier().should.match(/^innerAssetId:\d{4}$/);
             resource.theValues[0].theValue.should.be.a('string');
-            resource.theValues[1].getIdentifier().should.match(/^innerAssetId:\d{4}$/);
-            resource.theValues[1].theValue.should.be.a('string');
-            resource.theValues[2].getIdentifier().should.match(/^innerAssetId:\d{4}$/);
-            resource.theValues[2].theValue.should.be.a('string');
         });
 
         it('should generate a default value for base class properties', () => {
@@ -309,20 +308,22 @@ describe('InstanceGenerator', () => {
         });
 
         it('should not generate default value for optional property if not requested', () => {
-            let resource = test(`namespace org.acme.test
+            parameters.includeOptionalFields = false;
+            const resource = test(`namespace org.acme.test
             asset MyAsset identified by assetId {
                 o String assetId
                 o String theValue optional
-            }`, { includeOptionalFields: false });
+            }`);
             should.equal(resource.theValue, undefined);
         });
 
         it('should generate default value for optional property if requested', () => {
-            let resource = test(`namespace org.acme.test
+            parameters.includeOptionalFields = true;
+            const resource = test(`namespace org.acme.test
             asset MyAsset identified by assetId {
                 o String assetId
                 o String theValue optional
-            }`, { includeOptionalFields: true });
+            }`);
             resource.theValue.should.be.a('String');
         });
 

--- a/packages/composer-common/test/serializer/instancegenerator.js
+++ b/packages/composer-common/test/serializer/instancegenerator.js
@@ -289,7 +289,7 @@ describe('InstanceGenerator', () => {
                 o String id
                 o BaseConcept aConcept
             }`);
-            resource.aConcept.$type.should.match(/^MyConcept$/);
+            resource.aConcept.getType().should.equal('MyConcept');
         });
 
         it('should throw an error when trying to generate a resource from a model that uses an Abstract type with no concrete Implementing type', () => {
@@ -325,6 +325,15 @@ describe('InstanceGenerator', () => {
                 o String theValue optional
             }`);
             resource.theValue.should.be.a('String');
+        });
+
+        it('should generate concrete subclass for abstract reference', function() {
+            let resource = test(`namespace org.acme.test
+            asset MyAsset identified by id {
+                o String id
+                --> Asset theValue
+            }`);
+            resource.theValue.getType().should.equal('MyAsset');
         });
 
     });

--- a/packages/composer-common/test/serializer/valuegenerator.js
+++ b/packages/composer-common/test/serializer/valuegenerator.js
@@ -19,66 +19,79 @@ const ValueGeneratorFactory = require('../../lib/serializer/valuegenerator');
 const chai = require('chai');
 const expect = chai.expect;
 
-describe('ValueGenerator', () => {
+describe('ValueGenerator', function() {
 
-    /** Array of names of the static factory methods for obtaining ValueGenerator objects. */
-    let generatorNames;
-
-    /**
-     * Check that invoking the supplied function name on all of the ValueGenerator implementations returns the expected type.
-     * @param {string} functionName name of the function to invoke.
-     * @param {string} type expected return type.
-     */
-    let assertFunctionReturnsType = (functionName, type) => {
-        generatorNames.forEach((generatorName) => {
-            const generator = ValueGeneratorFactory[generatorName]();
-            const returnValue = generator[functionName]();
-            expect(returnValue, generatorName + '.' + functionName + '() should return a ' + type)
-                .to.be.a(type);
-        });
-    };
-
-    before(() => {
-        generatorNames = Object.getOwnPropertyNames(ValueGeneratorFactory)
+    describe('Consistent return types', function() {
+        /** Array of names of the static factory methods for obtaining ValueGenerator objects. */
+        const generatorNames = Object.getOwnPropertyNames(ValueGeneratorFactory)
             .filter((p) => {
                 return typeof ValueGeneratorFactory[p] === 'function';
             });
+
+        /**
+         * Check that invoking the supplied function name on all of the ValueGenerator implementations returns the expected type.
+         * @param {string} functionName name of the function to invoke.
+         * @param {string} type expected return type.
+         */
+        const assertFunctionReturnsType = (functionName, type) => {
+            generatorNames.forEach((generatorName) => {
+                const generator = ValueGeneratorFactory[generatorName]();
+                const returnValue = generator[functionName]();
+                expect(returnValue, generatorName + '.' + functionName + '() should return a ' + type)
+                    .to.be.a(type);
+            });
+        };
+
+        it('getDateTime should return a Date', function() {
+            assertFunctionReturnsType('getDateTime', 'Date');
+        });
+
+        it('getInteger should return a number', function() {
+            assertFunctionReturnsType('getInteger', 'number');
+        });
+
+        it('getLong should return a number', function() {
+            assertFunctionReturnsType('getLong', 'number');
+        });
+
+        it('getDouble should return a number', function() {
+            assertFunctionReturnsType('getDouble', 'number');
+        });
+
+        it('getBoolean should return a boolean', function() {
+            assertFunctionReturnsType('getBoolean', 'boolean');
+        });
+
+        it('getString should return a string', function() {
+            assertFunctionReturnsType('getString', 'string');
+        });
     });
 
-    it('getDateTime should return a Date', () => {
-        assertFunctionReturnsType('getDateTime', 'Date');
+    describe('EmptyValueGenerator', function() {
+        it('getEnum should return the first value', function() {
+            const inputs = ['One', 'Two', 'Three'];
+            const output = ValueGeneratorFactory.empty().getEnum(inputs);
+            expect(output).to.equal(inputs[0]);
+        });
+
+        it('getArray should return empty array', function() {
+            const output = ValueGeneratorFactory.empty().getArray(() => '');
+            expect(output).to.be.a('Array').that.is.empty;
+        });
     });
 
-    it('getInteger should return a number', () => {
-        assertFunctionReturnsType('getInteger', 'number');
-    });
+    describe('SampleValueGenerator', function() {
+        it('getEnum should return one of the input values', function() {
+            const inputs = ['One', 'Two', 'Three'];
+            const output = ValueGeneratorFactory.sample().getEnum(inputs);
+            expect(inputs).to.include(output);
+        });
 
-    it('getLong should return a number', () => {
-        assertFunctionReturnsType('getLong', 'number');
-    });
-
-    it('getDouble should return a number', () => {
-        assertFunctionReturnsType('getDouble', 'number');
-    });
-
-    it('getBoolean should return a boolean', () => {
-        assertFunctionReturnsType('getBoolean', 'boolean');
-    });
-
-    it('getString should return a string', () => {
-        assertFunctionReturnsType('getString', 'string');
-    });
-
-    it('EmptyValueGenerator.getEnum should return the first value', () => {
-        const inputs = ['One', 'Two', 'Three'];
-        const output = ValueGeneratorFactory.empty().getEnum(inputs);
-        expect(output).to.equal(inputs[0]);
-    });
-
-    it('SampleValueGenerator.getEnum should return one of the input values', () => {
-        const inputs = ['One', 'Two', 'Three'];
-        const output = ValueGeneratorFactory.sample().getEnum(inputs);
-        expect(inputs).to.include(output);
+        it('getArray should return array with one element obtained from callback', function() {
+            const value = 'TEST_VALUE';
+            const output = ValueGeneratorFactory.sample().getArray(() => value);
+            expect(output).to.be.a('Array').and.deep.equal([value]);
+        });
     });
 
 });

--- a/packages/composer-playground/src/app/test/resource/resource.component.html
+++ b/packages/composer-playground/src/app/test/resource/resource.component.html
@@ -18,6 +18,12 @@
                             (ngModelChange)="onDefinitionChanged()"
                             width="100%" height="100%" ngDefaultControl>
                 </codemirror>
+                <div>
+                    <label>Optional Properties
+                        <input type="checkbox" name="include-optional" value="true"
+                            [(ngModel)]="includeOptionalFields" (change)="generateResource(false)">
+                    </label>
+                </div>
                 <div class="resource-error-text" ng-if="definitionError!=null">
                     <p>{{definitionError}}</p>
                 </div>

--- a/packages/composer-playground/src/app/test/resource/resource.component.ts
+++ b/packages/composer-playground/src/app/test/resource/resource.component.ts
@@ -37,6 +37,7 @@ export class ResourceComponent implements OnInit {
     private resourceDeclaration: ClassDeclaration = null;
     private actionInProgress: boolean = false;
     private definitionError: string = null;
+    private includeOptionalFields: boolean = false;
 
     private codeConfig = {
         lineNumbers: true,
@@ -118,7 +119,10 @@ export class ResourceComponent implements OnInit {
         idx = leftPad(idx, 4, '0');
         let id = `${this.resourceDeclaration.getIdentifierFieldName()}:${idx}`;
         try {
-            const generateParameters = {generate: withSampleData ? 'sample' : 'empty'};
+            const generateParameters = {
+                generate: withSampleData ? 'sample' : 'empty',
+                includeOptionalFields: this.includeOptionalFields
+            };
             let resource = factory.newResource(
                 this.resourceDeclaration.getModelFile().getNamespace(),
                 this.resourceDeclaration.getName(),

--- a/packages/composer-playground/src/app/test/transaction/transaction.component.html
+++ b/packages/composer-playground/src/app/test/transaction/transaction.component.html
@@ -33,6 +33,12 @@
                             (ngModelChange)="onDefinitionChanged()"
                             width="100%" height="100%" ngDefaultControl>
                 </codemirror>
+                <div>
+                    <label>Optional Properties
+                        <input type="checkbox" name="include-optional" value="true"
+                            [(ngModel)]="includeOptionalFields" (change)="generateTransactionDeclaration(false)">
+                    </label>
+                </div>
                 <div class="resource-error-text" ng-if="definitionError!=null">
                     <p>{{definitionError}}</p>
                 </div>

--- a/packages/composer-playground/src/app/test/transaction/transaction.component.ts
+++ b/packages/composer-playground/src/app/test/transaction/transaction.component.ts
@@ -30,6 +30,7 @@ export class TransactionComponent implements OnInit {
     private selectedTransactionName: string = null;
     private hiddenTransactionItems = new Map();
     private submittedTransaction = null;
+    private includeOptionalFields: boolean = false;
 
     private resourceDefinition: string = null;
     private submitInProgress: boolean = false;
@@ -121,7 +122,10 @@ export class TransactionComponent implements OnInit {
     private generateTransactionDeclaration(withSampleData?: boolean): void {
         let businessNetworkDefinition = this.clientService.getBusinessNetwork();
         let factory = businessNetworkDefinition.getFactory();
-        const generateParameters = {generate: withSampleData ? 'sample' : 'empty'};
+        const generateParameters = {
+            generate: withSampleData ? 'sample' : 'empty',
+            includeOptionalFields: this.includeOptionalFields
+        };
         let resource = factory.newTransaction(
             this.selectedTransaction.getModelFile().getNamespace(),
             this.selectedTransaction.getName(),

--- a/packages/generator-hyperledger-composer/generators/angular/index.js
+++ b/packages/generator-hyperledger-composer/generators/angular/index.js
@@ -445,7 +445,7 @@ module.exports = yeoman.Base.extend({
 
                         assetList.push({
                             'name': asset.name,
-                            'namespace': asset.getModelFile().getNamespace(),
+                            'namespace': asset.getNamespace(),
                             'properties': tempList,
                             'identifier': asset.getIdentifierFieldName()
                         });


### PR DESCRIPTION
Change composer-common/Factory API so that:
- An _includeOptionalFields_ option controls whether optional fields are included in generated data.
- Array field values are generated with a single element (rather than three) for _sample_ data generation, and with no values for _empty_ data generation.

Add _Optional Properties_ checkbox to create new resource and submit transaction dialogs.