### PR TITLE
Playground import from npm fails to work for unstable

### DIFF
--- a/packages/composer-playground-api/package.json
+++ b/packages/composer-playground-api/package.json
@@ -1,92 +1,91 @@
 {
-    "name": "composer-playground-api",
-    "version": "0.9.1",
-    "description": "The REST API for the Hyperledger Composer Playground",
-    "engines": {
-        "node": ">=6",
-        "npm": ">=3"
-    },
-    "bin": {
-        "composer-playground-api": "cli.js"
-    },
-    "main": "index.js",
-    "scripts": {
-        "pretest": "npm run licchk",
-        "licchk": "license-check",
-        "postlicchk": "npm run doc",
-        "doc": "jsdoc --pedantic --recurse -c jsdoc.conf",
-        "postdoc": "npm run lint",
-        "lint": "eslint .",
-        "start": "node cli.js",
-        "test": "nyc mocha --recursive -t 10000"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/hyperledger/composer.git"
-    },
-    "keywords": [
-        "blockchain",
-        "hyperledger",
-        "solutions"
+  "name": "composer-playground-api",
+  "version": "0.9.1",
+  "description": "The REST API for the Hyperledger Composer Playground",
+  "engines": {
+    "node": ">=6",
+    "npm": ">=3"
+  },
+  "bin": {
+    "composer-playground-api": "cli.js"
+  },
+  "main": "index.js",
+  "scripts": {
+    "pretest": "npm run licchk",
+    "licchk": "license-check",
+    "postlicchk": "npm run doc",
+    "doc": "jsdoc --pedantic --recurse -c jsdoc.conf",
+    "postdoc": "npm run lint",
+    "lint": "eslint .",
+    "start": "node cli.js",
+    "test": "nyc mocha --recursive -t 10000"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hyperledger/composer.git"
+  },
+  "keywords": [
+    "blockchain",
+    "hyperledger",
+    "solutions"
+  ],
+  "author": "Hyperledger Composer",
+  "license": "Apache-2.0",
+  "license-check-config": {
+    "src": [
+      "**/*.js",
+      "!./cli.js",
+      "!./coverage/**/*",
+      "!./node_modules/**/*",
+      "!./out/**/*"
     ],
-    "author": "Hyperledger Composer",
-    "license": "Apache-2.0",
-    "license-check-config": {
-        "src": [
-            "**/*.js",
-            "!./cli.js",
-            "!./coverage/**/*",
-            "!./node_modules/**/*",
-            "!./out/**/*"
-        ],
-        "path": "header.txt",
-        "blocking": true,
-        "logInfo": false,
-        "logError": true
-    },
-    "devDependencies": {
-        "chai": "^3.5.0",
-        "chai-http": "^3.0.0",
-        "eslint": "^3.17.1",
-        "jsdoc": "^3.4.3",
-        "license-check": "^1.1.5",
-        "mocha": "^3.2.0",
-        "nyc": "^10.1.2",
-        "proxyquire": "^1.7.11",
-        "sinon": "^1.17.7"
-    },
-    "dependencies": {
-        "async": "^2.5.0",
-        "body-parser": "^1.17.0",
-        "composer-common": "^0.9.1",
-        "composer-connector-server": "^0.9.1",
-        "dotenv": "^4.0.0",
-        "express": "^4.15.2",
-        "http-status": "^1.0.1",
-        "npm-registry-client": "^8.4.0",
-        "pkginfo": "^0.4.0",
-        "request": "^2.81.0",
-        "semver": "^5.3.0",
-        "socket.io": "^1.7.3",
-        "tar": "^3.1.5"
-    },
-    "nyc": {
-        "exclude": [
-            "coverage/**",
-            "out/**",
-            "scripts/**",
-            "systest/**",
-            "test/**"
-        ],
-        "reporter": [
-            "text-summary",
-            "html"
-        ],
-        "all": true,
-        "check-coverage": true,
-        "statements": 44,
-        "branches": 44,
-        "functions": 46,
-        "lines": 44
-    }
+    "path": "header.txt",
+    "blocking": true,
+    "logInfo": false,
+    "logError": true
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "chai-http": "^3.0.0",
+    "eslint": "^3.17.1",
+    "jsdoc": "^3.4.3",
+    "license-check": "^1.1.5",
+    "mocha": "^3.2.0",
+    "nyc": "^10.1.2",
+    "proxyquire": "^1.7.11",
+    "sinon": "^1.17.7"
+  },
+  "dependencies": {
+    "async": "^2.5.0",
+    "body-parser": "^1.17.0",
+    "composer-common": "^0.9.1",
+    "composer-connector-server": "^0.9.1",
+    "dotenv": "^4.0.0",
+    "express": "^4.15.2",
+    "http-status": "^1.0.1",
+    "npm-registry-client": "^8.4.0",
+    "request": "^2.81.0",
+    "semver": "^5.3.0",
+    "socket.io": "^1.7.3",
+    "tar": "^3.1.5"
+  },
+  "nyc": {
+    "exclude": [
+      "coverage/**",
+      "out/**",
+      "scripts/**",
+      "systest/**",
+      "test/**"
+    ],
+    "reporter": [
+      "text-summary",
+      "html"
+    ],
+    "all": true,
+    "check-coverage": true,
+    "statements": 44,
+    "branches": 44,
+    "functions": 46,
+    "lines": 44
+  }
 }

--- a/packages/composer-playground-api/routes/npm.js
+++ b/packages/composer-playground-api/routes/npm.js
@@ -21,10 +21,8 @@ const tar = require('tar');
 const url = require('url');
 const async = require('async');
 const httpstatus = require('http-status');
-// eslint-disable-next-line no-unused-vars
-const pkgInfo = require('pkginfo')(module, 'dependencies');
 
-const composerVersion = module.exports.dependencies['composer-common'].substring(1);
+const composerVersion = require('composer-common/package.json').version;
 
 const express = require('express');
 const Logger = require('composer-common').Logger;
@@ -144,7 +142,11 @@ module.exports = (app) => {
                     } else if (!metadata.engines.composer) {
                         return false;
                     }
-                    return semver.satisfies(composerVersion, metadata.engines.composer);
+                    let composerVersionToUse = composerVersion;
+                    if (semver.prerelease(composerVersionToUse)) {
+                        composerVersionToUse = semver.inc(composerVersionToUse, 'patch');
+                    }
+                    return semver.satisfies(composerVersionToUse, metadata.engines.composer);
                 });
 
             // If we found multiple versions of the package, we want the first (newest).


### PR DESCRIPTION
The npm import from Playground works locally, but fails on unstable Bluemix with this error:

Response with status: 502 Bad Gateway for URL: http://composer-playground-unstable.mybluemix.net/api/getSampleList

The error is occurring as the version is modified by the build to be just `0.9.1-2017...`, along with all the dependencies. There is a substring being used to remove a leading `^`, but that is not present when we bind all the package versions together using `pkgstamp`, and so we try to parse the invalid version `.9.1-2017...` which causes the process to crash.

Made a few changes:

- Run tests with two different Composer versions, one released (0.9.0) one prerelease (0.9.0-2017...)
- Add a network that depends on 0.9.1 to check its excluded correctly
- Remove pkginfo and just grab the version via package.json
- Since there's now double the tests, replaced call count stuff with fail flags