### PR TITLE
Prevent non JS files from being imported from GitHub

### DIFF
--- a/packages/composer-playground/src/app/services/samplebusinessnetwork.service.spec.ts
+++ b/packages/composer-playground/src/app/services/samplebusinessnetwork.service.spec.ts
@@ -580,11 +580,11 @@ describe('SampleBusinessNetworkService', () => {
         it('should get all the scripts', fakeAsync(inject([SampleBusinessNetworkService], (service: SampleBusinessNetworkService) => {
 
             let octoScriptMock = {
-                items: [{path: 'scriptOne'}]
+                items: [{path: 'scriptOne.js'}]
             };
 
             let octoScriptFileMock = {
-                name: 'scriptOne',
+                name: 'scriptOne.js',
                 content: 'YSBzY3JpcHQ='
             };
 
@@ -596,7 +596,7 @@ describe('SampleBusinessNetworkService', () => {
                 fetch: sinon.stub().returns(Promise.resolve(octoScriptMock))
             });
 
-            repoMock.contents.withArgs('scriptOne').returns({
+            repoMock.contents.withArgs('scriptOne.js').returns({
                 fetch: sinon.stub().returns(Promise.resolve(octoScriptFileMock))
             });
 
@@ -608,7 +608,44 @@ describe('SampleBusinessNetworkService', () => {
             service.getScripts('myOwner', 'myRepository', 'packages/')
                 .then((result) => {
                     result.length.should.equal(1);
-                    result[0].should.deep.equal({name: 'scriptOne', data: 'a script'});
+                    result[0].should.deep.equal({name: 'scriptOne.js', data: 'a script'});
+                });
+
+            tick();
+        })));
+
+        it('should filter out non js files', fakeAsync(inject([SampleBusinessNetworkService], (service: SampleBusinessNetworkService) => {
+
+            let octoScriptMock = {
+                items: [{path: 'scriptOne.js'}, {path: '.eslintrc.yml'}]
+            };
+
+            let octoScriptFileMock = {
+                name: 'scriptOne.js',
+                content: 'YSBzY3JpcHQ='
+            };
+
+            let repoMock = {
+                contents: sinon.stub()
+            };
+
+            repoMock.contents.withArgs('packages/lib').returns({
+                fetch: sinon.stub().returns(Promise.resolve(octoScriptMock))
+            });
+
+            repoMock.contents.withArgs('scriptOne.js').returns({
+                fetch: sinon.stub().returns(Promise.resolve(octoScriptFileMock))
+            });
+
+            let octoMock = {
+                repos: sinon.stub().returns(repoMock)
+            };
+
+            service['octo'] = octoMock;
+            service.getScripts('myOwner', 'myRepository', 'packages/')
+                .then((result) => {
+                    result.length.should.equal(1);
+                    result[0].should.deep.equal({name: 'scriptOne.js', data: 'a script'});
                 });
 
             tick();

--- a/packages/composer-playground/src/app/services/samplebusinessnetwork.service.ts
+++ b/packages/composer-playground/src/app/services/samplebusinessnetwork.service.ts
@@ -233,12 +233,13 @@ export class SampleBusinessNetworkService {
         }
 
         let repo = this.octo.repos(owner, repository);
-
         return repo.contents(path + 'lib').fetch()
             .then((scripts) => {
-                let scriptFilePromises: Promise<any>[] = [];
+                let scriptFilePromises: Promise < any > [] = [];
                 scripts.items.forEach((script) => {
-                    scriptFilePromises.push(repo.contents(script.path).fetch());
+                    if (script.path.endsWith('.js')) {
+                        scriptFilePromises.push(repo.contents(script.path).fetch());
+                    }
                 });
                 return Promise.all(scriptFilePromises);
             })

--- a/packages/composer-playground/src/app/services/samplebusinessnetwork.service.ts
+++ b/packages/composer-playground/src/app/services/samplebusinessnetwork.service.ts
@@ -345,7 +345,7 @@ export class SampleBusinessNetworkService {
 
                 let scriptManager = businessNetworkDefinition.getScriptManager();
                 scripts.forEach((script) => {
-                    if(script.name.endsWith('.js')) {
+                    if (script.name.endsWith('.js')) {
                         let thisScript = scriptManager.createScript(script.name, 'JS', script.data);
                         scriptManager.addScript(thisScript);
                     }


### PR DESCRIPTION
Excluded non .js files from being imported from GitHub. This is currently preventing the trade-network sample from being imported, because it contains an eslint yml file under scripts.