### PR TITLE
Allow ACL rules to resolve and navigate relationships

### DIFF
--- a/packages/composer-runtime/lib/accesscontroller.js
+++ b/packages/composer-runtime/lib/accesscontroller.js
@@ -378,15 +378,14 @@ class AccessController {
      */
     matchPredicate(resource, participant, transaction, aclRule) {
         const method = 'matchPredicate';
-        const entry = Math.random() * 1000;
-        LOG.entry(method + entry, resource, participant, transaction, aclRule);
+        LOG.entry(method, resource, participant, transaction, aclRule);
 
         // We want to permit access to related assets and participants, so prepare the resources.
         const compiledAclBundle = this.context.getCompiledAclBundle();
         const resolver = this.context.getResolver();
         let resolverPromise = Promise.resolve(), resolverCallbackCalled = false;
         const resolverCallback = (resolverPromise_) => {
-            LOG.debug(method + entry, 'Got resolver callback');
+            LOG.debug(method, 'Got resolver callback');
             resolverCallbackCalled = true;
             resolverPromise = resolverPromise.then(() => {
                 return resolverPromise_;
@@ -407,6 +406,7 @@ class AccessController {
 
                 // We should always have a participant to prepare.
                 return resolver.prepare(participant, resolverCallback);
+
             })
             .then((preparedParticipant_) => {
 
@@ -426,7 +426,7 @@ class AccessController {
 
                 // Now all the resources are prepared, loop until we are no longer resolving anything.
                 const iteration = () => {
-                    LOG.debug(method + entry, 'Executing compiled ACL predicate');
+                    LOG.debug(method, 'Executing compiled ACL predicate');
                     resolverCallbackCalled = false;
                     const result = compiledAclBundle.execute(aclRule, preparedResource, preparedParticipant, preparedTransaction);
                     if (resolverCallbackCalled) {
@@ -443,7 +443,7 @@ class AccessController {
             .then((result) => {
 
                 // Return the result, which should be a boolean.
-                LOG.exit(method + entry, result);
+                LOG.exit(method, result);
                 return result;
 
             });

--- a/packages/composer-runtime/lib/api.js
+++ b/packages/composer-runtime/lib/api.js
@@ -326,17 +326,23 @@ class Api {
             }
             return context.getCompiledQueryBundle().execute(dataService, identifier, parameters)
                 .then((objects) => {
-                    const resources = objects.map((object) => {
+                    return objects.map((object) => {
                         object = Registry.removeInternalProperties(object);
                         return serializer.fromJSON(object);
-                    }).filter((resource) => {
-                        try {
-                            accessController.check(resource, 'READ');
-                            return true;
-                        } catch (e) {
-                            return false;
-                        }
-                    });
+                    }).reduce((resources, resource) => {
+                        return resources.then((resources) => {
+                            return accessController.check(resource, 'READ')
+                                .then(() => {
+                                    resources.push(resource);
+                                    return resources;
+                                })
+                                .catch((error) => {
+                                    return resources;
+                                });
+                        });
+                    }, Promise.resolve([]));
+                })
+                .then((resources) => {
                     LOG.exit(method, resources);
                     return resources;
                 });

--- a/packages/composer-runtime/lib/callbackrelationship.js
+++ b/packages/composer-runtime/lib/callbackrelationship.js
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Logger = require('composer-common').Logger;
+const Relationship = require('composer-common').Relationship;
+
+const LOG = Logger.getLog('InvalidRelationship');
+
+/**
+ * A callback relationship is a wrapper around a relationship.
+ * This class calls the specified callback whenever a user attempts
+ * to access any of the properties of the relationship, apart from
+ * the identifier.
+ * @protected
+ */
+class CallbackRelationship extends Relationship {
+
+    /**
+     * @callback relationshipCallback
+     * @protected
+     * @param {string} propertyName The property name being accessed.
+     * @param {*} newValue The new value for the property, if it is being set.
+     */
+
+    /**
+     *
+     * @param {Relationship} relationship The relationship to wrap.
+     * @param {relationshipCallback} callback The callback to call when a property is accessed.
+     */
+    constructor(relationship, callback) {
+        super(relationship.getModelManager(), relationship.getNamespace(), relationship.getType(), relationship.getIdentifier());
+        const method = 'constructor';
+        LOG.entry(method, relationship, callback);
+        const classDeclaration = this.getClassDeclaration();
+        const identifierFieldName = classDeclaration.getIdentifierFieldName();
+        const properties = classDeclaration.getProperties();
+        properties.forEach((property) => {
+            const propertyName = property.getName();
+            if (propertyName === identifierFieldName) {
+                LOG.debug(method, 'Defining identifier property', propertyName);
+                Object.defineProperty(this, propertyName, {
+                    configurable: false,
+                    enumerable: true,
+                    get: () => {
+                        return this.$identifier;
+                    },
+                    set: (newValue) => {
+                        this.$identifier = newValue;
+                    }
+                });
+            } else {
+                LOG.debug(method, 'Defining callback property', propertyName);
+                Object.defineProperty(this, propertyName, {
+                    configurable: false,
+                    enumerable: true,
+                    get: () => {
+                        return callback(propertyName);
+                    },
+                    set: (newValue) => {
+                        return callback(propertyName, newValue);
+                    }
+                });
+            }
+        });
+        LOG.exit(method);
+    }
+
+}
+
+module.exports = CallbackRelationship;

--- a/packages/composer-runtime/lib/context.js
+++ b/packages/composer-runtime/lib/context.js
@@ -621,7 +621,7 @@ class Context {
      */
     getResolver() {
         if (!this.resolver) {
-            this.resolver = new Resolver(this.getIntrospector(), this.getRegistryManager());
+            this.resolver = new Resolver(this.getFactory(), this.getIntrospector(), this.getRegistryManager());
         }
         return this.resolver;
     }
@@ -706,7 +706,7 @@ class Context {
      */
     getAccessController() {
         if (!this.accessController) {
-            this.accessController = new AccessController(this.getAclManager(), this.getCompiledAclBundle());
+            this.accessController = new AccessController(this);
         }
         return this.accessController;
     }

--- a/packages/composer-runtime/lib/engine.resources.js
+++ b/packages/composer-runtime/lib/engine.resources.js
@@ -302,15 +302,15 @@ class EngineResources {
             .then((resources) => {
                 let resolver = context.getResolver();
                 return resources.reduce((result, resource) => {
-                    return result.then(() => {
+                    return result.then((resources) => {
                         LOG.debug(method, 'Resolving resource', resource.getFullyQualifiedIdentifier());
-                        return resolver.resolve(resource);
+                        return resolver.resolve(resource)
+                            .then((resolved) => {
+                                resources.push(resolved);
+                                return resources;
+                            });
                     });
-                }, Promise.resolve())
-                .then(() => {
-                    LOG.debug(method, 'Resolved all resources', resources.length);
-                    return resources;
-                });
+                }, Promise.resolve([]));
             })
             .then((resources) => {
                 return resources.map((resource) => {

--- a/packages/composer-runtime/lib/engine.transactions.js
+++ b/packages/composer-runtime/lib/engine.transactions.js
@@ -43,7 +43,7 @@ class EngineTransactions {
 
         // Find the default transaction registry.
         let registryManager = context.getRegistryManager();
-        let transaction = null, resolvedTransaction = null;
+        let transaction = null;
 
         // Parse the transaction from the JSON string..
         LOG.debug(method, 'Parsing transaction from JSON');
@@ -54,17 +54,14 @@ class EngineTransactions {
         // First we parse *our* copy, that is not resolved. This is the copy that gets added to the
         // transaction registry, and is the one in the context (for adding log entries).
         transaction = context.getSerializer().fromJSON(transactionData);
-        // Then we parse the *users* copy, that is resolved, and they can modify to their hearts content.
-        // This is only given to the user, and is discarded afterwards.
-        resolvedTransaction = context.getSerializer().fromJSON(transactionData);
 
         // Store the transaction in the context.
         context.setTransaction(transaction);
 
         // Resolve the users copy of the transaction.
-        LOG.debug(method, 'Parsed transaction, resolving it', resolvedTransaction);
-        return context.getResolver().resolve(resolvedTransaction)
-            .then(() => {
+        LOG.debug(method, 'Parsed transaction, resolving it', transaction);
+        return context.getResolver().resolve(transaction)
+            .then((resolvedTransaction) => {
 
                 // Execute the transaction.
                 let api = context.getApi();

--- a/packages/composer-runtime/lib/invalidrelationship.js
+++ b/packages/composer-runtime/lib/invalidrelationship.js
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Logger = require('composer-common').Logger;
+const Relationship = require('composer-common').Relationship;
+
+const LOG = Logger.getLog('InvalidRelationship');
+
+/**
+ * An invalid relationship is a wrapper around a relationship that
+ * could not be resolved due to a missing resource or lack of permission.
+ * This class throws errors whenever a user attempts to access any of
+ * the properties of the relationship, apart from the identifier.
+ * @protected
+ */
+class InvalidRelationship extends Relationship {
+
+    /**
+     *
+     * @param {Relationship} relationship The relationship to wrap.
+     * @param {Error} error The error to throw when the relationship is accessed.
+     */
+    constructor(relationship, error) {
+        super(relationship.getModelManager(), relationship.getNamespace(), relationship.getType(), relationship.getIdentifier());
+        const method = 'constructor';
+        LOG.entry(method, relationship, error);
+        const classDeclaration = this.getClassDeclaration();
+        const identifierFieldName = classDeclaration.getIdentifierFieldName();
+        const properties = classDeclaration.getProperties();
+        properties.forEach((property) => {
+            const propertyName = property.getName();
+            if (propertyName === identifierFieldName) {
+                LOG.debug(method, 'Defining identifier property', propertyName);
+                Object.defineProperty(this, propertyName, {
+                    configurable: false,
+                    enumerable: true,
+                    get: () => {
+                        return this.$identifier;
+                    },
+                    set: (newValue) => {
+                        this.$identifier = newValue;
+                    }
+                });
+            } else {
+                LOG.debug(method, 'Defining invalid property', propertyName);
+                Object.defineProperty(this, propertyName, {
+                    configurable: false,
+                    enumerable: true,
+                    get: () => {
+                        throw error;
+                    },
+                    set: () => {
+                        throw error;
+                    }
+                });
+            }
+        });
+        LOG.exit(method);
+    }
+
+}
+
+module.exports = InvalidRelationship;

--- a/packages/composer-runtime/lib/resolver.js
+++ b/packages/composer-runtime/lib/resolver.js
@@ -15,13 +15,16 @@
 'use strict';
 
 const AssetDeclaration = require('composer-common').AssetDeclaration;
+const CallbackRelationship = require('./callbackrelationship');
+const Concept = require('composer-common').Concept;
+const InvalidRelationship = require('./invalidrelationship');
 const Logger = require('composer-common').Logger;
 const ParticipantDeclaration = require('composer-common').ParticipantDeclaration;
 const Relationship = require('composer-common').Relationship;
 const Resource = require('composer-common').Resource;
 const TransactionDeclaration = require('composer-common').TransactionDeclaration;
 
-const LOG = Logger.getLog('Context');
+const LOG = Logger.getLog('Resolver');
 
 /**
  * A class for resolving resources and their relationships to other resources.
@@ -33,15 +36,51 @@ class Resolver {
 
     /**
      * Constructor.
+     * @param {Factory} factory The factory to use.
      * @param {Introspector} introspector The introspector to use.
      * @param {RegistryManager} registryManager The registry manager to use.
      */
-    constructor(introspector, registryManager) {
+    constructor(factory, introspector, registryManager) {
         const method = 'constructor';
         LOG.entry(method, registryManager);
+        this.factory = factory;
         this.introspector = introspector;
         this.registryManager = registryManager;
         LOG.exit(method);
+    }
+
+    /**
+     * @callback prepareCallback
+     * @protected
+     * @param {Promise} promise A promise that is resolved when resolving is complete.
+     */
+
+    /**
+     * Prepare the specified resource and all of its relationships. This means that all
+     * relationships will be replaced with wrappers that lazily trigger the resolving process.
+     * @param {Resource|Relationship} identifiable The identifiable to resolve.
+     * @param {prepareCallback} callback The callback to call if and when resolving occurs.
+     * @return {Promise} A promise that is resolved immediately.
+     */
+    prepare(identifiable, callback) {
+        const method = 'prepare';
+        LOG.entry(method, identifiable.toString());
+        let resolveState = {
+            cachedResources: new Map(),
+            prepare: true,
+            prepareCallback: callback,
+            preparePromise: Promise.resolve()
+        };
+        if (identifiable instanceof Resource) {
+            return this.resolveResourceOrConcept(identifiable, resolveState)
+                .then((result) => {
+                    LOG.exit(method, result.toString());
+                    return result;
+                });
+        } else {
+            LOG.error(method, 'unsupported type for identifiable');
+            throw new Error('unsupported type for identifiable');
+        }
     }
 
     /**
@@ -57,8 +96,7 @@ class Resolver {
             cachedResources: new Map()
         };
         if (identifiable instanceof Resource) {
-            resolveState.cachedResources.set(identifiable.getFullyQualifiedIdentifier(), identifiable);
-            return this.resolveResource(identifiable, resolveState)
+            return this.resolveResourceOrConcept(identifiable, resolveState)
                 .then((result) => {
                     LOG.exit(method, result.toString());
                     return result;
@@ -84,78 +122,207 @@ class Resolver {
      * @return {Promise} A promise that is resolved with a {@link Resource} object,
      * or rejected with an error.
      */
-    resolveResource(resource, resolveState) {
-        const method = 'resolveResource';
+    resolveResourceOrConcept(resource, resolveState) {
+        const method = 'resolveResourceOrConcept';
         LOG.entry(method, resource.toString(), resolveState);
+
+        // Create a new resource, we don't want to modify the original.
+        let newResource;
+        if (resource instanceof Resource) {
+
+            // Check we haven't cached this resource already.
+            let fqi = resource.getFullyQualifiedIdentifier();
+            if (resolveState.cachedResources.has(fqi)) {
+                LOG.debug(method, 'Target resource is already present in cache', fqi);
+                let resource = resolveState.cachedResources.get(fqi);
+                LOG.exit(method, resource.toString());
+                return Promise.resolve(resource);
+            }
+
+            // Create a new resource and cache that.
+            newResource = this.factory.newResource(resource.getNamespace(), resource.getType(), resource.getIdentifier());
+            resolveState.cachedResources.set(fqi, newResource);
+
+        } else {
+            newResource = this.factory.newConcept(resource.getNamespace(), resource.getType());
+        }
+
+        // Iterate over all the properties of the resource.
         let classDeclaration = resource.getClassDeclaration();
         return classDeclaration.getProperties().reduce((result, property) => {
 
             // Get the property value.
             LOG.debug(method, 'Looking at property', property.getName());
             let value = resource[property.getName()];
+
+            // Shortcut if the value is not set.
+            if (value === undefined) {
+                return result;
+            }
+
+            // Process the value accordingly based on its type.
             if (value instanceof Resource) {
 
                 // Replace the property value with the resolved resource.
                 LOG.debug(method, 'Property value is a resource, resolving', value.toString());
                 return result.then(() => {
-                    return this.resolveResource(value, resolveState);
+                    return this.resolveResourceOrConcept(value, resolveState);
                 }).then((newValue) => {
-                    resource[property.getName()] = newValue;
+                    newResource[property.getName()] = newValue;
+                });
+
+            } else if (value instanceof Concept) {
+
+                // Replace the property value with the resolved resource.
+                LOG.debug(method, 'Property value is a concept, resolving', value.toString());
+                return result.then(() => {
+                    return this.resolveResourceOrConcept(value, resolveState);
+                }).then((newValue) => {
+                    newResource[property.getName()] = newValue;
                 });
 
             } else if (value instanceof Relationship) {
+
+                // If we are called as part of prepare, we set up a lazy relationship.
+                if (resolveState.prepare) {
+                    const newValue = new CallbackRelationship(value, (propertyName) => {
+                        LOG.debug(method, 'Relationship callback, resolving', newValue, propertyName);
+                        const result = resolveState.preparePromise.then(() => {
+                            return this.resolveRelationship(newValue, resolveState);
+                        }).then((resolvedValue) => {
+                            LOG.debug(method, 'Relationship callback, resolved', resolvedValue, propertyName);
+                            newResource[property.getName()] = resolvedValue;
+                            return resolvedValue[propertyName];
+                        });
+                        resolveState.preparePromise = result;
+                        resolveState.prepareCallback(result);
+                        return result;
+                    });
+                    newResource[property.getName()] = newValue;
+                    return result;
+                }
 
                 // Replace the property value with the resolved relationship.
                 LOG.debug(method, 'Property value is a relationship, resolving', value.toString());
                 return result.then(() => {
                     return this.resolveRelationship(value, resolveState);
                 }).then((newValue) => {
-                    resource[property.getName()] = newValue;
+                    newResource[property.getName()] = newValue;
                 });
 
             } else if (Array.isArray(value)) {
 
                 // Go through each item in the array.
                 LOG.debug(method, 'Property value is an array, iterating over values', value.length);
-                return value.reduce((arrayReduceResult, item, index) => {
-
-                    // Handle the array item.
-                    if (item instanceof Resource) {
-
-                        // Replace the property value with the resolved resource.
-                        LOG.debug(method, 'Array item is a resource, resolving', item.toString());
-                        return arrayReduceResult.then(() => {
-                            return this.resolveResource(item, resolveState);
-                        }).then((newItem) => {
-                            value[index] = newItem;
-                        });
-
-                    } else if (item instanceof Relationship) {
-
-                        // Replace the property value with the resolved relationship.
-                        LOG.debug(method, 'Property value is a relationship, resolving', item.toString());
-                        return arrayReduceResult.then(() => {
-                            return this.resolveRelationship(item, resolveState);
-                        }).then((newItem) => {
-                            value[index] = newItem;
-                        });
-
-                    } else {
-                        LOG.debug(method, 'Array item is neither a resource or a relationship, ignoring', item);
-                        return arrayReduceResult;
-                    }
-
-                }, result);
+                return result.then(() => {
+                    return this.resolveArray(value, resolveState);
+                })
+                .then((newValue) => {
+                    newResource[property.getName()] = newValue;
+                });
 
             } else {
+
+                // Copy the original value across.
                 LOG.debug(method, 'Property value is neither a resource or a relationship, ignoring', value);
+                newResource[property.getName()] = value;
                 return result;
+
             }
 
         }, Promise.resolve())
             .then(() => {
                 LOG.exit(method, resource.toString());
-                return resource;
+                return newResource;
+            });
+    }
+
+    /**
+     * Resolve all of the elements in the specified array.
+     * @private
+     * @param {*} array The array to resolve.
+     * @param {Object} resolveState The current resolve state.
+     * @param {Map} resolveState.cachedResources The cache of resolved resources.
+     * @return {Promise} A promise that is resolved with an array of resolved objects,
+     * or rejected with an error.
+     */
+    resolveArray(array, resolveState) {
+        const method = 'resolveArray';
+        LOG.entry(method, array, resolveState);
+        return array.reduce((promise, item, index) => {
+
+            // Check the type of the item in the array.
+            if (item instanceof Resource) {
+
+                // Replace the property value with the resolved resource.
+                LOG.debug(method, 'Array item is a resource, resolving', item.toString());
+                return promise.then((newArray) => {
+                    return this.resolveResourceOrConcept(item, resolveState)
+                        .then((newItem) => {
+                            newArray.push(newItem);
+                            return newArray;
+                        });
+                });
+
+            } else if (item instanceof Concept) {
+
+                // Replace the property value with the resolved concept.
+                LOG.debug(method, 'Array item is a concept, resolving', item.toString());
+                return promise.then((newArray) => {
+                    return this.resolveResourceOrConcept(item, resolveState)
+                        .then((newItem) => {
+                            newArray.push(newItem);
+                            return newArray;
+                        });
+                });
+
+            } else if (item instanceof Relationship) {
+
+                // Replace the property value with the resolved relationship.
+                LOG.debug(method, 'Property value is a relationship, resolving', item.toString());
+                return promise.then((newArray) => {
+
+                    // If we are called as part of prepare, we set up a lazy relationship.
+                    if (resolveState.prepare) {
+                        const newIndex = newArray.length;
+                        const newItem = new CallbackRelationship(item, (propertyName) => {
+                            LOG.debug(method, 'Relationship callback, resolving', newItem, propertyName);
+                            const result = resolveState.preparePromise.then(() => {
+                                return this.resolveRelationship(newItem, resolveState);
+                            }).then((resolvedItem) => {
+                                newArray[newIndex] = resolvedItem;
+                                return resolvedItem[propertyName];
+                            });
+                            resolveState.preparePromise = result;
+                            resolveState.prepareCallback(result);
+                            return result;
+                        });
+                        newArray.push(newItem);
+                        return newArray;
+                    }
+
+                    return this.resolveRelationship(item, resolveState)
+                        .then((newItem) => {
+                            newArray.push(newItem);
+                            return newArray;
+                        });
+                });
+
+            } else {
+
+                // Copy the original value across.
+                LOG.debug(method, 'Array item is neither a resource or a relationship, ignoring', item);
+                return promise.then((newArray) => {
+                    newArray.push(item);
+                    return newArray;
+                });
+
+            }
+
+        }, Promise.resolve([]))
+            .then((result) => {
+                LOG.exit(method, result);
+                return result;
             });
     }
 
@@ -205,6 +372,8 @@ class Resolver {
     resolveRelationship(relationship, resolveState) {
         const method = 'resolveRelationship';
         LOG.entry(method, relationship.toString(), resolveState);
+
+        // Check the cache for an existing resolved relationship.
         let fqi = relationship.getFullyQualifiedIdentifier();
         if (resolveState.cachedResources.has(fqi)) {
             LOG.debug(method, 'Target resource is already present in cache', fqi);
@@ -212,6 +381,8 @@ class Resolver {
             LOG.exit(method, resource.toString());
             return Promise.resolve(resource);
         }
+
+        // Nope, need to resolve it!
         return this.getRegistryForRelationship(relationship)
             .then((registry) => {
                 let resourceId = relationship.getIdentifier();
@@ -219,20 +390,26 @@ class Resolver {
                 return registry.get(resourceId);
             })
             .then((resource) => {
-                LOG.debug(method, 'Got resource from registry, adding to cache');
-                resolveState.cachedResources.set(fqi, resource);
                 if (resolveState.skipRecursion) {
                     LOG.debug(method, 'Got resource from registry, but skipping resolve');
+                    resolveState.cachedResources.set(fqi, resource);
                     return resource;
                 } else {
                     LOG.debug(method, 'Got resource from registry, resolving');
-                    return this.resolveResource(resource, resolveState);
+                    return this.resolveResourceOrConcept(resource, resolveState);
                 }
             })
             .then((resource) => {
                 LOG.exit(method, resource.toString());
                 return resource;
+            })
+            .catch((error) => {
+                LOG.error(method, 'Failed to resolve relationship', error);
+                const invalid = new InvalidRelationship(relationship, error);
+                LOG.exit(method, invalid);
+                return invalid;
             });
+
     }
 
 }

--- a/packages/composer-runtime/test/accesscontroller.js
+++ b/packages/composer-runtime/test/accesscontroller.js
@@ -19,11 +19,16 @@ const AccessException = require('../lib/accessexception');
 const AclFile = require('composer-common').AclFile;
 const AclManager = require('composer-common').AclManager;
 const CompiledAclBundle = require('../lib/compiledaclbundle');
+const Context = require('../lib/context');
 const Factory = require('composer-common').Factory;
 const ModelManager = require('composer-common').ModelManager;
+const Resolver = require('../lib/resolver');
 
-require('chai').should();
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-as-promised'));
 const sinon = require('sinon');
+require('sinon-as-promised');
 
 describe('AccessController', () => {
 
@@ -38,6 +43,8 @@ describe('AccessController', () => {
     let transaction2;
     let controller;
     let mockCompiledAclBundle;
+    let mockResolver;
+    let mockContext;
 
     beforeEach(() => {
         modelManager = new ModelManager();
@@ -105,7 +112,12 @@ describe('AccessController', () => {
         transaction2 = factory.newResource('org.acme.test', 'TestTransaction2', 'T0123');
         mockCompiledAclBundle = sinon.createStubInstance(CompiledAclBundle);
         mockCompiledAclBundle.execute.returns(true);
-        controller = new AccessController(aclManager, mockCompiledAclBundle);
+        mockResolver = sinon.createStubInstance(Resolver);
+        mockContext = sinon.createStubInstance(Context);
+        mockContext.getAclManager.returns(aclManager);
+        mockContext.getCompiledAclBundle.returns(mockCompiledAclBundle);
+        mockContext.getResolver.returns(mockResolver);
+        controller = new AccessController(mockContext);
         controller.setParticipant(participant);
         controller.setTransaction(transaction);
     });
@@ -155,11 +167,11 @@ describe('AccessController', () => {
 
         it('should do nothing if there is no participant', () => {
             controller.setParticipant(null);
-            controller.check(asset, 'READ');
+            return controller.check(asset, 'READ');
         });
 
         it('should do nothing if there is no access control file', () => {
-            controller.check(asset, 'READ');
+            return controller.check(asset, 'READ');
         });
 
         it('should throw if there are no access control rules', () => {
@@ -167,25 +179,27 @@ describe('AccessController', () => {
             // an ACL file, and then stub the ACL manager to pretend like no rules exist.
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW }');
             sinon.stub(aclManager, 'getAclRules').returns([]);
-            (() => {
-                controller.check(asset, 'READ');
-            }).should.throw(AccessException, /does not have/);
+            return controller.check(asset, 'READ')
+                .should.be.rejectedWith(AccessException, /does not have/);
         });
 
         it('should not throw if there is one matching ALLOW access control rule', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}');
             let spy = sinon.spy(controller, 'checkRule');
-            controller.check(asset, 'READ');
-            sinon.assert.calledOnce(spy);
+            return controller.check(asset, 'READ')
+                .then(() => {
+                    sinon.assert.calledOnce(spy);
+                });
         });
 
         it('should throw if there is one matching DENY access control rule', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: DENY}');
             let spy = sinon.spy(controller, 'checkRule');
-            (() => {
-                controller.check(asset, 'READ');
-            }).should.throw(AccessException, /does not have/);
-            sinon.assert.calledOnce(spy);
+            return controller.check(asset, 'READ')
+                .should.be.rejectedWith(AccessException, /does not have/)
+                .then(() => {
+                    sinon.assert.calledOnce(spy);
+                });
         });
 
         it('should not throw if there is two non-matching ALLOW access control rules followed by one matching ALLOW access control rule', () => {
@@ -195,8 +209,10 @@ describe('AccessController', () => {
                 'rule R3 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n'
             );
             let spy = sinon.spy(controller, 'checkRule');
-            controller.check(asset, 'READ');
-            sinon.assert.calledThrice(spy);
+            return controller.check(asset, 'READ')
+                .then(() => {
+                    sinon.assert.calledThrice(spy);
+                });
         });
 
         it('should not throw if there is two non-matching DENY access control rules followed by one matching ALLOW access control rule', () => {
@@ -206,8 +222,10 @@ describe('AccessController', () => {
                 'rule R3 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n'
             );
             let spy = sinon.spy(controller, 'checkRule');
-            controller.check(asset, 'READ');
-            sinon.assert.calledThrice(spy);
+            return controller.check(asset, 'READ')
+                .then(() => {
+                    sinon.assert.calledThrice(spy);
+                });
         });
 
         it('should throw if there is two non-matching ALLOW access control rules followed by one matching DENY access control rule', () => {
@@ -217,10 +235,11 @@ describe('AccessController', () => {
                 'rule R3 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: DENY}\n'
             );
             let spy = sinon.spy(controller, 'checkRule');
-            (() => {
-                controller.check(asset, 'READ');
-            }).should.throw(AccessException, /does not have/);
-            sinon.assert.calledThrice(spy);
+            return controller.check(asset, 'READ')
+                .should.be.rejectedWith(AccessException, /does not have/)
+                .then(() => {
+                    sinon.assert.calledThrice(spy);
+                });
         });
 
         it('should not throw if there is one matching ALLOW access control rule followed by two non-matching ALLOW access control rules', () => {
@@ -230,8 +249,10 @@ describe('AccessController', () => {
                 'rule R3 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: UPDATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n'
             );
             let spy = sinon.spy(controller, 'checkRule');
-            controller.check(asset, 'READ');
-            sinon.assert.calledOnce(spy);
+            return controller.check(asset, 'READ')
+                .then(() => {
+                    sinon.assert.calledOnce(spy);
+                });
         });
 
         it('should not throw if there is one matching ALLOW access control rule followed by two non-matching DENY access control rules', () => {
@@ -241,8 +262,10 @@ describe('AccessController', () => {
                 'rule R3 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: UPDATE resource: "org.acme.test.TestAsset#A1234" action: DENY}\n'
             );
             let spy = sinon.spy(controller, 'checkRule');
-            controller.check(asset, 'READ');
-            sinon.assert.calledOnce(spy);
+            return controller.check(asset, 'READ')
+                .then(() => {
+                    sinon.assert.calledOnce(spy);
+                });
         });
 
         it('should throw if there is one matching DENY access control rule followed by two non-matching ALLOW access control rules', () => {
@@ -252,10 +275,11 @@ describe('AccessController', () => {
                 'rule R3 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: UPDATE resource: "org.acme.test.TestAsset#A1234" action: ALLOW}\n'
             );
             let spy = sinon.spy(controller, 'checkRule');
-            (() => {
-                controller.check(asset, 'READ');
-            }).should.throw(AccessException, /does not have/);
-            sinon.assert.calledOnce(spy);
+            return controller.check(asset, 'READ')
+                .should.be.rejectedWith(AccessException, /does not have/)
+                .then(() => {
+                    sinon.assert.calledOnce(spy);
+                });
         });
 
     });
@@ -265,55 +289,64 @@ describe('AccessController', () => {
         it('should return false if the noun is not matched', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A5678" action: ALLOW}');
             let spy = sinon.spy(controller, 'matchNoun');
-            controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
-                .should.be.false;
-            sinon.assert.calledOnce(spy);
+            return controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
+                .should.eventually.be.false
+                .then(() => {
+                    sinon.assert.calledOnce(spy);
+                });
         });
 
         it('should return false if the verb is not matched', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}');
             let spy = sinon.spy(controller, 'matchVerb');
-            controller.checkRule(asset, 'CREATE', participant, transaction, aclManager.getAclRules()[0])
-                .should.be.false;
-            sinon.assert.calledOnce(spy);
+            return controller.checkRule(asset, 'CREATE', participant, transaction, aclManager.getAclRules()[0])
+                .should.eventually.be.false
+                .then(() => {
+                    sinon.assert.calledOnce(spy);
+                });
         });
 
         it('should return false if the participant is not matched', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P1234" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}');
             let spy = sinon.spy(controller, 'matchParticipant');
-            controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
-                .should.be.false;
-            sinon.assert.calledOnce(spy);
+            return controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
+                .should.eventually.be.false
+                .then(() => {
+                    sinon.assert.calledOnce(spy);
+                });
         });
 
         it('should return false if the transaction is not matched', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction: "org.acme.test.TestTransaction3" action: ALLOW}');
             let spy = sinon.spy(controller, 'matchTransaction');
-            controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
-                .should.be.false;
-            sinon.assert.calledOnce(spy);
+            return controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
+                .should.eventually.be.false
+                .then(() => {
+                    sinon.assert.calledOnce(spy);
+                });
         });
 
         it('should return false if the predicate is not matched', () => {
             mockCompiledAclBundle.execute.returns(false);
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" condition: (false) action: ALLOW}');
             let spy = sinon.spy(controller, 'matchPredicate');
-            controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
-                .should.be.false;
-            sinon.assert.calledOnce(spy);
+            return controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
+                .should.eventually.be.false
+                .then(() => {
+                    sinon.assert.calledOnce(spy);
+                });
         });
 
         it('should return true if the rule matches and ALLOW is specified', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" condition: (true) action: ALLOW}');
-            controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
-                .should.be.true;
+            return controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
+                .should.eventually.be.true;
         });
 
         it('should throw if the rule matches and DENY is specified', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A1234" action: DENY}');
-            (() => {
-                controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0]);
-            }).should.throw(AccessException, /does not have/);
+            return controller.checkRule(asset, 'READ', participant, transaction, aclManager.getAclRules()[0])
+                .should.be.rejectedWith(AccessException, /does not have/);
         });
 
     });
@@ -572,12 +605,52 @@ describe('AccessController', () => {
 
     describe('#matchPredicate', () => {
 
-        it('should call the compiled ACL bundle', () => {
+        it('should call the compiled ACL bundle with an asset, participant, and transaction', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}');
-            controller.matchPredicate(asset, participant, transaction, aclManager.getAclRules()[0])
-                .should.be.true;
-            sinon.assert.calledOnce(mockCompiledAclBundle.execute);
-            sinon.assert.calledWith(mockCompiledAclBundle.execute, aclManager.getAclRules()[0], asset, participant, transaction);
+            mockResolver.prepare.withArgs(asset).resolves(asset2);
+            mockResolver.prepare.withArgs(participant).resolves(participant2);
+            mockResolver.prepare.withArgs(transaction).resolves(transaction2);
+            return controller.matchPredicate(asset, participant, transaction, aclManager.getAclRules()[0])
+                .should.eventually.be.true
+                .then(() => {
+                    sinon.assert.calledOnce(mockCompiledAclBundle.execute);
+                    sinon.assert.calledWith(mockCompiledAclBundle.execute, aclManager.getAclRules()[0], asset2, participant2, transaction2);
+                });
+        });
+
+        it('should call the compiled ACL bundle with an asset and participant', () => {
+            setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}');
+            mockResolver.prepare.withArgs(asset).resolves(asset2);
+            mockResolver.prepare.withArgs(participant).resolves(participant2);
+            return controller.matchPredicate(asset, participant, undefined, aclManager.getAclRules()[0])
+                .should.eventually.be.true
+                .then(() => {
+                    sinon.assert.calledOnce(mockCompiledAclBundle.execute);
+                    sinon.assert.calledWith(mockCompiledAclBundle.execute, aclManager.getAclRules()[0], asset2, participant2, undefined);
+                });
+        });
+
+        it('should call the compiled ACL bundle and lazily resolve relationships as they are accessed', () => {
+            setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}');
+            mockResolver.prepare.withArgs(asset).resolves(asset2);
+            mockResolver.prepare.withArgs(participant).resolves(participant2);
+            mockResolver.prepare.withArgs(transaction).resolves(transaction2);
+            const originalExecute = mockCompiledAclBundle.execute;
+            let iterations = 3;
+            mockCompiledAclBundle.execute = (aclRule, asset, participant, transaction) => {
+                if (iterations) {
+                    iterations--;
+                    mockResolver.prepare.args[iterations][1](Promise.resolve());
+                }
+                return originalExecute(aclRule, asset, participant, transaction);
+            };
+            return controller.matchPredicate(asset, participant, transaction, aclManager.getAclRules()[0])
+                .should.eventually.be.true
+                .then(() => {
+                    mockCompiledAclBundle.execute = originalExecute;
+                    sinon.assert.callCount(mockCompiledAclBundle.execute, 4);
+                    sinon.assert.calledWith(mockCompiledAclBundle.execute, aclManager.getAclRules()[0], asset2, participant2, transaction2);
+                });
         });
 
     });

--- a/packages/composer-runtime/test/api.js
+++ b/packages/composer-runtime/test/api.js
@@ -70,6 +70,7 @@ describe('Api', () => {
         mockDataService = sinon.createStubInstance(DataService);
         mockContext.getDataService.returns(mockDataService);
         mockAccessController = sinon.createStubInstance(AccessController);
+        mockAccessController.check.resolves();
         mockContext.getAccessController.returns(mockAccessController);
         mockCompiledQueryBundle = sinon.createStubInstance(CompiledQueryBundle);
         mockContext.getCompiledQueryBundle.returns(mockCompiledQueryBundle);
@@ -251,7 +252,7 @@ describe('Api', () => {
                 resource.$identifier = 'id' + i;
                 mockSerializer.fromJSON.withArgs(filteredObject).returns(resource);
                 if (i % 2 === 0) {
-                    mockAccessController.check.withArgs(resource, 'READ').throws(new Error('access denied'));
+                    mockAccessController.check.withArgs(resource, 'READ').rejects(new Error('access denied'));
                 } else {
                     mockResources.push(resource);
                 }

--- a/packages/composer-runtime/test/callbackrelationship.js
+++ b/packages/composer-runtime/test/callbackrelationship.js
@@ -1,0 +1,189 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const CallbackRelationship = require('../lib/callbackrelationship');
+const Factory = require('composer-common').Factory;
+const ModelManager = require('composer-common').ModelManager;
+const Relationship = require('composer-common').Relationship;
+
+require('chai').should();
+const sinon = require('sinon');
+
+describe('CallbackRelationship', () => {
+
+    let modelManager;
+    let factory;
+    let relationship;
+    let cb;
+
+    beforeEach(() => {
+        modelManager = new ModelManager();
+        modelManager.addModelFile(`namespace org.acme.sample
+
+        concept SampleConcept {
+            o String value
+        }
+
+        participant SampleParticipant identified by participantId {
+            o String participantId
+            o String value
+        }
+
+        asset SampleAsset identified by assetId {
+            o String assetId
+            o String value
+            o String[] values
+            o SampleConcept concept
+            o SampleConcept[] concepts
+            --> SampleParticipant owner
+            --> SampleParticipant[] owners
+        }`);
+        factory = new Factory(modelManager);
+        cb = sinon.stub();
+        relationship = new CallbackRelationship(new Relationship(modelManager, 'org.acme.sample', 'SampleAsset', 'ASSET_1'), cb);
+    });
+
+    describe('#constructor', () => {
+
+        it('should be a relationship', () => {
+            relationship.should.be.an.instanceOf(Relationship);
+        });
+
+        it('should not call the callback when attempting to get the identifier', () => {
+            relationship.getIdentifier().should.equal('ASSET_1');
+            relationship.assetId.should.equal('ASSET_1');
+            sinon.assert.notCalled(cb);
+        });
+
+        it('should not call the callback when attempting to set the identifier', () => {
+            relationship.setIdentifier('ASSET_X');
+            relationship.getIdentifier().should.equal('ASSET_X');
+            relationship.assetId = 'ASSET_Y';
+            relationship.getIdentifier().should.equal('ASSET_Y');
+            sinon.assert.notCalled(cb);
+        });
+
+        it('should call the callback when attempting to get the primitive value', () => {
+            cb.returns('hello');
+            relationship.value === 'hello';
+            sinon.assert.calledOnce(cb);
+            sinon.assert.calledWith(cb, 'value');
+            relationship.value.should.equal('hello');
+        });
+
+        it('should call the callback when attempting to set the primitive value', () => {
+            cb.returns('hello');
+            relationship.value = 'hello';
+            sinon.assert.calledOnce(cb);
+            sinon.assert.calledWith(cb, 'value', 'hello');
+            relationship.value.should.equal('hello');
+        });
+
+        it('should call the callback when attempting to get the primitive array value', () => {
+            cb.returns([ 'hello', 'world' ]);
+            relationship.values[1] === 'hello';
+            sinon.assert.calledOnce(cb);
+            sinon.assert.calledWith(cb, 'values');
+            relationship.values.should.deep.equal([ 'hello', 'world' ]);
+        });
+
+        it('should call the callback when attempting to set the primitive array value', () => {
+            cb.returns([ 'hello', 'world' ]);
+            relationship.values[1] = 'world';
+            sinon.assert.calledOnce(cb);
+            sinon.assert.calledWith(cb, 'values');
+            relationship.values.should.deep.equal([ 'hello', 'world' ]);
+        });
+
+        it('should call the callback when attempting to get the concept value', () => {
+            const concept = factory.newConcept('org.acme.sample', 'SampleConcept');
+            cb.returns(concept);
+            relationship.concept.value === 'hello';
+            sinon.assert.calledOnce(cb);
+            sinon.assert.calledWith(cb, 'concept');
+            relationship.concept.should.equal(concept);
+        });
+
+        it('should call the callback when attempting to set the concept value', () => {
+            const concept = factory.newConcept('org.acme.sample', 'SampleConcept');
+            cb.returns(concept);
+            relationship.concept.value = 'hello';
+            sinon.assert.calledOnce(cb);
+            sinon.assert.calledWith(cb, 'concept');
+            relationship.concept.should.equal(concept);
+        });
+
+        it('should call the callback when attempting to get the concept array value', () => {
+            const concept1 = factory.newConcept('org.acme.sample', 'SampleConcept');
+            const concept2 = factory.newConcept('org.acme.sample', 'SampleConcept');
+            cb.returns([ concept1, concept2 ]);
+            relationship.concepts[1].value === 'hello';
+            sinon.assert.calledOnce(cb);
+            sinon.assert.calledWith(cb, 'concepts');
+            relationship.concepts.should.deep.equal([ concept1, concept2 ]);
+        });
+
+        it('should call the callback when attempting to set the concept array value', () => {
+            const concept1 = factory.newConcept('org.acme.sample', 'SampleConcept');
+            const concept2 = factory.newConcept('org.acme.sample', 'SampleConcept');
+            cb.returns([ concept1, concept2 ]);
+            relationship.concepts[1].value = 'hello';
+            sinon.assert.calledOnce(cb);
+            sinon.assert.calledWith(cb, 'concepts');
+            relationship.concepts.should.deep.equal([ concept1, concept2 ]);
+        });
+
+        it('should call the callback when attempting to get the relationship value', () => {
+            const childRelationship = factory.newRelationship('org.acme.sample', 'SampleParticipant');
+            cb.returns(childRelationship);
+            relationship.owner.value === 'hello';
+            sinon.assert.calledOnce(cb);
+            sinon.assert.calledWith(cb, 'owner');
+            relationship.owner.should.deep.equal(childRelationship);
+        });
+
+        it('should call the callback when attempting to set the relationship value', () => {
+            const childRelationship = factory.newRelationship('org.acme.sample', 'SampleParticipant');
+            cb.returns(childRelationship);
+            relationship.owner.value = 'hello';
+            sinon.assert.calledOnce(cb);
+            sinon.assert.calledWith(cb, 'owner');
+            relationship.owner.should.deep.equal(childRelationship);
+        });
+
+        it('should call the callback when attempting to get the relationship array value', () => {
+            const childRelationship1 = factory.newRelationship('org.acme.sample', 'SampleParticipant');
+            const childRelationship2 = factory.newRelationship('org.acme.sample', 'SampleParticipant');
+            cb.returns([ childRelationship1, childRelationship2 ]);
+            relationship.owners[1].value === 'hello';
+            sinon.assert.calledOnce(cb);
+            sinon.assert.calledWith(cb, 'owners');
+            relationship.owners.should.deep.equal([ childRelationship1, childRelationship2 ]);
+        });
+
+        it('should call the callback when attempting to set the relationship array value', () => {
+            const childRelationship1 = factory.newRelationship('org.acme.sample', 'SampleParticipant');
+            const childRelationship2 = factory.newRelationship('org.acme.sample', 'SampleParticipant');
+            cb.returns([ childRelationship1, childRelationship2 ]);
+            relationship.owners[1].value = 'hello';
+            sinon.assert.calledOnce(cb);
+            sinon.assert.calledWith(cb, 'owners');
+            relationship.owners.should.deep.equal([ childRelationship1, childRelationship2 ]);
+        });
+
+    });
+
+});

--- a/packages/composer-runtime/test/context.js
+++ b/packages/composer-runtime/test/context.js
@@ -702,6 +702,8 @@ describe('Context', () => {
             sinon.stub(context, 'getRegistryManager').returns(mockRegistryManager);
             let mockIntrospector = sinon.createStubInstance(Introspector);
             sinon.stub(context, 'getIntrospector').returns(mockIntrospector);
+            let mockFactory = sinon.createStubInstance(Factory);
+            sinon.stub(context, 'getFactory').returns(mockFactory);
             context.getResolver().should.be.an.instanceOf(Resolver);
         });
 

--- a/packages/composer-runtime/test/engine.queries.js
+++ b/packages/composer-runtime/test/engine.queries.js
@@ -58,6 +58,7 @@ describe('EngineQueries', () => {
         mockCompiledQueryBundle = sinon.createStubInstance(CompiledQueryBundle);
         mockContext.getCompiledQueryBundle.returns(mockCompiledQueryBundle);
         mockAccessController = sinon.createStubInstance(AccessController);
+        mockAccessController.check.resolves();
         mockContext.getAccessController.returns(mockAccessController);
         mockSerializer = sinon.createStubInstance(Serializer);
         mockContext.getSerializer.returns(mockSerializer);
@@ -105,7 +106,7 @@ describe('EngineQueries', () => {
         });
 
         it('should return the results of a built query with an ACL limiting the results', () => {
-            mockAccessController.check.withArgs(mockResource2, 'READ').throws(new Error('no access'));
+            mockAccessController.check.withArgs(mockResource2, 'READ').rejects(new Error('no access'));
             return engine.query(mockContext, 'executeQuery', ['build', 'SELECT doge', '{"param1":true}'])
                 .then((resources) => {
                     sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
@@ -135,7 +136,7 @@ describe('EngineQueries', () => {
         });
 
         it('should return the results of a named query with an ACL limiting the results', () => {
-            mockAccessController.check.withArgs(mockResource2, 'READ').throws(new Error('no access'));
+            mockAccessController.check.withArgs(mockResource2, 'READ').rejects(new Error('no access'));
             return engine.query(mockContext, 'executeQuery', ['named', 'Q1', '{"param1":true}'])
                 .then((resources) => {
                     sinon.assert.calledOnce(mockCompiledQueryBundle.execute);

--- a/packages/composer-runtime/test/invalidrelationship.js
+++ b/packages/composer-runtime/test/invalidrelationship.js
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const InvalidRelationship = require('../lib/invalidrelationship');
+const ModelManager = require('composer-common').ModelManager;
+const Relationship = require('composer-common').Relationship;
+
+require('chai').should();
+
+describe('InvalidRelationship', () => {
+
+    let modelManager;
+    let relationship;
+
+    beforeEach(() => {
+        modelManager = new ModelManager();
+        modelManager.addModelFile(`namespace org.acme.sample
+
+        concept SampleConcept {
+            o String value
+        }
+
+        participant SampleParticipant identified by participantId {
+            o String participantId
+            o String value
+        }
+
+        asset SampleAsset identified by assetId {
+            o String assetId
+            o String value
+            o String[] values
+            o SampleConcept concept
+            o SampleConcept[] concepts
+            --> SampleParticipant owner
+            --> SampleParticipant[] owners
+        }`);
+        relationship = new InvalidRelationship(new Relationship(modelManager, 'org.acme.sample', 'SampleAsset', 'ASSET_1'), new Error('such error'));
+    });
+
+    describe('#constructor', () => {
+
+        it('should be a relationship', () => {
+            relationship.should.be.an.instanceOf(Relationship);
+        });
+
+        it('should not throw attempting to get the identifier', () => {
+            relationship.getIdentifier().should.equal('ASSET_1');
+            relationship.assetId.should.equal('ASSET_1');
+        });
+
+        it('should not throw attempting to set the identifier', () => {
+            relationship.setIdentifier('ASSET_X');
+            relationship.getIdentifier().should.equal('ASSET_X');
+            relationship.assetId = 'ASSET_Y';
+            relationship.getIdentifier().should.equal('ASSET_Y');
+        });
+
+        it('should throw attempting to get the primitive value', () => {
+            (() => {
+                relationship.value === 'hello';
+            }).should.throw(/such error/);
+        });
+
+        it('should throw attempting to set the primitive value', () => {
+            (() => {
+                relationship.value = 'hello';
+            }).should.throw(/such error/);
+        });
+
+        it('should throw attempting to get the primitive array value', () => {
+            (() => {
+                relationship.values[1] === 'hello';
+            }).should.throw(/such error/);
+        });
+
+        it('should throw attempting to set the primitive array value', () => {
+            (() => {
+                relationship.values[1] = 'hello';
+            }).should.throw(/such error/);
+        });
+
+        it('should throw attempting to get the concept value', () => {
+            (() => {
+                relationship.concept.value === 'hello';
+            }).should.throw(/such error/);
+        });
+
+        it('should throw attempting to set the concept value', () => {
+            (() => {
+                relationship.concept.value = 'hello';
+            }).should.throw(/such error/);
+        });
+
+        it('should throw attempting to get the concept array value', () => {
+            (() => {
+                relationship.concepts[1].value === 'hello';
+            }).should.throw(/such error/);
+        });
+
+        it('should throw attempting to set the concept array value', () => {
+            (() => {
+                relationship.concepts[1].value = 'hello';
+            }).should.throw(/such error/);
+        });
+
+        it('should throw attempting to get the relationship value', () => {
+            (() => {
+                relationship.owner.value === 'hello';
+            }).should.throw(/such error/);
+        });
+
+        it('should throw attempting to set the relationship value', () => {
+            (() => {
+                relationship.owner.value = 'hello';
+            }).should.throw(/such error/);
+        });
+
+        it('should throw attempting to get the relationship array value', () => {
+            (() => {
+                relationship.owners[1].value === 'hello';
+            }).should.throw(/such error/);
+        });
+
+        it('should throw attempting to set the relationship array value', () => {
+            (() => {
+                relationship.owners[1].value = 'hello';
+            }).should.throw(/such error/);
+        });
+
+    });
+
+});

--- a/packages/composer-runtime/test/registry.js
+++ b/packages/composer-runtime/test/registry.js
@@ -41,6 +41,7 @@ describe('Registry', () => {
         mockDataCollection = sinon.createStubInstance(DataCollection);
         mockSerializer = sinon.createStubInstance(Serializer);
         mockAccessController = sinon.createStubInstance(AccessController);
+        mockAccessController.check.resolves();
         mockParticipant = sinon.createStubInstance(Resource);
         registry = new Registry(mockDataCollection, mockSerializer, mockAccessController, 'Asset', 'doges', 'The doges registry');
     });
@@ -111,7 +112,7 @@ describe('Registry', () => {
         });
 
         it('should not throw or leak information about resources that cannot be accessed', () => {
-            mockAccessController.check.withArgs(mockResource2, 'READ').throws(new AccessException(mockResource2, 'READ', mockParticipant));
+            mockAccessController.check.withArgs(mockResource2, 'READ').rejects(new AccessException(mockResource2, 'READ', mockParticipant));
             return registry.getAll()
                 .then((resources) => {
                     sinon.assert.calledTwice(mockAccessController.check);
@@ -156,7 +157,7 @@ describe('Registry', () => {
         });
 
         it('should not throw or leak information about resources that cannot be accessed', () => {
-            mockAccessController.check.withArgs(mockResource, 'READ').throws(new AccessException(mockResource, 'READ', mockParticipant));
+            mockAccessController.check.withArgs(mockResource, 'READ').rejects(new AccessException(mockResource, 'READ', mockParticipant));
             return registry.get('doge1')
                 .should.be.rejectedWith(/does not exist/);
         });
@@ -203,7 +204,7 @@ describe('Registry', () => {
         });
 
         it('should not throw or leak information about resources that cannot be accessed', () => {
-            mockAccessController.check.withArgs(mockResource, 'READ').throws(new AccessException(mockResource, 'READ', mockParticipant));
+            mockAccessController.check.withArgs(mockResource, 'READ').rejects(new AccessException(mockResource, 'READ', mockParticipant));
             return registry.exists('doge1')
                 .should.eventually.equal(false)
                 .then(() => {
@@ -278,7 +279,7 @@ describe('Registry', () => {
         it('should throw if the access controller throws an exception', () => {
             mockDataCollection.add.resolves();
             // End of resources.
-            mockAccessController.check.withArgs(mockResource2, 'CREATE').throws(new AccessException(mockResource2, 'CREATE', mockParticipant));
+            mockAccessController.check.withArgs(mockResource2, 'CREATE').rejects(new AccessException(mockResource2, 'CREATE', mockParticipant));
             return registry.addAll([mockResource1, mockResource2])
                 .should.be.rejectedWith(AccessException);
         });
@@ -328,11 +329,10 @@ describe('Registry', () => {
         });
 
         it('should throw if the access controller throws an exception', () => {
-            mockAccessController.check.withArgs(mockResource, 'CREATE').throws(new AccessException(mockResource, 'CREATE', mockParticipant));
+            mockAccessController.check.withArgs(mockResource, 'CREATE').rejects(new AccessException(mockResource, 'CREATE', mockParticipant));
             mockDataCollection.add.resolves();
-            (() => {
-                registry.add(mockResource);
-            }).should.throw(AccessException);
+            return registry.add(mockResource)
+                .should.be.rejectedWith(AccessException);
         });
 
         it('should return errors from the data service', () => {
@@ -432,7 +432,7 @@ describe('Registry', () => {
         });
 
         it('should throw if the access controller throws an exception', () => {
-            mockAccessController.check.withArgs(mockOldResource2, 'UPDATE').throws(new AccessException(mockOldResource2, 'UPDATE', mockParticipant));
+            mockAccessController.check.withArgs(mockOldResource2, 'UPDATE').rejects(new AccessException(mockOldResource2, 'UPDATE', mockParticipant));
             mockDataCollection.update.resolves();
             return registry.updateAll([mockResource1, mockResource2])
                 .should.be.rejectedWith(AccessException);
@@ -500,7 +500,7 @@ describe('Registry', () => {
         });
 
         it('should throw if the access controller throws an exception', () => {
-            mockAccessController.check.withArgs(mockOldResource, 'UPDATE').throws(new AccessException(mockOldResource, 'UPDATE', mockParticipant));
+            mockAccessController.check.withArgs(mockOldResource, 'UPDATE').rejects(new AccessException(mockOldResource, 'UPDATE', mockParticipant));
             mockDataCollection.update.resolves();
             return registry.update(mockResource)
                 .should.be.rejectedWith(AccessException);
@@ -565,7 +565,7 @@ describe('Registry', () => {
         });
 
         it('should throw if the access controller throws an exception', () => {
-            mockAccessController.check.withArgs(mockResource2, 'DELETE').throws(new AccessException(mockResource2, 'DELETE', mockParticipant));
+            mockAccessController.check.withArgs(mockResource2, 'DELETE').rejects(new AccessException(mockResource2, 'DELETE', mockParticipant));
             mockDataCollection.remove.resolves();
             return registry.removeAll([mockResource1, mockResource2])
                 .should.be.rejectedWith(AccessException);
@@ -632,7 +632,7 @@ describe('Registry', () => {
         });
 
         it('should throw if the access controller throws an exception', () => {
-            mockAccessController.check.withArgs(mockResource, 'DELETE').throws(new AccessException(mockResource, 'DELETE', mockParticipant));
+            mockAccessController.check.withArgs(mockResource, 'DELETE').rejects(new AccessException(mockResource, 'DELETE', mockParticipant));
             mockDataCollection.remove.resolves();
             return registry.remove(mockResource)
                 .should.be.rejectedWith(AccessException);

--- a/packages/composer-systests/systest/accesscontrols.js
+++ b/packages/composer-systests/systest/accesscontrols.js
@@ -197,7 +197,10 @@ describe('Access control system tests', () => {
             });
     });
 
-    it('should be able to enforce read access permissions on an asset registry via client query', () => {
+    it('should be able to enforce read access permissions on an asset registry via client query', function () {
+        if (TestUtil.isHyperledgerFabricV06()) {
+            return this.skip();
+        }
         return Promise.resolve()
             .then(() => {
                 const query = aliceClient.buildQuery('SELECT systest.accesscontrols.SampleAsset');
@@ -273,7 +276,10 @@ describe('Access control system tests', () => {
             });
     });
 
-    it('should be able to enforce read access permissions on a participant registry via client query', () => {
+    it('should be able to enforce read access permissions on a participant registry via client query', function () {
+        if (TestUtil.isHyperledgerFabricV06()) {
+            return this.skip();
+        }
         return Promise.resolve()
             .then(() => {
                 const query = aliceClient.buildQuery('SELECT systest.accesscontrols.SampleParticipant');

--- a/packages/composer-systests/systest/accesscontrols.js
+++ b/packages/composer-systests/systest/accesscontrols.js
@@ -27,6 +27,8 @@ const chai = require('chai');
 chai.should();
 chai.use(require('chai-as-promised'));
 
+process.setMaxListeners(Infinity);
+
 describe('Access control system tests', () => {
 
     let businessNetworkDefinition;
@@ -70,12 +72,14 @@ describe('Access control system tests', () => {
         alice = factory.newResource('systest.accesscontrols', 'SampleParticipant', 'alice@mailcorp.com');
         alice.firstName = 'Alice';
         alice.lastName = 'Ashley';
+        alice.asset = factory.newRelationship('systest.accesscontrols', 'SampleAsset', 'AL1 CE');
         aliceCar = factory.newResource('systest.accesscontrols', 'SampleAsset', 'AL1 CE');
         aliceCar.theValue = 'Alice\'s car';
         aliceCar.owner = factory.newRelationship('systest.accesscontrols', 'SampleParticipant', 'alice@mailcorp.com');
         bob = factory.newResource('systest.accesscontrols', 'SampleParticipant', 'bob@mailcorp.com');
         bob.firstName = 'Bob';
         bob.lastName = 'Bradley';
+        bob.asset = factory.newRelationship('systest.accesscontrols', 'SampleAsset', 'BO85 CAR');
         bobCar = factory.newResource('systest.accesscontrols', 'SampleAsset', 'BO85 CAR');
         bobCar.theValue = 'Bob\'s car';
         bobCar.owner = factory.newRelationship('systest.accesscontrols', 'SampleParticipant', 'bob@mailcorp.com');
@@ -131,7 +135,7 @@ describe('Access control system tests', () => {
             });
     });
 
-    it('should be able to enforce read access permissions on an asset registry', () => {
+    it('should be able to enforce read access permissions on an asset registry via client getAll', () => {
         return Promise.resolve()
             .then(() => {
                 // Alice should only be able to read Alice's car.
@@ -142,7 +146,11 @@ describe('Access control system tests', () => {
                 // Bob should only be able to read Bob's car.
                 return bobAssetRegistry.getAll()
                     .should.eventually.be.deep.equal([bobCar]);
-            })
+            });
+    });
+
+    it('should be able to enforce read access permissions on an asset registry via client get', () => {
+        return Promise.resolve()
             .then(() => {
                 // Alice should be able to get her car by ID.
                 return aliceAssetRegistry.get('AL1 CE')
@@ -162,7 +170,11 @@ describe('Access control system tests', () => {
                 // Bob should not be able to get Alice's car by ID.
                 return bobAssetRegistry.get('AL1 CE')
                     .should.be.rejectedWith(/does not exist/);
-            })
+            });
+    });
+
+    it('should be able to enforce read access permissions on an asset registry via client exists', () => {
+        return Promise.resolve()
             .then(() => {
                 // Alice should be able to see if her car exists.
                 return aliceAssetRegistry.exists('AL1 CE')
@@ -185,7 +197,21 @@ describe('Access control system tests', () => {
             });
     });
 
-    it('should be able to enforce read access permissions on a participant registry', () => {
+    it('should be able to enforce read access permissions on an asset registry via client query', () => {
+        return Promise.resolve()
+            .then(() => {
+                const query = aliceClient.buildQuery('SELECT systest.accesscontrols.SampleAsset');
+                return aliceClient.query(query)
+                    .should.eventually.be.deep.equal([aliceCar]);
+            })
+            .then(() => {
+                const query = bobClient.buildQuery('SELECT systest.accesscontrols.SampleAsset');
+                return bobClient.query(query)
+                    .should.eventually.be.deep.equal([bobCar]);
+            });
+    });
+
+    it('should be able to enforce read access permissions on a participant registry via client getAll', () => {
         return Promise.resolve()
             .then(() => {
                 // Alice should only be able to read Alice's record.
@@ -196,7 +222,11 @@ describe('Access control system tests', () => {
                 // Bob should only be able to read Bob's record.
                 return bobParticipantRegistry.getAll()
                     .should.eventually.be.deep.equal([bob]);
-            })
+            });
+    });
+
+    it('should be able to enforce read access permissions on a participant registry via client get', () => {
+        return Promise.resolve()
             .then(() => {
                 // Alice should be able to get her record by ID.
                 return aliceParticipantRegistry.get('alice@mailcorp.com')
@@ -216,7 +246,11 @@ describe('Access control system tests', () => {
                 // Bob should not be able to get Alice's record by ID.
                 return bobParticipantRegistry.get('alice@mailcorp.com')
                     .should.be.rejectedWith(/does not exist/);
-            })
+            });
+    });
+
+    it('should be able to enforce read access permissions on a participant registry via client exists', () => {
+        return Promise.resolve()
             .then(() => {
                 // Alice should be able to see if her record exists.
                 return aliceParticipantRegistry.exists('alice@mailcorp.com')
@@ -239,7 +273,73 @@ describe('Access control system tests', () => {
             });
     });
 
-    it('should be able to enforce delete access permissions on an asset registry', () => {
+    it('should be able to enforce read access permissions on a participant registry via client query', () => {
+        return Promise.resolve()
+            .then(() => {
+                const query = aliceClient.buildQuery('SELECT systest.accesscontrols.SampleParticipant');
+                return aliceClient.query(query)
+                    .should.eventually.be.deep.equal([alice]);
+            })
+            .then(() => {
+                const query = bobClient.buildQuery('SELECT systest.accesscontrols.SampleParticipant');
+                return bobClient.query(query)
+                    .should.eventually.be.deep.equal([bob]);
+            });
+    });
+
+    it('should be able to enforce update access permissions on an asset registry via client update', () => {
+        return Promise.resolve()
+            .then(() => {
+                // Alice should not be able to update Bob's car.
+                bobCar.theValue = 'lol alice is a haxxor';
+                return aliceAssetRegistry.update(bobCar)
+                    .should.be.rejected;
+            })
+            .then(() => {
+                // Bob should not be able to update Alice's car.
+                aliceCar.theValue = 'lol bob is a haxxor';
+                return bobAssetRegistry.update(aliceCar)
+                    .should.be.rejected;
+            })
+            .then(() => {
+                // Alice should only be able to update Alice's car.
+                aliceCar.theValue = 'alice rules';
+                return aliceAssetRegistry.update(aliceCar);
+            })
+            .then(() => {
+                // Bob should only be able to update Bob's car.
+                bobCar.theValue = 'bob rules';
+                return bobAssetRegistry.update(bobCar);
+            });
+    });
+
+    it('should be able to enforce update access permissions on a participant registry via client update', () => {
+        return Promise.resolve()
+            .then(() => {
+                // Alice should not be able to update Bob's record.
+                bob.lastName = 'lol alice is a haxxor';
+                return aliceParticipantRegistry.update(bob)
+                    .should.be.rejected;
+            })
+            .then(() => {
+                // Bob should not be able to update Alice's record.
+                alice.lastName = 'lol bob is a haxxor';
+                return bobParticipantRegistry.update(alice)
+                    .should.be.rejected;
+            })
+            .then(() => {
+                // Alice should only be able to update Alice's record.
+                alice.lastName = 'alice rules';
+                return aliceParticipantRegistry.update(alice);
+            })
+            .then(() => {
+                // Bob should only be able to update Bob's record.
+                bob.lastName = 'bob rules';
+                return bobParticipantRegistry.update(bob);
+            });
+    });
+
+    it('should be able to enforce delete access permissions on an asset registry via client remove', () => {
         return Promise.resolve()
             .then(() => {
                 // Alice should not be able to remove Bob's car by ID.
@@ -261,7 +361,7 @@ describe('Access control system tests', () => {
             });
     });
 
-    it('should be able to enforce delete access permissions on a participant registry', () => {
+    it('should be able to enforce delete access permissions on a participant registry via client remove', () => {
         return Promise.resolve()
             .then(() => {
                 // Alice should not be able to remove Bob's record by ID.

--- a/packages/composer-systests/systest/data/accesscontrols.acl
+++ b/packages/composer-systests/systest/data/accesscontrols.acl
@@ -42,3 +42,21 @@ rule R5 {
     condition: (participantsAreEqual(p1, p2))
     action: ALLOW
 }
+
+rule R6 {
+    description: "The owner of a vehicle can update the vehicle"
+    participant(p): "systest.accesscontrols.SampleParticipant"
+    operation: UPDATE
+    resource(a): "systest.accesscontrols.SampleAsset"
+    condition: (p.firstName === a.owner.firstName && p.lastName === a.owner.lastName)
+    action: ALLOW
+}
+
+rule R7 {
+    description: "The owner of a vehicle can update the vehicle"
+    participant(p1): "systest.accesscontrols.SampleParticipant"
+    operation: UPDATE
+    resource(p2): "systest.accesscontrols.SampleParticipant"
+    condition: (p1.asset.owner.firstName === p2.asset.owner.firstName && p1.asset.owner.asset.owner.lastName === p2.asset.owner.asset.owner.lastName)
+    action: ALLOW
+}

--- a/packages/composer-systests/systest/data/accesscontrols.cto
+++ b/packages/composer-systests/systest/data/accesscontrols.cto
@@ -10,6 +10,7 @@ participant SampleParticipant identified by email {
   o String email
   o String firstName
   o String lastName
+  --> SampleAsset asset
 }
 
 transaction SampleTransaction {

--- a/packages/composer-systests/systest/identities.js
+++ b/packages/composer-systests/systest/identities.js
@@ -27,6 +27,8 @@ const chai = require('chai');
 chai.should();
 chai.use(require('chai-as-promised'));
 
+process.setMaxListeners(Infinity);
+
 describe('Identity system tests', () => {
 
     let businessNetworkDefinition;

--- a/packages/composer-systests/systest/testutil.js
+++ b/packages/composer-systests/systest/testutil.js
@@ -380,7 +380,7 @@ class TestUtil {
             enrollmentID = enrollmentID || 'admin';
             let password = TestUtil.isHyperledgerFabric() && process.env.SYSTEST.match('^hlfv1') ? 'adminpw' : 'Xurw3yU9zI0l';
             enrollmentSecret = enrollmentSecret || password;
-            console.log(`Calling Client.connect('composer-systest', '${network}', '${enrollmentID}', '${enrollmentSecret}') ...`);
+            // console.log(`Calling Client.connect('composer-systest', '${network}', '${enrollmentID}', '${enrollmentSecret}') ...`);
             return thisClient.connect('composer-systests', network, enrollmentID, enrollmentSecret);
         })
         .then(() => {


### PR DESCRIPTION
Rework the runtime access controller to permit ACL rules that resolve and navigate relationships.
For example, when writing an ACL rule for an asset, you often want to look at the owner of the asset and make the decision based on some property of the owner.

Here is a daft example:

```
rule R7 {
    description: "The owner of a vehicle can update the vehicle"
    participant(p1): "systest.accesscontrols.SampleParticipant"
    operation: UPDATE
    resource(p2): "systest.accesscontrols.SampleParticipant"
    condition: (p1.asset.owner.firstName === p2.asset.owner.firstName && p1.asset.owner.asset.owner.lastName === p2.asset.owner.asset.owner.lastName)
    action: ALLOW
}
```

The changes require quite a bit of work:

- Repurposing a lot of code from `QueryExecutor` into `Resolver` so that resources can be prepared for lazy resolution.
  - Lazy resolution uses `CallbackRelationship` to callback into the resolver on property access and trigger resolution.
- Updating `Resolver` to create `InvalidRelationship` objects for invalid or missing relationship targets. These do not throw until you try and access a property in the resolved item.
- Rewriting `AccessController` to be asynchronous and use promises, because now resolution may occur in the middle of an ACL check.
- Updating `AccessController` to use the lazy resolution feature of the resolver and re-run the ACL checks until no more resolution is required.