### PR TITLE
Allow ACL rule conditions to call utility functions

### DIFF
--- a/packages/composer-connector-proxy/lib/proxyutil.js
+++ b/packages/composer-connector-proxy/lib/proxyutil.js
@@ -26,7 +26,11 @@ class ProxyUtil {
      * @return {Error} The inflated error.
      */
     static inflaterr(error) {
-        let result = global[error.name](error.message);
+        let ctor = global[error.name];
+        if (!ctor) {
+            ctor = Error;
+        }
+        let result = ctor(error.message);
         result.stack = error.stack;
         return result;
     }

--- a/packages/composer-connector-proxy/test/proxyutil.js
+++ b/packages/composer-connector-proxy/test/proxyutil.js
@@ -31,6 +31,18 @@ describe('ProxyUtil', () => {
             }).should.throw(TypeError, /some type error/);
         });
 
+        it('should inflate an unrecognized error', () => {
+            const expectedError = new TypeError('some type error');
+            const serializedError = serializerr(expectedError);
+            (() => {
+                throw ProxyUtil.inflaterr({
+                    name: 'FooBarError',
+                    message: serializedError.message,
+                    stack: serializedError.stack
+                });
+            }).should.throw(Error, /some type error/);
+        });
+
     });
 
 });

--- a/packages/composer-runtime/lib/accesscontroller.js
+++ b/packages/composer-runtime/lib/accesscontroller.js
@@ -32,11 +32,13 @@ class AccessController {
     /**
      * Constructor.
      * @param {AclManager} aclManager The ACL manager to use.
+     * @param {CompiledAclBundle} compiledAclBundle The compiled ACL bundle to use.
      */
-    constructor(aclManager) {
+    constructor(aclManager, compiledAclBundle) {
         const method = 'constructor';
         LOG.entry(method, aclManager);
         this.aclManager = aclManager;
+        this.compiledAclBundle = compiledAclBundle;
         this.participant = null;
         this.transaction = null;
         LOG.exit(method);
@@ -178,7 +180,7 @@ class AccessController {
         }
 
         // Is the predicate met?
-        if (!this.matchPredicate(resource, access, participant, transaction, aclRule)) {
+        if (!this.matchPredicate(resource, participant, transaction, aclRule)) {
             LOG.debug(method, 'Predicate does not match');
             LOG.exit(method, false);
             return false;
@@ -357,74 +359,20 @@ class AccessController {
      * Check that the specified participant has the specified
      * level of access to the specified resource.
      * @param {Resource} resource The resource.
-     * @param {string} access The level of access.
      * @param {Resource} participant The participant.
      * @param {Resource} transaction The transaction.
      * @param {AclRule} aclRule The ACL rule.
      * @returns {boolean} True if the specified ACL rule permits
      * the specified level of access to the specified resource.
      */
-    matchPredicate(resource, access, participant, transaction, aclRule) {
+    matchPredicate(resource, participant, transaction, aclRule) {
         const method = 'matchPredicate';
-        LOG.entry(method, resource, access, participant, transaction, aclRule);
-
-        // Get the predicate from the rule.
-        let predicate = aclRule.getPredicate().getExpression();
-
-        // We can fast track the simple boolean predicates.
-        if (predicate === 'true') {
-            LOG.exit(method, true);
-            return true;
-        } else if (predicate === 'false') {
-            LOG.exit(method, false);
-            return false;
-        }
-
-        // Otherwise we need to build a function.
-        let source = `return (${predicate});`;
-        let argNames = [];
-        let argValues = [];
-
-        // Check to see if the resource needs to be bound.
-        let resourceVar = aclRule.getNoun().getVariableName();
-        if (resourceVar) {
-            argNames.push(resourceVar);
-            argValues.push(resource);
-        }
-
-        // Check to see if the participant needs to be bound.
-        let reqParticipant = aclRule.getParticipant();
-        if (reqParticipant) {
-            let participantVar = aclRule.getParticipant().getVariableName();
-            if (participantVar) {
-                argNames.push(participantVar);
-                argValues.push(participant);
-            }
-        }
-
-        // Check to see if the transaction needs to be bound.
-        let reqTransaction = aclRule.getTransaction();
-        if (reqTransaction) {
-            let transactionVar = aclRule.getTransaction().getVariableName();
-            if (transactionVar) {
-                argNames.push(transactionVar);
-                argValues.push(transaction);
-            }
-        }
+        LOG.entry(method, resource, participant, transaction, aclRule);
 
         // Compile and execute the function.
-        let result;
-        try {
-            LOG.debug(method, 'Compiling and executing function', source, argNames, argValues);
-            let func = new Function(argNames.join(','), source);
-            result = func.apply(null, argValues);
-        } catch (e) {
-            LOG.error(method, e);
-            throw new AccessException(resource, access, participant, transaction);
-        }
+        const result = this.compiledAclBundle.execute(aclRule, resource, participant, transaction);
 
-        // Convert the result into a boolean before returning it.
-        result = !!result;
+        // Return the result, which should be a boolean.
         LOG.exit(method, result);
         return result;
     }

--- a/packages/composer-runtime/lib/aclcompiler.js
+++ b/packages/composer-runtime/lib/aclcompiler.js
@@ -1,0 +1,299 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Api = require('./api');
+const assert = require('assert');
+const CompiledAclBundle = require('./compiledaclbundle');
+const Logger = require('composer-common').Logger;
+const SourceMapConsumer = require('source-map').SourceMapConsumer;
+const SourceMapGenerator = require('source-map').SourceMapGenerator;
+const SourceNode = require('source-map').SourceNode;
+
+const LOG = Logger.getLog('AclCompiler');
+
+/**
+ * An ACL compiler compiles all ACLs in a ACL manager into a compiled
+ * ACL bundle that can easily be called by the runtime.
+ * @protected
+ */
+class AclCompiler {
+
+    /**
+     * Compile all the ACL in the specified ACL manager into a compiled
+     * ACL bundle for use by the runtime.
+     * @param {AclManager} aclManager The ACL manager to process.
+     * @param {ScriptManager} scriptManager The script manager to process.
+     * @return {CompiledAclBundle} The compiled script bundle.
+     */
+    compile(aclManager, scriptManager) {
+        const method = 'compile';
+        LOG.entry(method, aclManager, scriptManager);
+
+        // Create the compiler context.
+        const rootNode = new SourceNode(null, null, null);
+        const aclRules = [];
+        const context = {
+            rootNode: rootNode,
+            aclRules: aclRules
+        };
+
+        // Define the globals.
+        const globals = {
+            assert: assert
+        };
+
+        // Add the start section.
+        rootNode.add('function __generator(__globals) {\n');
+        Object.keys(globals).forEach((globalName) => {
+            LOG.debug(method, 'Adding global', globalName);
+            rootNode.add(`    var ${globalName} = __globals.${globalName};\n`);
+        });
+        rootNode.add('    function __api_disabled() { throw new Error(\'The runtime API is not available\'); }\n');
+        Api.getMethodNames().forEach((methodName) => {
+            LOG.debug(method, 'Adding API method', methodName);
+            rootNode.add(`    var ${methodName} = __api_disabled;\n`);
+        });
+        rootNode.add('    __globals = __api_disabled = null;\n');
+
+        // Process the script manager.
+        this.processScriptManager(context, scriptManager);
+
+        // Process the ACL manager.
+        this.processAclManager(context, aclManager);
+
+        // Add the end section.
+        rootNode.add('    return {\n');
+        context.aclRules.forEach((aclRule) => {
+            LOG.debug(method, 'Adding ACL rule', aclRule.getName());
+            rootNode.add(`        '${aclRule.getName()}': ${aclRule.getName()},\n`);
+        });
+        rootNode.add('    };');
+        rootNode.add('}\n');
+        rootNode.add('__generator;\n');
+
+        // Generate the combined source code and source map.
+        const combined = rootNode.toStringWithSourceMap();
+        const sourceCode = combined.code;
+        const sourceMap = combined.map;
+
+        // Serialize the source map as base64.
+        const sourceMapBase64 = Buffer.from(sourceMap.toString()).toString('base64');
+
+        // Combine the source code and the serialized source map.
+        const finalSourceCode = sourceCode + '\n//# sourceMappingURL=data:application/json;base64,' + sourceMapBase64;
+
+        // Compile the source code into a generator function.
+        // The "new Function('return eval')" hack stops the generator function getting access
+        // to all our local variables. We could just use "new Function", but that screws up
+        // the source maps so they all need to be offset by 2.
+        let generatorFunction = new Function('__generatorSource', 'return eval(__generatorSource)')(finalSourceCode);
+        generatorFunction = generatorFunction.bind(null, globals);
+        let result = new CompiledAclBundle(aclRules, generatorFunction);
+        LOG.exit(method, result);
+        return result;
+    }
+
+    /**
+     * Process the specified script manager by processing the scripts in the script manager.
+     * @param {Object} context The compiler context.
+     * @param {ScriptManager} scriptManager The script manager to process.
+     */
+    processScriptManager(context, scriptManager) {
+        const method = 'processScriptManager';
+        LOG.entry(method, context, scriptManager);
+
+        // Process all of the scripts in the script manager.
+        scriptManager.getScripts().forEach((script) => {
+            LOG.debug(method, 'Processing script', script.getIdentifier());
+            this.processScript(context, script);
+        });
+
+        LOG.exit(method);
+    }
+
+    /**
+     * Process the specified script by processing the function declarations in the script,
+     * then convert the script into a script node and add it to the root node.
+     * @param {Object} context The compiler context.
+     * @param {Script} script The script to process.
+     */
+    processScript(context, script) {
+        const method = 'processScript';
+        LOG.entry(method, context, script);
+
+        // Convert the script into a script node, and add it to the root node.
+        const scriptNode = this.convertScriptToScriptNode(context, script);
+        context.rootNode.add(scriptNode);
+
+        LOG.exit(method);
+    }
+
+    /**
+     * Process the specified ACL manager by processing the ACL rules in the ACL manager.
+     * @param {Object} context The compiler context.
+     * @param {AclManager} aclManager The ACL manager to process.
+     */
+    processAclManager(context, aclManager) {
+        const method = 'processAclManager';
+        LOG.entry(method, context, aclManager);
+
+        // Process all of the scripts in the script manager.
+        aclManager.getAclRules().forEach((aclRule) => {
+            LOG.debug(method, 'Processing ACL rule', aclRule.getName());
+            this.processAclRule(context, aclRule);
+        });
+
+        LOG.exit(method);
+    }
+
+    /**
+     * Process the specified ACL rule by compiling the predicate expression,
+     * if one exists in the ACL rule.
+     * @param {Object} context The compiler context.
+     * @param {AclRule} aclRule The ACL rule to process.
+     */
+    processAclRule(context, aclRule) {
+        const method = 'processAclRule';
+        LOG.entry(method, context, aclRule);
+
+        // Get the expression from the ACL rule.
+        context.aclRules.push(aclRule);
+        const name = aclRule.getName();
+        const predicate = aclRule.getPredicate();
+        const expression = predicate.getExpression();
+
+        // Check to see if the resource needs to be bound.
+        let resourceVarName = '__resource';
+        let resourceVar = aclRule.getNoun().getVariableName();
+        if (resourceVar) {
+            resourceVarName = resourceVar;
+        }
+
+        // Check to see if the participant needs to be bound.
+        let participantVarName = '__participant';
+        let reqParticipant = aclRule.getParticipant();
+        if (reqParticipant) {
+            let participantVar = aclRule.getParticipant().getVariableName();
+            if (participantVar) {
+                participantVarName = participantVar;
+            }
+        }
+
+        // Check to see if the transaction needs to be bound.
+        let transactionVarName = '__transaction';
+        let reqTransaction = aclRule.getTransaction();
+        if (reqTransaction) {
+            let transactionVar = aclRule.getTransaction().getVariableName();
+            if (transactionVar) {
+                transactionVarName = transactionVar;
+            }
+        }
+
+        // Create a function for the ACL rule.
+        const argNames = [resourceVarName, participantVarName, transactionVarName];
+        const joinedArgNames = argNames.join(',');
+        context.rootNode.add(`function ${name}(${joinedArgNames}) {\n`);
+        context.rootNode.add(`  return (${expression});\n`);
+        context.rootNode.add('}\n');
+
+        LOG.exit(method);
+    }
+
+    /**
+     * Convert the specified script into a source map.
+     * @param {Object} context The compiler context.
+     * @param {Script} script The function declaration to process.
+     * @return {String} The source map.
+     */
+    convertScriptToSourceMap(context, script) {
+        const method = 'convertScriptToSourceMap';
+        LOG.entry(method, context, script);
+
+        // Create a new source map generator.
+        const sourceMapGenerator = new SourceMapGenerator({ file: script.getIdentifier(), sourceRoot: process.cwd() });
+
+        // Get the parser tokens for the script.
+        const tokens = script.getTokens();
+
+        // Add mappings for all of the tokens into the source map.
+        tokens.forEach((token) => {
+            sourceMapGenerator.addMapping({
+                source: script.getIdentifier(),
+                original: token.loc.start,
+                generated: token.loc.start
+            });
+        });
+
+        // Inline the contents of the script into the source map.
+        sourceMapGenerator.setSourceContent(script.getIdentifier(), script.getContents());
+
+        // Return the source map.
+        const result = sourceMapGenerator.toString();
+        LOG.exit(method, result);
+        return result;
+    }
+
+    /**
+     * Convert the specified script into a script node with a source map.
+     * @param {Object} context The compiler context.
+     * @param {Script} script The function declaration to process.
+     * @return {SourceNode} The script node.
+     */
+    convertScriptToScriptNode(context, script) {
+        const method = 'convertScriptToScriptNode';
+        LOG.entry(method, context, script);
+
+        // Convert the script into a source map.
+        let sourceFileName = script.getIdentifier();
+        let sourceCode = script.getContents();
+        let sourceMap = this.convertScriptToSourceMap(context, script);
+
+        // Allow someone else to post-process the converted script.
+        const transformedScript = this.transformScript(sourceFileName, sourceCode, sourceMap);
+        sourceFileName = transformedScript.sourceFileName;
+        sourceCode = transformedScript.sourceCode;
+        sourceMap = transformedScript.sourceMap;
+
+        // Create a new source node from the script contents and source map
+        const sourceMapConsumer = new SourceMapConsumer(sourceMap);
+        const result = SourceNode.fromStringWithSourceMap(sourceCode, sourceMapConsumer);
+        LOG.exit(method, result);
+        return result;
+    }
+
+    /**
+     * Optional hook to transform a script into another format, for example
+     * by using a code coverage instrumenter.
+     * @param {String} sourceFileName The file name for the script.
+     * @param {String} sourceCode The source code for the script.
+     * @param {String} sourceMap The source map for the script.
+     * @return {Object} The transformed script.
+     */
+    transformScript(sourceFileName, sourceCode, sourceMap) {
+        const method = 'transformScript';
+        LOG.entry(method, sourceFileName, sourceCode, sourceMap);
+        const result = {
+            sourceFileName: sourceFileName,
+            sourceCode: sourceCode,
+            sourceMap: sourceMap
+        };
+        LOG.exit(method, result);
+        return result;
+    }
+
+}
+
+module.exports = AclCompiler;

--- a/packages/composer-runtime/lib/compiledaclbundle.js
+++ b/packages/composer-runtime/lib/compiledaclbundle.js
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Logger = require('composer-common').Logger;
+
+const LOG = Logger.getLog('CompiledAclBundle');
+
+/**
+ * A script compiler compiles all scripts in a script manager into a compiled
+ * script bundle that can easily be called by the runtime.
+ * @protected
+ */
+class CompiledAclBundle {
+
+    /**
+     * Constructor.
+     * @param {AclRule[]} aclRules The ACL rules to use.
+     * @param {Function} generatorFunction The generator function to use.
+     */
+    constructor(aclRules, generatorFunction) {
+        this.aclRules = aclRules;
+        this.generatorFunction = generatorFunction;
+    }
+
+    /**
+     * Execute the specified ACL rule.
+     * @param {AclRule} aclRule The ACL rule to execute.
+     * @param {Resource} resource The resource being accessed.
+     * @param {Resource} participant The participant attempting the operation.
+     * @param {Resource} transaction The transaction, if any, that is currently executing.
+     * @return {Promise} A promise that is resolved when the transaction has been
+     * executed, or rejected with an error.
+     */
+    execute(aclRule, resource, participant, transaction) {
+        const method = 'execute';
+        LOG.entry(method, aclRule, resource, participant, transaction);
+
+        // Check to see that the ACL rule is present.
+        const exists = this.aclRules.find((thisAclRule) => {
+            return thisAclRule.getName() === aclRule.getName();
+        });
+        if (!exists) {
+            throw new Error(`The ACL rule ${aclRule.getName()} does not exist`);
+        }
+
+        // Generate an instance of the compiled ACL bundle.
+        const bundle = this.generatorFunction();
+
+        // Execute the function.
+        const functionName = aclRule.getName();
+        const func = bundle[functionName];
+        let funcResult;
+        try {
+            LOG.debug(method, 'Executing function', functionName);
+            funcResult = func(resource, participant, transaction);
+            LOG.debug(method, 'Function returned', funcResult);
+        } catch (e) {
+            LOG.debug(method, 'Function threw error', e);
+        }
+
+        // Force the result to be a boolean.
+        const result = !!funcResult;
+        LOG.exit(method, result);
+        return result;
+    }
+
+}
+
+module.exports = CompiledAclBundle;

--- a/packages/composer-runtime/lib/context.js
+++ b/packages/composer-runtime/lib/context.js
@@ -113,6 +113,8 @@ class Context {
         this.compiledScriptBundle = null;
         this.queryCompiler = null;
         this.compiledQueryBundle = null;
+        this.aclCompiler = null;
+        this.compiledAclBundle = null;
     }
 
     /**

--- a/packages/composer-runtime/lib/context.js
+++ b/packages/composer-runtime/lib/context.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const AclCompiler = require('./aclcompiler');
 const AccessController = require('./accesscontroller');
 const Api = require('./api');
 const BusinessNetworkDefinition = require('composer-common').BusinessNetworkDefinition;
@@ -32,6 +33,7 @@ const LOG = Logger.getLog('Context');
 const businessNetworkCache = LRU(8);
 const compiledScriptBundleCache = LRU(8);
 const compiledQueryBundleCache = LRU(8);
+const compiledAclBundleCache = LRU(8);
 
 /**
  * A class representing the current request being handled by the JavaScript engine.
@@ -74,6 +76,18 @@ class Context {
         const method = 'cacheCompiledQueryBundle';
         LOG.entry(method, businessNetworkHash, compiledQueryBundle);
         compiledQueryBundleCache.set(businessNetworkHash, compiledQueryBundle);
+        LOG.exit(method);
+    }
+
+    /**
+     * Store a compiled ACL bundle in the cache.
+     * @param {string} businessNetworkHash The hash of the business network definition.
+     * @param {CompiledAclBundle} compiledAclBundle The compiled ACL bundle.
+     */
+    static cacheCompiledAclBundle(businessNetworkHash, compiledAclBundle) {
+        const method = 'cacheCompiledAclBundle';
+        LOG.entry(method, businessNetworkHash, compiledAclBundle);
+        compiledAclBundleCache.set(businessNetworkHash, compiledAclBundle);
         LOG.exit(method);
     }
 
@@ -214,6 +228,36 @@ class Context {
     }
 
     /**
+     * Load or compile the compiled ACL bundle.
+     * @param {Object} businessNetworkRecord The business network record.
+     * @param {BusinessNetworkDefinition} businessNetworkDefinition The business network definition.
+     * @return {Promise} A promise that will be resolved with a {@link BusinessNetworkDefinition}
+     * when complete, or rejected with an error.
+     */
+    loadCompiledAclBundle(businessNetworkRecord, businessNetworkDefinition) {
+        const method = 'loadCompiledAclBundle';
+        LOG.entry(method);
+        LOG.debug(method, 'Looking in cache for compiled ACL bundle', businessNetworkRecord.hash);
+        let compiledAclBundle = compiledAclBundleCache.get(businessNetworkRecord.hash);
+        if (compiledAclBundle) {
+            LOG.debug(method, 'Compiled ACL bundle is in cache');
+            return Promise.resolve(compiledAclBundle);
+        }
+        LOG.debug(method, 'Compiled ACL bundle is not in cache, loading');
+        return Promise.resolve()
+            .then(() => {
+                let compiledAclBundle = this.getAclCompiler().compile(businessNetworkDefinition.getAclManager(), businessNetworkDefinition.getScriptManager());
+                Context.cacheCompiledAclBundle(businessNetworkRecord.hash, compiledAclBundle);
+                LOG.exit(method, compiledAclBundle);
+                return compiledAclBundle;
+            })
+            .catch((error) => {
+                LOG.error(method, error);
+                throw error;
+            });
+    }
+
+    /**
      * Load the current participant.
      * @return {Promise} A promise that will be resolved with a {@link Resource}
      * when complete, or rejected with an error.
@@ -336,6 +380,37 @@ class Context {
     }
 
     /**
+     * Get the compiled ACL bundle to use.
+     * @param {BusinessNetworkDefinition} businessNetworkDefinition The business network definition to use.
+     * @param {Object} [options] The options to use.
+     * @param {CompiledAclBundle} [options.compiledAclBundle] The business network definition to use.
+     * @return {Promise} A promise that will be resolved when complete, or rejected
+     * with an error.
+     */
+    findCompiledAclBundle(businessNetworkDefinition, options) {
+        const method = 'findCompiledAclBundle';
+        LOG.entry(method, options);
+        options = options || {};
+        return Promise.resolve()
+            .then(() => {
+                if (options.compiledAclBundle) {
+                    LOG.debug(method, 'Compiled ACL bundle already specified');
+                    return options.compiledAclBundle;
+                } else {
+                    LOG.debug(method, 'Compiled ACL bundle not specified, loading from world state');
+                    return this.loadBusinessNetworkRecord()
+                        .then((businessNetworkRecord) => {
+                            return this.loadCompiledAclBundle(businessNetworkRecord, businessNetworkDefinition);
+                        });
+                }
+            })
+            .then((compiledAclBundle) => {
+                LOG.exit(method, compiledAclBundle);
+                return compiledAclBundle;
+            });
+    }
+
+    /**
      * Initialize the context for use.
      * @param {Object} [options] The options to use.
      * @param {BusinessNetworkDefinition} [options.businessNetworkDefinition] The business network definition to use.
@@ -368,6 +443,11 @@ class Context {
             .then((compiledQueryBundle) => {
                 LOG.debug(method, 'Got compiled query bundle');
                 this.compiledQueryBundle = compiledQueryBundle;
+                return this.findCompiledAclBundle(this.businessNetworkDefinition, options);
+            })
+            .then((compiledAclBundle) => {
+                LOG.debug(method, 'Got compiled ACL bundle');
+                this.compiledAclBundle = compiledAclBundle;
                 LOG.debug(method, 'Loading sysregistries collection', options.sysregistries);
                 if (options.sysregistries) {
                     this.sysregistries = options.sysregistries;
@@ -624,7 +704,7 @@ class Context {
      */
     getAccessController() {
         if (!this.accessController) {
-            this.accessController = new AccessController(this.getAclManager());
+            this.accessController = new AccessController(this.getAclManager(), this.getCompiledAclBundle());
         }
         return this.accessController;
     }
@@ -699,10 +779,29 @@ class Context {
 
     /**
      * Get the compiled query bundle.
-     * @return {CompiledScriptBundle} compiledQueryBundle The compiled query bundle.
+     * @return {CompiledQueryBundle} compiledQueryBundle The compiled query bundle.
      */
     getCompiledQueryBundle() {
         return this.compiledQueryBundle;
+    }
+
+    /**
+     * Get the ACL compiler.
+     * @return {AclCompiler} aclCompiler The ACL compiler.
+     */
+    getAclCompiler() {
+        if (!this.aclCompiler) {
+            this.aclCompiler = new AclCompiler();
+        }
+        return this.aclCompiler;
+    }
+
+    /**
+     * Get the compiled ACL bundle.
+     * @return {CompiledAclBundle} compiledAclBundle The compiled ACL bundle.
+     */
+    getCompiledAclBundle() {
+        return this.compiledAclBundle;
     }
 
     /**

--- a/packages/composer-runtime/lib/engine.businessnetworks.js
+++ b/packages/composer-runtime/lib/engine.businessnetworks.js
@@ -102,7 +102,8 @@ class EngineBusinessNetworks {
             throw new Error(util.format('Invalid arguments "%j" to function "%s", expecting "%j"', args, 'updateBusinessNetwork', ['businessNetworkArchive']));
         }
         let dataService = context.getDataService();
-        let businessNetworkBase64, businessNetworkHash, businessNetworkDefinition, compiledScriptBundle, compiledQueryBundle;
+        let businessNetworkBase64, businessNetworkHash, businessNetworkDefinition;
+        let compiledScriptBundle, compiledQueryBundle, compiledAclBundle;
         return Promise.resolve()
             .then(() => {
 
@@ -133,6 +134,11 @@ class EngineBusinessNetworks {
                 LOG.debug(method, 'Loaded compiled query bundle, storing in cache');
                 Context.cacheCompiledQueryBundle(businessNetworkHash, compiledQueryBundle);
 
+                // Cache the compiled ACL bundle.
+                compiledAclBundle = context.getAclCompiler().compile(businessNetworkDefinition.getAclManager(), businessNetworkDefinition.getScriptManager());
+                LOG.debug(method, 'Loaded compiled ACL bundle, storing in cache');
+                Context.cacheCompiledAclBundle(businessNetworkHash, compiledAclBundle);
+
                 // Get the sysdata collection where the business network definition is stored.
                 LOG.debug(method, 'Loaded business network definition, storing in $sysdata collection');
                 return dataService.getCollection('$sysdata');
@@ -155,6 +161,7 @@ class EngineBusinessNetworks {
                     businessNetworkDefinition: businessNetworkDefinition,
                     compiledScriptBundle: compiledScriptBundle,
                     compiledQueryBundle: compiledQueryBundle,
+                    compiledAclBundle: compiledAclBundle,
                     reinitialize: true
                 });
 

--- a/packages/composer-runtime/lib/engine.js
+++ b/packages/composer-runtime/lib/engine.js
@@ -103,7 +103,8 @@ class Engine {
         }
 
         let dataService = context.getDataService();
-        let businessNetworkBase64, businessNetworkHash, businessNetworkRecord, businessNetworkDefinition, compiledScriptBundle, compiledQueryBundle;
+        let businessNetworkBase64, businessNetworkHash, businessNetworkRecord, businessNetworkDefinition;
+        let compiledScriptBundle, compiledQueryBundle, compiledAclBundle;
         let sysregistries, sysidentities;
         return Promise.resolve()
             .then(() => {
@@ -149,6 +150,11 @@ class Engine {
                 LOG.debug(method, 'Loaded compiled query bundle, storing in cache');
                 Context.cacheCompiledQueryBundle(businessNetworkHash, compiledQueryBundle);
 
+                // Cache the compiled ACL bundle.
+                compiledAclBundle = context.getAclCompiler().compile(businessNetworkDefinition.getAclManager(), businessNetworkDefinition.getScriptManager());
+                LOG.debug(method, 'Loaded compiled ACL bundle, storing in cache');
+                Context.cacheCompiledAclBundle(businessNetworkHash, compiledAclBundle);
+
                 // Get the sysdata collection where the business network definition is stored.
                 LOG.debug(method, 'Loaded business network definition, storing in $sysdata collection');
                 return dataService.ensureCollection('$sysdata');
@@ -188,6 +194,7 @@ class Engine {
                     businessNetworkDefinition: businessNetworkDefinition,
                     compiledScriptBundle: compiledScriptBundle,
                     compiledQueryBundle: compiledQueryBundle,
+                    compiledAclBundle: compiledAclBundle,
                     sysregistries: sysregistries,
                     sysidentities: sysidentities
                 });

--- a/packages/composer-runtime/test/aclcompiler.js
+++ b/packages/composer-runtime/test/aclcompiler.js
@@ -1,0 +1,425 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const AclCompiler = require('../lib/aclcompiler');
+const AclManager = require('composer-common').AclManager;
+const assert = require('assert');
+const ModelManager = require('composer-common').ModelManager;
+const path = require('path');
+const Resource = require('composer-common').Resource;
+const ScriptManager = require('composer-common').ScriptManager;
+const SourceMapConsumer = require('source-map').SourceMapConsumer;
+const SourceNode = require('source-map').SourceNode;
+
+require('chai').should();
+const sinon = require('sinon');
+
+describe('AclCompiler', () => {
+
+    let modelManager;
+    let scriptManager;
+    let aclManager;
+    let aclRules;
+    let functionDeclarations;
+    let aclCompiler;
+    let sandbox;
+
+    beforeEach(() => {
+        modelManager = new ModelManager();
+        modelManager.addModelFile(`
+        namespace org.acme
+        asset TestAsset identified by assetId {
+            o String assetId
+        }
+        participant TestParticipant identified by participantId {
+            o String participantId
+        }
+        transaction TestTransaction {
+        }
+        transaction TestTransaction2 {
+        }
+        transaction TestTransaction3 {
+        }
+        transaction TestTransaction4 {
+        }`);
+        scriptManager = new ScriptManager(modelManager);
+        scriptManager.addScript(scriptManager.createScript('script1', 'JS', `
+            function doIt() {
+                assert.ok(true);
+                return true;
+            }
+
+            function doIt3a() {
+            }
+
+            function doIt3b() {
+            }
+
+            function testItAll(r, p, t) {
+                assert.ok(r, p, t);
+            }`));
+        functionDeclarations = [];
+        scriptManager.getScripts().forEach((script) => {
+            script.getFunctionDeclarations().forEach((functionDeclaration) => {
+                functionDeclarations.push(functionDeclaration);
+            });
+        });
+        aclManager = new AclManager(modelManager);
+        aclManager.setAclFile(aclManager.createAclFile('permissions.acl', `
+        rule R1 {
+            description: "test acl rule"
+            participant: "org.acme.TestParticipant"
+            operation: ALL
+            resource: "org.acme.TestAsset"
+            condition: (true)
+            action: ALLOW
+        }
+        rule R2 {
+            description: "test acl rule"
+            participant: "org.acme.TestParticipant"
+            operation: ALL
+            resource: "org.acme.TestAsset"
+            condition: (doIt())
+            action: ALLOW
+        }
+        rule R3 {
+            description: "test acl rule"
+            participant: "org.acme.TestParticipant"
+            operation: ALL
+            resource(THERES): "org.acme.TestAsset"
+            condition: (doIt())
+            action: ALLOW
+        }
+        rule R4 {
+            description: "test acl rule"
+            participant: "ANY"
+            operation: ALL
+            resource: "org.acme.TestAsset"
+            condition: (doIt())
+            action: ALLOW
+        }
+        rule R5 {
+            description: "test acl rule"
+            participant(THEPART): "org.acme.TestParticipant"
+            operation: ALL
+            resource: "org.acme.TestAsset"
+            condition: (doIt())
+            action: ALLOW
+        }
+        rule R6 {
+            description: "test acl rule"
+            participant: "org.acme.TestParticipant"
+            operation: ALL
+            resource: "org.acme.TestAsset"
+            transaction: "org.acme.TestTransaction"
+            condition: (doIt())
+            action: ALLOW
+        }
+        rule R7 {
+            description: "test acl rule"
+            participant: "org.acme.TestParticipant"
+            operation: ALL
+            resource: "org.acme.TestAsset"
+            transaction(THETX): "org.acme.TestTransaction"
+            condition: (doIt())
+            action: ALLOW
+        }
+        rule R8 {
+            description: "test acl rule"
+            participant(p): "org.acme.TestParticipant"
+            operation: ALL
+            resource(r): "org.acme.TestAsset"
+            transaction(t): "org.acme.TestTransaction"
+            condition: (testItAll(r, p, t))
+            action: ALLOW
+        }
+        rule R9 {
+            description: "test acl rule"
+            participant: "org.acme.TestParticipant"
+            operation: ALL
+            resource: "org.acme.TestAsset"
+            transaction: "org.acme.TestTransaction"
+            condition: (testItAll(__resource, __participant, __transaction))
+            action: ALLOW
+        }
+        `));
+        aclRules = aclManager.getAclRules();
+        aclCompiler = new AclCompiler();
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('#compile', () => {
+
+        it('should compile all of the ACL rules in the specified ACL manager into a bundle', () => {
+            sandbox.stub(assert, 'ok');
+            const compiledAclBundle = aclCompiler.compile(aclManager, scriptManager);
+            const aclRules = compiledAclBundle.aclRules;
+            const generatorFunction = compiledAclBundle.generatorFunction;
+            aclRules.should.have.lengthOf(9);
+            generatorFunction.should.be.a('function');
+            const result = generatorFunction();
+            result.should.be.an('object');
+            result.R1.should.be.a('function');
+            result.R1().should.be.true;
+            result.R2.should.be.a('function');
+            result.R2().should.be.true;
+            sinon.assert.calledOnce(assert.ok);
+            sinon.assert.calledWith(assert.ok, true);
+            result.R3.should.be.a('function');
+            result.R4.should.be.a('function');
+            result.R5.should.be.a('function');
+            result.R6.should.be.a('function');
+            result.R7.should.be.a('function');
+            result.R8.should.be.a('function');
+            result.R9.should.be.a('function');
+        });
+
+        it('should generate functions with correctly bound variables', () => {
+            sandbox.stub(assert, 'ok');
+            const compiledAclBundle = aclCompiler.compile(aclManager, scriptManager);
+            const generatorFunction = compiledAclBundle.generatorFunction;
+            const result = generatorFunction();
+            const mockParticipant = sinon.createStubInstance(Resource);
+            mockParticipant.participantId = 'P1';
+            const mockAsset = sinon.createStubInstance(Resource);
+            mockAsset.assetId = 'A1';
+            const mockTransaction = sinon.createStubInstance(Resource);
+            mockTransaction.transactionId = 'T1';
+            result.R8(mockAsset, mockParticipant, mockTransaction);
+            sinon.assert.calledOnce(assert.ok);
+            sinon.assert.calledWith(assert.ok, mockAsset, mockParticipant, mockTransaction);
+        });
+
+        it('should generate functions with default bound variables', () => {
+            sandbox.stub(assert, 'ok');
+            const compiledAclBundle = aclCompiler.compile(aclManager, scriptManager);
+            const generatorFunction = compiledAclBundle.generatorFunction;
+            const result = generatorFunction();
+            const mockParticipant = sinon.createStubInstance(Resource);
+            mockParticipant.participantId = 'P1';
+            const mockAsset = sinon.createStubInstance(Resource);
+            mockAsset.assetId = 'A1';
+            const mockTransaction = sinon.createStubInstance(Resource);
+            mockTransaction.transactionId = 'T1';
+            result.R9(mockAsset, mockParticipant, mockTransaction);
+            sinon.assert.calledOnce(assert.ok);
+            sinon.assert.calledWith(assert.ok, mockAsset, mockParticipant, mockTransaction);
+        });
+
+    });
+
+    describe('#processAclManager', () => {
+
+        it('should process all of the ACL rules in the specified ACL manager', () => {
+            const context = {
+                rootNode: {
+                    add: sinon.stub()
+                },
+                aclRules: []
+            };
+            aclCompiler.processAclManager(context, aclManager);
+            sinon.assert.callCount(context.rootNode.add, 3 * aclRules.length);
+            context.aclRules.should.deep.equal(aclRules);
+        });
+
+    });
+
+    describe('#processAclRule', () => {
+
+        it('should process the specified ACL rule', () => {
+            const context = {
+                rootNode: {
+                    add: sinon.stub()
+                },
+                aclRules: []
+            };
+            const aclRule = aclRules[0];
+            aclCompiler.processAclRule(context, aclRule);
+            sinon.assert.calledThrice(context.rootNode.add);
+            context.aclRules.should.deep.equal([ aclRule ]);
+        });
+
+        it('should process an ACL rule with a resource binding', () => {
+            const context = {
+                rootNode: {
+                    add: sinon.stub()
+                },
+                aclRules: []
+            };
+            const aclRule = aclRules[2];
+            aclCompiler.processAclRule(context, aclRule);
+            sinon.assert.calledThrice(context.rootNode.add);
+            sinon.assert.calledWith(context.rootNode.add, sinon.match(/function R3\(THERES,__participant,__transaction\) {/));
+            context.aclRules.should.deep.equal([ aclRule ]);
+        });
+
+        it('should process an ACL rule with an unbound participant', () => {
+            const context = {
+                rootNode: {
+                    add: sinon.stub()
+                },
+                aclRules: []
+            };
+            const aclRule = aclRules[3];
+            aclCompiler.processAclRule(context, aclRule);
+            sinon.assert.calledThrice(context.rootNode.add);
+            sinon.assert.calledWith(context.rootNode.add, sinon.match(/function R4\(__resource,__participant,__transaction\) {/));
+            context.aclRules.should.deep.equal([ aclRule ]);
+        });
+
+        it('should process an ACL rule with a participant binding', () => {
+            const context = {
+                rootNode: {
+                    add: sinon.stub()
+                },
+                aclRules: []
+            };
+            const aclRule = aclRules[4];
+            aclCompiler.processAclRule(context, aclRule);
+            sinon.assert.calledThrice(context.rootNode.add);
+            sinon.assert.calledWith(context.rootNode.add, sinon.match(/function R5\(__resource,THEPART,__transaction\) {/));
+            context.aclRules.should.deep.equal([ aclRule ]);
+        });
+
+        it('should process an ACL rule with an unbound transaction', () => {
+            const context = {
+                rootNode: {
+                    add: sinon.stub()
+                },
+                aclRules: []
+            };
+            const aclRule = aclRules[5];
+            aclCompiler.processAclRule(context, aclRule);
+            sinon.assert.calledThrice(context.rootNode.add);
+            sinon.assert.calledWith(context.rootNode.add, sinon.match(/function R6\(__resource,__participant,__transaction\) {/));
+            context.aclRules.should.deep.equal([ aclRule ]);
+        });
+
+        it('should process an ACL rule with a transaction binding', () => {
+            const context = {
+                rootNode: {
+                    add: sinon.stub()
+                },
+                aclRules: []
+            };
+            const aclRule = aclRules[6];
+            aclCompiler.processAclRule(context, aclRule);
+            sinon.assert.calledThrice(context.rootNode.add);
+            sinon.assert.calledWith(context.rootNode.add, sinon.match(/function R7\(__resource,__participant,THETX\) {/));
+            context.aclRules.should.deep.equal([ aclRule ]);
+        });
+
+    });
+
+    describe('#processScriptManager', () => {
+
+        it('should process all of the scripts in the specified script manager', () => {
+            const context = {
+                rootNode: {
+                    add: sinon.stub()
+                }
+            };
+            aclCompiler.processScriptManager(context, scriptManager);
+            sinon.assert.calledOnce(context.rootNode.add);
+            sinon.assert.calledWith(context.rootNode.add, sinon.match.instanceOf(SourceNode));
+        });
+
+    });
+
+    describe('#processScript', () => {
+
+        it('should process the specified script', () => {
+            const context = {
+                rootNode: {
+                    add: sinon.stub()
+                }
+            };
+            const script = scriptManager.getScript('script1');
+            aclCompiler.processScript(context, script);
+            sinon.assert.calledOnce(context.rootNode.add);
+            sinon.assert.calledWith(context.rootNode.add, sinon.match.instanceOf(SourceNode));
+        });
+
+    });
+
+    describe('#convertScriptToSourceMap', () => {
+
+        it('should convert a script into a valid source map', () => {
+            const context = {};
+            const script = scriptManager.getScript('script1');
+            const sourceMap = aclCompiler.convertScriptToSourceMap(context, script);
+            sourceMap.should.be.a('string');
+            const sourceMapConsumer = new SourceMapConsumer(sourceMap);
+            const mappings = [];
+            sourceMapConsumer.eachMapping((mapping) => {
+                mappings.push(mapping);
+            });
+            mappings.should.have.lengthOf(51);
+            sourceMapConsumer.sourceContentFor(path.resolve(process.cwd(), 'script1')).should.match(/function doIt\(\) {/);
+        });
+
+    });
+
+    describe('#convertScriptToScriptNode', () => {
+
+        it('should convert a script into a source node', () => {
+            const context = {};
+            const script = scriptManager.getScript('script1');
+            const sourceNode = aclCompiler.convertScriptToScriptNode(context, script);
+            sourceNode.should.be.an.instanceOf(SourceNode);
+            const result = sourceNode.toStringWithSourceMap();
+            result.code.should.equal(script.getContents());
+            const sourceMap = result.map.toString();
+            sourceMap.should.be.a('string');
+        });
+
+        it('should allow the script to be transformed', () => {
+            aclCompiler.transformScript = (sourceFileName, sourceCode, sourceMap) => {
+                return {
+                    sourceFileName: sourceFileName,
+                    sourceCode: sourceCode.replace(/function/, /FANCTION/),
+                    sourceMap: sourceMap
+                };
+            };
+            const context = {};
+            const script = scriptManager.getScript('script1');
+            const sourceNode = aclCompiler.convertScriptToScriptNode(context, script);
+            sourceNode.should.be.an.instanceOf(SourceNode);
+            const result = sourceNode.toStringWithSourceMap();
+            result.code.should.match(/FANCTION/);
+            const sourceMap = result.map.toString();
+            sourceMap.should.be.a('string');
+        });
+
+    });
+
+    describe('#transformScript', () => {
+
+        it('should return the script', () => {
+            aclCompiler.transformScript('script1', 'eval(true)', 'some map').should.deep.equal({
+                sourceCode: 'eval(true)',
+                sourceFileName: 'script1',
+                sourceMap: 'some map'
+            });
+        });
+
+    });
+
+});

--- a/packages/composer-runtime/test/compiledaclbundle.js
+++ b/packages/composer-runtime/test/compiledaclbundle.js
@@ -1,0 +1,182 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const AclManager = require('composer-common').AclManager;
+const CompiledAclBundle = require('../lib/compiledaclbundle');
+const ModelManager = require('composer-common').ModelManager;
+const Resource = require('composer-common').Resource;
+
+require('chai').should();
+const sinon = require('sinon');
+require('sinon-as-promised');
+
+describe('CompiledAclBundle', () => {
+
+    let modelManager;
+    let aclManager;
+    let aclRules;
+    let missingAclRule;
+    let mockGeneratorFunction;
+    let bundle;
+    let compiledScriptBundle;
+
+    beforeEach(() => {
+        modelManager = new ModelManager();
+        modelManager.addModelFile(`
+        namespace org.acme
+        asset TestAsset identified by assetId {
+            o String assetId
+        }
+        participant TestParticipant identified by participantId {
+            o String participantId
+        }
+        transaction TestTransaction {
+        }
+        transaction TestTransaction2 {
+        }
+        transaction TestTransaction3 {
+        }
+        transaction TestTransaction4 {
+        }`);
+        aclManager = new AclManager(modelManager);
+        aclManager.setAclFile(aclManager.createAclFile('permissions.acl', `
+        rule R1 {
+            description: "test acl rule"
+            participant: "org.acme.TestParticipant"
+            operation: ALL
+            resource: "org.acme.TestAsset"
+            condition: (true)
+            action: ALLOW
+        }
+        rule R2 {
+            description: "test acl rule"
+            participant: "org.acme.TestParticipant"
+            operation: ALL
+            resource: "org.acme.TestAsset"
+            condition: (doIt())
+            action: ALLOW
+        }
+        rule R3 {
+            description: "test acl rule"
+            participant: "org.acme.TestParticipant"
+            operation: ALL
+            resource(THERES): "org.acme.TestAsset"
+            condition: (doIt())
+            action: ALLOW
+        }
+        rule R4 {
+            description: "test acl rule"
+            participant: "ANY"
+            operation: ALL
+            resource: "org.acme.TestAsset"
+            condition: (doIt())
+            action: ALLOW
+        }
+        rule R5 {
+            description: "test acl rule"
+            participant(THEPART): "org.acme.TestParticipant"
+            operation: ALL
+            resource: "org.acme.TestAsset"
+            condition: (doIt())
+            action: ALLOW
+        }
+        rule R6 {
+            description: "test acl rule"
+            participant: "org.acme.TestParticipant"
+            operation: ALL
+            resource: "org.acme.TestAsset"
+            transaction: "org.acme.TestTransaction"
+            condition: (doIt())
+            action: ALLOW
+        }
+        rule R7 {
+            description: "test acl rule"
+            participant: "org.acme.TestParticipant"
+            operation: ALL
+            resource: "org.acme.TestAsset"
+            transaction(THETX): "org.acme.TestTransaction"
+            condition: (doIt())
+            action: ALLOW
+        }
+        rule R8 {
+            description: "test acl rule"
+            participant(p): "org.acme.TestParticipant"
+            operation: ALL
+            resource(r): "org.acme.TestAsset"
+            transaction(t): "org.acme.TestTransaction"
+            condition: (testItAll(p, r, t))
+            action: ALLOW
+        }
+        rule R9 {
+            description: "test acl rule"
+            participant: "org.acme.TestParticipant"
+            operation: ALL
+            resource: "org.acme.TestAsset"
+            transaction: "org.acme.TestTransaction"
+            condition: (testItAll(__participant, __resource, __transaction))
+            action: ALLOW
+        }
+        `));
+        aclRules = aclManager.getAclRules();
+        missingAclRule = aclRules.pop();
+        bundle = {
+            R1: sinon.stub().returns(true),
+            R2: sinon.stub().throws(new Error('such error'))
+        };
+        mockGeneratorFunction = sinon.stub().returns(bundle);
+        compiledScriptBundle = new CompiledAclBundle(aclRules, mockGeneratorFunction);
+    });
+
+    describe('#execute', () => {
+
+        let mockParticipant, mockAsset, mockTransaction;
+
+        beforeEach(() => {
+            mockParticipant = sinon.createStubInstance(Resource);
+            mockParticipant.participantId = 'P1';
+            mockAsset = sinon.createStubInstance(Resource);
+            mockAsset.assetId = 'A1';
+            mockTransaction = sinon.createStubInstance(Resource);
+            mockTransaction.transactionId = 'T1';
+        });
+
+        it('should throw if no functions could be found', () => {
+            (() => {
+                compiledScriptBundle.execute(missingAclRule, mockAsset, mockParticipant, mockTransaction);
+            }).should.throw(/The ACL rule .* does not exist/);
+        });
+
+        it('should call a function', () => {
+            const result = compiledScriptBundle.execute(aclRules[0], mockAsset, mockParticipant, mockTransaction);
+            result.should.be.true;
+            sinon.assert.calledOnce(mockGeneratorFunction);
+            sinon.assert.calledWith(mockGeneratorFunction);
+            sinon.assert.calledOnce(bundle.R1);
+            sinon.assert.calledWith(bundle.R1, mockAsset, mockParticipant, mockTransaction);
+        });
+
+        it('should handle a function throwing an error', () => {
+            const result = compiledScriptBundle.execute(aclRules[1], mockAsset, mockParticipant, mockTransaction);
+            result.should.be.false;
+            sinon.assert.calledOnce(mockGeneratorFunction);
+            sinon.assert.calledWith(mockGeneratorFunction);
+            sinon.assert.calledOnce(bundle.R2);
+            sinon.assert.calledWith(bundle.R2, mockAsset, mockParticipant, mockTransaction);
+        });
+
+    });
+
+});

--- a/packages/composer-runtime/test/context.js
+++ b/packages/composer-runtime/test/context.js
@@ -14,10 +14,12 @@
 
 'use strict';
 
+const AclCompiler = require('../lib/aclcompiler');
 const AccessController = require('../lib/accesscontroller');
 const AclManager = require('composer-common').AclManager;
 const Api = require('../lib/api');
 const BusinessNetworkDefinition = require('composer-common').BusinessNetworkDefinition;
+const CompiledAclBundle = require('../lib/compiledaclbundle');
 const CompiledQueryBundle = require('../lib/compiledquerybundle');
 const CompiledScriptBundle = require('../lib/compiledscriptbundle');
 const Context = require('../lib/context');
@@ -216,6 +218,45 @@ describe('Context', () => {
 
     });
 
+    describe('#loadCompiledAclBundle', () => {
+
+        const businessNetworkRecord = { data: 'aGVsbG8gd29ybGQ=', hash: 'dc9c1c09907c36f5379d615ae61c02b46ba254d92edb77cb63bdcc5247ccd01c' };
+        const businessNetworkDefinition = sinon.createStubInstance(BusinessNetworkDefinition);
+        let mockAclCompiler;
+        let mockCompiledAclBundle;
+
+        beforeEach(() => {
+            mockAclCompiler = sinon.createStubInstance(AclCompiler);
+            mockCompiledAclBundle = sinon.createStubInstance(CompiledAclBundle);
+            mockAclCompiler.compile.returns(mockCompiledAclBundle);
+            context.aclCompiler = mockAclCompiler;
+        });
+
+        it('should load the compiled ACL bundle if it is not already in the cache', () => {
+            return context.loadCompiledAclBundle(businessNetworkRecord, businessNetworkDefinition)
+                .then((compiledAclBundle) => {
+                    compiledAclBundle.should.equal(mockCompiledAclBundle);
+                });
+        });
+
+        it('should not load the compiled ACL bundle if it is already in the cache', () => {
+            Context.cacheCompiledAclBundle('dc9c1c09907c36f5379d615ae61c02b46ba254d92edb77cb63bdcc5247ccd01c', mockCompiledAclBundle);
+            mockAclCompiler.compile.throws(new Error('such error'));
+            return context.loadCompiledAclBundle(businessNetworkRecord, businessNetworkDefinition)
+                .then((compiledAclBundle) => {
+                    compiledAclBundle.should.equal(mockCompiledAclBundle);
+                });
+        });
+
+        it('should handle any errors thrown loading the compiled ACL bundle', () => {
+            Context.cacheCompiledAclBundle('dc9c1c09907c36f5379d615ae61c02b46ba254d92edb77cb63bdcc5247ccd01c', null);
+            mockAclCompiler.compile.throws(new Error('such error'));
+            return context.loadCompiledAclBundle(businessNetworkRecord, businessNetworkDefinition)
+                .should.be.rejectedWith(/such error/);
+        });
+
+    });
+
     describe('#loadCurrentParticipant', () => {
 
         it('should return null if no identity is specified', () => {
@@ -352,17 +393,51 @@ describe('Context', () => {
 
     });
 
+    describe('#findCompiledAclBundle', () => {
+
+        const businessNetworkRecord = { data: 'aGVsbG8gd29ybGQ=', hash: 'dc9c1c09907c36f5379d615ae61c02b46ba254d92edb77cb63bdcc5247ccd01c' };
+        const businessNetworkDefinition = sinon.createStubInstance(BusinessNetworkDefinition);
+        const compiledAclBundle = sinon.createStubInstance(CompiledAclBundle);
+
+        beforeEach(() => {
+            sinon.stub(context, 'loadBusinessNetworkRecord').resolves(businessNetworkRecord);
+            sinon.stub(context, 'loadCompiledAclBundle').resolves(compiledAclBundle);
+        });
+
+        it('should load the compiled ACL bundle if not specified', () => {
+            return context.findCompiledAclBundle(businessNetworkDefinition)
+                .then((foundCompiledAclBundle) => {
+                    sinon.assert.calledOnce(context.loadCompiledAclBundle);
+                    sinon.assert.calledWith(context.loadCompiledAclBundle, businessNetworkRecord, businessNetworkDefinition);
+                    foundCompiledAclBundle.should.equal(compiledAclBundle);
+                });
+        });
+
+        it('should use the compiled ACL bundle in the options', () => {
+            const options = {
+                compiledAclBundle: sinon.createStubInstance(CompiledAclBundle)
+            };
+            return context.findCompiledAclBundle(businessNetworkDefinition, options)
+                .then((foundCompiledAclBundle) => {
+                    foundCompiledAclBundle.should.equal(options.compiledAclBundle);
+                });
+        });
+
+    });
+
     describe('#initialize', () => {
 
-        let mockBusinessNetworkDefinition, mockCompiledScriptBundle, mockCompiledQueryBundle, mockSystemRegistries, mockSystemIdentities;
+        let mockBusinessNetworkDefinition, mockCompiledScriptBundle, mockCompiledQueryBundle, mockSystemRegistries, mockSystemIdentities, mockCompiledAclBundle;
 
         beforeEach(() => {
             mockBusinessNetworkDefinition = sinon.createStubInstance(BusinessNetworkDefinition);
             mockCompiledScriptBundle = sinon.createStubInstance(CompiledScriptBundle);
             mockCompiledQueryBundle = sinon.createStubInstance(CompiledQueryBundle);
+            mockCompiledAclBundle = sinon.createStubInstance(CompiledAclBundle);
             sinon.stub(context, 'findBusinessNetworkDefinition').resolves(mockBusinessNetworkDefinition);
             sinon.stub(context, 'findCompiledScriptBundle').resolves(mockCompiledScriptBundle);
             sinon.stub(context, 'findCompiledQueryBundle').resolves(mockCompiledQueryBundle);
+            sinon.stub(context, 'findCompiledAclBundle').resolves(mockCompiledAclBundle);
             sinon.stub(context, 'loadCurrentParticipant').resolves(null);
             let mockDataService = sinon.createStubInstance(DataService);
             sinon.stub(context, 'getDataService').returns(mockDataService);
@@ -382,9 +457,12 @@ describe('Context', () => {
                     sinon.assert.calledWith(context.findCompiledScriptBundle, mockBusinessNetworkDefinition, options);
                     sinon.assert.calledOnce(context.findCompiledQueryBundle);
                     sinon.assert.calledWith(context.findCompiledQueryBundle, mockBusinessNetworkDefinition, options);
+                    sinon.assert.calledOnce(context.findCompiledAclBundle);
+                    sinon.assert.calledWith(context.findCompiledAclBundle, mockBusinessNetworkDefinition, options);
                     context.businessNetworkDefinition.should.equal(mockBusinessNetworkDefinition);
                     context.compiledScriptBundle.should.equal(mockCompiledScriptBundle);
                     context.compiledQueryBundle.should.equal(mockCompiledQueryBundle);
+                    context.compiledAclBundle.should.equal(mockCompiledAclBundle);
                     sinon.assert.calledOnce(context.loadCurrentParticipant);
                     should.equal(context.participant, null);
                     context.sysregistries.should.equal(mockSystemRegistries);
@@ -842,7 +920,7 @@ describe('Context', () => {
             context.getScriptCompiler().should.be.an.instanceOf(ScriptCompiler);
         });
 
-        it('should return an existing registry manager', () => {
+        it('should return an existing script compiler', () => {
             let mockScriptCompiler = sinon.createStubInstance(ScriptCompiler);
             context.scriptCompiler = mockScriptCompiler;
             context.getScriptCompiler().should.equal(mockScriptCompiler);
@@ -866,7 +944,7 @@ describe('Context', () => {
             context.getQueryCompiler().should.be.an.instanceOf(QueryCompiler);
         });
 
-        it('should return an existing registry manager', () => {
+        it('should return an existing query compiler', () => {
             let mockQueryCompiler = sinon.createStubInstance(QueryCompiler);
             context.queryCompiler = mockQueryCompiler;
             context.getQueryCompiler().should.equal(mockQueryCompiler);
@@ -883,6 +961,31 @@ describe('Context', () => {
         });
 
     });
+
+    describe('#getAclCompiler', () => {
+
+        it('should return a new ACL compiler', () => {
+            context.getAclCompiler().should.be.an.instanceOf(AclCompiler);
+        });
+
+        it('should return an existing ACL compiler', () => {
+            let mockAclCompiler = sinon.createStubInstance(AclCompiler);
+            context.aclCompiler = mockAclCompiler;
+            context.getAclCompiler().should.equal(mockAclCompiler);
+        });
+
+    });
+
+    describe('#getCompiledAclBundle', () => {
+
+        it('should return the compiled query bundle', () => {
+            let mockCompiledAclBundle = sinon.createStubInstance(CompiledAclBundle);
+            context.compiledAclBundle = mockCompiledAclBundle;
+            context.getCompiledAclBundle().should.equal(mockCompiledAclBundle);
+        });
+
+    });
+
 
     describe('#transactionStart', () => {
 

--- a/packages/composer-runtime/test/engine.businessnetworks.js
+++ b/packages/composer-runtime/test/engine.businessnetworks.js
@@ -14,7 +14,9 @@
 
 'use strict';
 
+const AclCompiler = require('../lib/aclcompiler');
 const BusinessNetworkDefinition = require('composer-common').BusinessNetworkDefinition;
+const CompiledAclBundle = require('../lib/compiledaclbundle');
 const CompiledQueryBundle = require('../lib/compiledquerybundle');
 const CompiledScriptBundle = require('../lib/compiledscriptbundle');
 const Container = require('../lib/container');
@@ -135,8 +137,14 @@ describe('EngineBusinessNetworks', () => {
             let mockCompiledQueryBundle = sinon.createStubInstance(CompiledQueryBundle);
             mockQueryCompiler.compile.returns(mockCompiledQueryBundle);
             mockContext.getQueryCompiler.returns(mockQueryCompiler);
+            let mockAclCompiler = sinon.createStubInstance(AclCompiler);
+            let mockCompiledAclBundle = sinon.createStubInstance(CompiledAclBundle);
+            mockAclCompiler.compile.returns(mockCompiledAclBundle);
+            mockContext.getAclCompiler.returns(mockAclCompiler);
             sandbox.stub(Context, 'cacheBusinessNetwork');
             sandbox.stub(Context, 'cacheCompiledScriptBundle');
+            sandbox.stub(Context, 'cacheCompiledQueryBundle');
+            sandbox.stub(Context, 'cacheCompiledAclBundle');
             mockRegistryManager.createDefaults.resolves();
             return engine.invoke(mockContext, 'updateBusinessNetwork', ['aGVsbG8gd29ybGQ='])
                 .then((result) => {
@@ -146,6 +154,10 @@ describe('EngineBusinessNetworks', () => {
                     sinon.assert.calledWith(Context.cacheBusinessNetwork, 'dc9c1c09907c36f5379d615ae61c02b46ba254d92edb77cb63bdcc5247ccd01c', mockBusinessNetworkDefinition);
                     sinon.assert.calledOnce(Context.cacheCompiledScriptBundle);
                     sinon.assert.calledWith(Context.cacheCompiledScriptBundle, 'dc9c1c09907c36f5379d615ae61c02b46ba254d92edb77cb63bdcc5247ccd01c', mockCompiledScriptBundle);
+                    sinon.assert.calledOnce(Context.cacheCompiledQueryBundle);
+                    sinon.assert.calledWith(Context.cacheCompiledQueryBundle, 'dc9c1c09907c36f5379d615ae61c02b46ba254d92edb77cb63bdcc5247ccd01c', mockCompiledQueryBundle);
+                    sinon.assert.calledOnce(Context.cacheCompiledAclBundle);
+                    sinon.assert.calledWith(Context.cacheCompiledAclBundle, 'dc9c1c09907c36f5379d615ae61c02b46ba254d92edb77cb63bdcc5247ccd01c', mockCompiledAclBundle);
                     sinon.assert.calledTwice(mockContext.initialize);
                     // Initialize.
                     sinon.assert.calledWith(mockContext.initialize);
@@ -154,6 +166,7 @@ describe('EngineBusinessNetworks', () => {
                         businessNetworkDefinition: mockBusinessNetworkDefinition,
                         compiledScriptBundle: mockCompiledScriptBundle,
                         compiledQueryBundle: mockCompiledQueryBundle,
+                        compiledAclBundle: mockCompiledAclBundle,
                         reinitialize: true
                     });
                     sinon.assert.calledOnce(mockRegistryManager.createDefaults);

--- a/packages/composer-runtime/test/engine.js
+++ b/packages/composer-runtime/test/engine.js
@@ -14,7 +14,9 @@
 
 'use strict';
 
+const AclCompiler = require('../lib/aclcompiler');
 const BusinessNetworkDefinition = require('composer-common').BusinessNetworkDefinition;
+const CompiledAclBundle = require('../lib/compiledaclbundle');
 const CompiledQueryBundle = require('../lib/compiledquerybundle');
 const CompiledScriptBundle = require('../lib/compiledscriptbundle');
 const Container = require('../lib/container');
@@ -147,12 +149,18 @@ describe('Engine', () => {
             let mockCompiledQueryBundle = sinon.createStubInstance(CompiledQueryBundle);
             mockQueryCompiler.compile.returns(mockCompiledQueryBundle);
             mockContext.getQueryCompiler.returns(mockQueryCompiler);
+            let mockAclCompiler = sinon.createStubInstance(AclCompiler);
+            let mockCompiledAclBundle = sinon.createStubInstance(CompiledAclBundle);
+            mockAclCompiler.compile.returns(mockCompiledAclBundle);
+            mockContext.getAclCompiler.returns(mockAclCompiler);
             sysdata.add.withArgs('businessnetwork', sinon.match.any).resolves();
             mockDataService.ensureCollection.withArgs('$sysregistries').resolves(sysregistries);
             mockDataService.ensureCollection.withArgs('$sysidentities').resolves(sysidentities);
             mockRegistryManager.ensure.withArgs('Transaction', 'default', 'Default Transaction Registry').resolves();
             sandbox.stub(Context, 'cacheBusinessNetwork');
             sandbox.stub(Context, 'cacheCompiledScriptBundle');
+            sandbox.stub(Context, 'cacheCompiledQueryBundle');
+            sandbox.stub(Context, 'cacheCompiledAclBundle');
             mockRegistryManager.createDefaults.resolves();
             mockContext.getParticipant.returns(null);
             return engine.init(mockContext, 'init', ['aGVsbG8gd29ybGQ=','{"logLevel": "DEBUG"}'])
@@ -174,6 +182,10 @@ describe('Engine', () => {
                     sinon.assert.calledWith(Context.cacheBusinessNetwork, 'dc9c1c09907c36f5379d615ae61c02b46ba254d92edb77cb63bdcc5247ccd01c', mockBusinessNetworkDefinition);
                     sinon.assert.calledOnce(Context.cacheCompiledScriptBundle);
                     sinon.assert.calledWith(Context.cacheCompiledScriptBundle, 'dc9c1c09907c36f5379d615ae61c02b46ba254d92edb77cb63bdcc5247ccd01c', mockCompiledScriptBundle);
+                    sinon.assert.calledOnce(Context.cacheCompiledQueryBundle);
+                    sinon.assert.calledWith(Context.cacheCompiledQueryBundle, 'dc9c1c09907c36f5379d615ae61c02b46ba254d92edb77cb63bdcc5247ccd01c', mockCompiledQueryBundle);
+                    sinon.assert.calledOnce(Context.cacheCompiledAclBundle);
+                    sinon.assert.calledWith(Context.cacheCompiledAclBundle, 'dc9c1c09907c36f5379d615ae61c02b46ba254d92edb77cb63bdcc5247ccd01c', mockCompiledAclBundle);
                     sinon.assert.calledWith(mockDataService.ensureCollection, '$sysregistries');
                     sinon.assert.calledWith(mockDataService.ensureCollection, '$sysidentities');
                     sinon.assert.calledOnce(mockRegistryManager.ensure);
@@ -184,6 +196,7 @@ describe('Engine', () => {
                         businessNetworkDefinition: mockBusinessNetworkDefinition,
                         compiledScriptBundle: mockCompiledScriptBundle,
                         compiledQueryBundle: mockCompiledQueryBundle,
+                        compiledAclBundle: mockCompiledAclBundle,
                         sysregistries: sysregistries,
                         sysidentities: sysidentities
                     });
@@ -196,7 +209,6 @@ describe('Engine', () => {
 
                 });
         });
-
 
         it('should create system collections and default registries', () => {
             let sysdata = sinon.createStubInstance(DataCollection);
@@ -215,6 +227,10 @@ describe('Engine', () => {
             let mockCompiledQueryBundle = sinon.createStubInstance(CompiledQueryBundle);
             mockQueryCompiler.compile.returns(mockCompiledQueryBundle);
             mockContext.getQueryCompiler.returns(mockQueryCompiler);
+            let mockAclCompiler = sinon.createStubInstance(AclCompiler);
+            let mockCompiledAclBundle = sinon.createStubInstance(CompiledAclBundle);
+            mockAclCompiler.compile.returns(mockCompiledAclBundle);
+            mockContext.getAclCompiler.returns(mockAclCompiler);
             sysdata.add.withArgs('businessnetwork', sinon.match.any).resolves();
             mockDataService.ensureCollection.withArgs('$sysregistries').resolves(sysregistries);
             mockDataService.ensureCollection.withArgs('$sysidentities').resolves(sysidentities);
@@ -249,6 +265,7 @@ describe('Engine', () => {
                         businessNetworkDefinition: mockBusinessNetworkDefinition,
                         compiledScriptBundle: mockCompiledScriptBundle,
                         compiledQueryBundle: mockCompiledQueryBundle,
+                        compiledAclBundle: mockCompiledAclBundle,
                         sysregistries: sysregistries,
                         sysidentities: sysidentities
                     });

--- a/packages/composer-systests/systest/accesscontrols.js
+++ b/packages/composer-systests/systest/accesscontrols.js
@@ -244,12 +244,12 @@ describe('Access control system tests', () => {
             .then(() => {
                 // Alice should not be able to remove Bob's car by ID.
                 return aliceAssetRegistry.remove('BO85 CAR')
-                    .should.be.rejectedWith(/does not have 'DELETE' access/);
+                    .should.be.rejected;
             })
             .then(() => {
                 // Bob should not be able to remove Alice's car by ID.
                 return bobAssetRegistry.remove('AL1 CE')
-                    .should.be.rejectedWith(/does not have 'DELETE' access/);
+                    .should.be.rejected;
             })
             .then(() => {
                 // Alice should only be able to remove Alice's car.
@@ -266,12 +266,12 @@ describe('Access control system tests', () => {
             .then(() => {
                 // Alice should not be able to remove Bob's record by ID.
                 return aliceParticipantRegistry.remove('bob@mailcorp.com')
-                    .should.be.rejectedWith(/does not have 'DELETE' access/);
+                    .should.be.rejected;
             })
             .then(() => {
                 // Bob should not be able to remove Alice's record by ID.
                 return bobParticipantRegistry.remove('alice@mailcorp.com')
-                    .should.be.rejectedWith(/does not have 'DELETE' access/);
+                    .should.be.rejected;
             })
             .then(() => {
                 // Alice should only be able to remove Alice's record.

--- a/packages/composer-systests/systest/accesscontrols.js
+++ b/packages/composer-systests/systest/accesscontrols.js
@@ -239,4 +239,48 @@ describe('Access control system tests', () => {
             });
     });
 
+    it('should be able to enforce delete access permissions on an asset registry', () => {
+        return Promise.resolve()
+            .then(() => {
+                // Alice should not be able to remove Bob's car by ID.
+                return aliceAssetRegistry.remove('BO85 CAR')
+                    .should.be.rejectedWith(/does not have 'DELETE' access/);
+            })
+            .then(() => {
+                // Bob should not be able to remove Alice's car by ID.
+                return bobAssetRegistry.remove('AL1 CE')
+                    .should.be.rejectedWith(/does not have 'DELETE' access/);
+            })
+            .then(() => {
+                // Alice should only be able to remove Alice's car.
+                return aliceAssetRegistry.remove('AL1 CE');
+            })
+            .then(() => {
+                // Bob should only be able to remove Bob's car.
+                return bobAssetRegistry.remove('BO85 CAR');
+            });
+    });
+
+    it('should be able to enforce delete access permissions on a participant registry', () => {
+        return Promise.resolve()
+            .then(() => {
+                // Alice should not be able to remove Bob's record by ID.
+                return aliceParticipantRegistry.remove('bob@mailcorp.com')
+                    .should.be.rejectedWith(/does not have 'DELETE' access/);
+            })
+            .then(() => {
+                // Bob should not be able to remove Alice's record by ID.
+                return bobParticipantRegistry.remove('alice@mailcorp.com')
+                    .should.be.rejectedWith(/does not have 'DELETE' access/);
+            })
+            .then(() => {
+                // Alice should only be able to remove Alice's record.
+                return aliceParticipantRegistry.remove('alice@mailcorp.com');
+            })
+            .then(() => {
+                // Bob should only be able to remove Bob's record.
+                return bobParticipantRegistry.remove('bob@mailcorp.com');
+            });
+    });
+
 });

--- a/packages/composer-systests/systest/data/accesscontrols.acl
+++ b/packages/composer-systests/systest/data/accesscontrols.acl
@@ -24,3 +24,21 @@ rule R3 {
     condition: (p.getIdentifier() === po.getIdentifier())
     action: ALLOW
 }
+
+rule R4 {
+    description: "The owner of a vehicle can delete the vehicle"
+    participant(p): "systest.accesscontrols.SampleParticipant"
+    operation: DELETE
+    resource(a): "systest.accesscontrols.SampleAsset"
+    condition: (testOwnership(a, p))
+    action: ALLOW
+}
+
+rule R5 {
+    description: "A participant can delete themselves"
+    participant(p1): "systest.accesscontrols.SampleParticipant"
+    operation: DELETE
+    resource(p2): "systest.accesscontrols.SampleParticipant"
+    condition: (participantsAreEqual(p1, p2))
+    action: ALLOW
+}

--- a/packages/composer-systests/systest/data/accesscontrols.js
+++ b/packages/composer-systests/systest/data/accesscontrols.js
@@ -1,6 +1,26 @@
 'use strict';
 
 /**
+ * Test that the specified asset is owned by the specified participant.
+ * @param {Resource} asset The asset.
+ * @param {Resource} participant The participant.
+ * @return {boolean} True if yes, false if no.
+ */
+function testOwnership(asset, participant) {
+    return asset.owner.getIdentifier() === participant.getIdentifier();
+}
+
+/**
+ * Test that the specified participants are the same.
+ * @param {Resource} participant1 The first participant.
+ * @param {Resource} participant2 The second participant.
+ * @return {boolean} True if yes, false if no.
+ */
+function participantsAreEqual(participant1, participant2) {
+    return participant1.getIdentifier() === participant2.getIdentifier();
+}
+
+/**
  * Handle the sample transaction.
  * @param {systest.accesscontrols.SampleTransaction} transaction The transaction
  * @transaction

--- a/packages/composer-website/jekylldocs/reference/acl_language.md
+++ b/packages/composer-website/jekylldocs/reference/acl_language.md
@@ -64,7 +64,7 @@ Resource Examples:
 
 **Participant** defines the person or entity that has submitted a transaction for processing. If a Participant is specified they must exist in the Participant Registry. The PARTICIPANT may optionally be bound to a variable for use in a PREDICATE. The special value 'ANY' may be used to denote that participant type checking is not enforced for a rule.
 
-**Condition** is a Boolean JavaScript expression over bound variables. Any JavaScript expression that is legal with the an `if(...)` expression may be used here.
+**Condition** is a Boolean JavaScript expression over bound variables. Any JavaScript expression that is legal with the an `if(...)` expression may be used here. JavaScript expressions used for the condition of an ACL rule can refer to JavaScript utility functions in a script file. This allows a user to easily implement complex access control logic, and re-use the same access control logic functions across multiple ACL rules.
 
 **Action** identifies the action of the rule. It must be one of: ALLOW, DENY.
 


### PR DESCRIPTION
Allow an ACL rule condition to call a utility function defined in a script file.

This allows users to define utility functions which perform complex tests on resources without having to cram it into the condition clause of a ACL rule, and also enables unit testing and code coverage of those utility functions.

Example:

```
rule R5 {
    description: "A participant can delete themselves"
    participant(p1): "systest.accesscontrols.SampleParticipant"
    operation: DELETE
    resource(p2): "systest.accesscontrols.SampleParticipant"
    condition: (participantsAreEqual(p1, p2))
    action: ALLOW
}
```

```
/**
 * Test that the specified participants are the same.
 * @param {Resource} participant1 The first participant.
 * @param {Resource} participant2 The second participant.
 * @return {boolean} True if yes, false if no.
 */
function participantsAreEqual(participant1, participant2) {
    return participant1.getIdentifier() === participant2.getIdentifier();
}
```