### PR TITLE
filter system models from results when updating playground BNDs

### DIFF
--- a/packages/composer-playground/src/app/services/client.service.spec.ts
+++ b/packages/composer-playground/src/app/services/client.service.spec.ts
@@ -933,4 +933,84 @@ describe('ClientService', () => {
             businessNetworkConnectionMock.should.have.been.called;
         })));
     });
+
+    describe('createNewBusinessNetwork', () => {
+        it('should alert on failure', inject([ClientService], (service: ClientService) => {
+            // Set up mocks
+            let mockCreateBusinessNetwork = sinon.stub(service, 'createBusinessNetwork').throws('forced error');
+            let businessNetworkChangedSpy = sinon.spy(service.businessNetworkChanged$, 'next');
+            sinon.stub(service, 'getBusinessNetwork').returns(businessNetworkDefMock);
+
+            // Call function
+            service.createNewBusinessNetwork(null, null, null, null, null);
+
+            // Check expected
+            alertMock.busyStatus$.next.should.have.been.calledWith(null);
+            alertMock.errorStatus$.next.should.have.been.called;
+        }));
+
+        it('should not update the business network on failure', inject([ClientService], (service: ClientService) => {
+            // Set up mocks
+            let mockCreateBusinessNetwork = sinon.stub(service, 'createBusinessNetwork').throws('forced error');
+            let businessNetworkChangedSpy = sinon.spy(service.businessNetworkChanged$, 'next');
+            sinon.stub(service, 'getBusinessNetwork').returns(businessNetworkDefMock);
+
+            // Call function
+            service.createNewBusinessNetwork(null, null, null, null, null);
+
+            // Check expected
+            businessNetworkChangedSpy.should.not.have.been.called;
+        }));
+
+        it('should create a new business network and notify on success', inject([ClientService], (service: ClientService) => {
+            let businessNetworkChangedSpy = sinon.spy(service.businessNetworkChanged$, 'next');
+            let filterSpy = sinon.spy(service, 'filterModelFiles');
+
+            let mockFile0 = sinon.createStubInstance(ModelFile);
+            mockFile0.isSystemModelFile.returns(false);
+            let mockFile1 = sinon.createStubInstance(ModelFile);
+            mockFile1.isSystemModelFile.returns(false);
+            let mockFile2 = sinon.createStubInstance(ModelFile);
+            mockFile2.isSystemModelFile.returns(false);
+            let mockFile3 = sinon.createStubInstance(ModelFile);
+            mockFile3.isSystemModelFile.returns(false);
+            let mockFile4 = sinon.createStubInstance(ModelFile);
+            mockFile4.isSystemModelFile.returns(true);
+
+            let modelManagerMock = {
+                getModelFiles: sinon.stub().returns([mockFile0, mockFile1, mockFile2, mockFile3, mockFile4]),
+                addModelFiles: sinon.stub()
+            };
+
+            let aclManagerMock = {
+                setAclFile: sinon.stub(),
+                getAclFile: sinon.stub().returns(aclFileMock)
+            };
+
+            let scriptManagerMock = {
+                getScripts: sinon.stub().returns([scriptFileMock, scriptFileMock]),
+                addScript: sinon.stub()
+            };
+
+            businessNetworkDefMock.getModelManager.returns(modelManagerMock);
+            businessNetworkDefMock.getScriptManager.returns(scriptManagerMock);
+            businessNetworkDefMock.getAclManager.returns(aclManagerMock);
+
+            sinon.stub(service, 'getBusinessNetwork').returns(businessNetworkDefMock);
+
+            let mockCreateBusinessNetwork = sinon.stub(service, 'createBusinessNetwork').returns(businessNetworkDefMock);
+
+            // Call function
+            service.createNewBusinessNetwork('myBND', '1.0', 'description', '{}', null);
+
+            // We filter system namespaces
+            filterSpy.should.have.been.calledWith([mockFile0, mockFile1, mockFile2, mockFile3, mockFile4]);
+            let filterReturn = filterSpy.returnValues[0];
+            filterReturn.should.deep.equal([mockFile0, mockFile1, mockFile2, mockFile3]);
+
+            // We alert on success
+            businessNetworkChangedSpy.should.have.been.calledWith(true);
+        }));
+
+    });
 });


### PR DESCRIPTION
Related to #1446 

Turns out that we were trying to reuse the internal system models when creating the business network for replacement.... this was being rejected on the creation stage as they have reserved namespaces.

failure of this is detected in (pending) protractor tests that uncovered the issue.

## Design of the fix
Filter out system models before use. A nice enhancement could (should?) be the enablement of updating information of a bnd via compose-common changes (enabling metadata updates etc).
