### PR TITLE
feat(v1): Support connector specific options on identity issue

### DIFF
--- a/packages/composer-cli/lib/cmds/generator/createCodeCommand.js
+++ b/packages/composer-cli/lib/cmds/generator/createCodeCommand.js
@@ -30,14 +30,10 @@ module.exports.handler = (argv) => {
 
     argv.thePromise = Create.handler(argv)
     .then(() => {
-        console.log ('Command completed successfully.');
-
+        return;
     })
     .catch((error) => {
-        console.log(error.stack);
-        console.log(error+ '\nCommand failed.');
         throw error;
-
     });
     return argv.thePromise;
 };

--- a/packages/composer-cli/lib/cmds/identity/importCommand.js
+++ b/packages/composer-cli/lib/cmds/identity/importCommand.js
@@ -28,7 +28,10 @@ module.exports.builder = {
 module.exports.handler = (argv) => {
     argv.thePromise =  Import.handler(argv)
     .then(() => {
-        console.log ('Command completed successfully.');
+        return;
+    })
+    .catch((error) => {
+        throw error;
     });
     return argv.thePromise;
 };

--- a/packages/composer-cli/lib/cmds/identity/issueCommand.js
+++ b/packages/composer-cli/lib/cmds/identity/issueCommand.js
@@ -25,19 +25,19 @@ module.exports.builder = {
     enrollSecret: { alias: 's', required: false, describe: 'The enrollment secret of the user', type: 'string' },
     newUserId: { alias: 'u', required: true, describe: 'The user ID for the new identity', type: 'string' },
     participantId: { alias: 'a', required: true, describe: 'The particpant to issue the new identity to', type: 'string' },
-    issuer: { alias: 'x', required: true, describe: 'If the new identity should be able to issue other new identities', type: 'boolean' }
+    issuer: { alias: 'x', required: true, describe: 'If the new identity should be able to issue other new identities', type: 'boolean' },
+    option: { alias: 'o', required: false, describe: 'Options that are specific specific to connection. Multiple options are specified by repeating this option', type: 'string' },
+    optionsFile: { alias: 'O', required: false, describe: 'A file containing options that are specific to connection', type: 'string' }
 };
 
 module.exports.handler = (argv) => {
 
     argv.thePromise =  Issue.handler(argv)
     .then(() => {
-        console.log ('Command completed successfully.');
-
+        return;
     })
     .catch((error) => {
-        console.log(error+ '\nCommand failed.');
-
+        throw error;
     });
     return argv.thePromise;
 };

--- a/packages/composer-cli/lib/cmds/identity/lib/issue.js
+++ b/packages/composer-cli/lib/cmds/identity/lib/issue.js
@@ -65,7 +65,9 @@ class Issue {
             return businessNetworkConnection.connect(connectionProfileName, businessNetworkName, enrollId, enrollSecret);
         })
         .then(() => {
-            return businessNetworkConnection.issueIdentity(participantId, newUserId, { issuer: issuer });
+            let issueOptions = cmdUtil.parseOptions(argv);
+            issueOptions.issuer = issuer;
+            return businessNetworkConnection.issueIdentity(participantId, newUserId, issueOptions);
         })
         .then((result) => {
             console.log(`An identity was issued to the participant '${participantId}'`);

--- a/packages/composer-cli/lib/cmds/identity/revokeCommand.js
+++ b/packages/composer-cli/lib/cmds/identity/revokeCommand.js
@@ -30,12 +30,10 @@ module.exports.handler = (argv) => {
 
     argv.thePromise =  Revoke.handler(argv)
     .then(() => {
-        console.log ('Command completed successfully.');
-
+        return;
     })
     .catch((error) => {
-        console.log(error+ '\nCommand failed.');
-
+        throw error;
     });
     return argv.thePromise;
 };

--- a/packages/composer-cli/lib/cmds/participant/addCommand.js
+++ b/packages/composer-cli/lib/cmds/participant/addCommand.js
@@ -30,12 +30,10 @@ module.exports.handler = (argv) => {
 
     argv.thePromise =  Add.handler(argv)
     .then(() => {
-        console.log ('Command completed successfully.');
-
+        return;
     })
     .catch((error) => {
-        console.log(error+ '\nCommand failed.');
-
+        throw error;
     });
     return argv.thePromise;
 };

--- a/packages/composer-cli/lib/cmds/transaction/submitCommand.js
+++ b/packages/composer-cli/lib/cmds/transaction/submitCommand.js
@@ -30,18 +30,10 @@ module.exports.handler = (argv) => {
 
     argv.thePromise =  Submit.handler(argv)
     .then(() => {
-        console.log ('Command completed successfully.');
-
         return;
-
     })
     .catch((error) => {
-        console.log(error);
-        console.log('Command failed.');
         throw error;
-
-
-
     });
     return argv.thePromise;
 };

--- a/packages/composer-cli/test/identity/revoke.js
+++ b/packages/composer-cli/test/identity/revoke.js
@@ -22,6 +22,9 @@ const CmdUtil = require('../../lib/cmds/utils/cmdutils.js');
 
 const sinon = require('sinon');
 require('sinon-as-promised');
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-as-promised'));
 
 const BUSINESS_NETWORK_NAME = 'net.biz.TestNetwork-0.0.1';
 const DEFAULT_PROFILE_NAME = 'defaultProfile';
@@ -104,12 +107,7 @@ describe('composer identity revoke CLI unit tests', () => {
             userId: 'dogeid1'
         };
         return Revoke.handler(argv)
-            .then((res) => {
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, DEFAULT_PROFILE_NAME, argv.businessNetworkName, argv.enrollId, argv.enrollSecret);
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.revokeIdentity);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.revokeIdentity, 'dogeid1');
-            });
+            .should.be.rejectedWith(/such error/);
     });
 
 });

--- a/packages/composer-cli/test/participant/add.js
+++ b/packages/composer-cli/test/participant/add.js
@@ -28,6 +28,9 @@ const CmdUtil = require('../../lib/cmds/utils/cmdutils.js');
 
 const sinon = require('sinon');
 require('sinon-as-promised');
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-as-promised'));
 
 const NAMESPACE = 'net.biz.TestNetwork';
 const BUSINESS_NETWORK_NAME = 'net.biz.TestNetwork-0.0.1';
@@ -128,13 +131,7 @@ describe('composer participant add CLI unit tests', () => {
             data: '{"$class": "'+NAMESPACE+'", "success": "true"}'
         };
         return Add.handler(argv)
-            .then((res) => {
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, DEFAULT_PROFILE_NAME, argv.businessNetworkName, argv.enrollId, argv.enrollSecret);
-                sinon.assert.calledOnce(mockParticipantRegistry.add);
-                sinon.assert.calledWith(mockParticipantRegistry.add, mockResource);
-
-            });
+            .should.be.rejectedWith(/such error/);
     });
 
 });

--- a/packages/composer-connector-hlfv1/lib/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/lib/hlfconnection.js
@@ -851,6 +851,8 @@ class HLFConnection extends Connection {
      * permissions to create additional new identities. False by default.
      * @param {string} [options.affiliation] Specify the affiliation for the new
      * identity. Defaults to 'org1'.
+     * @param {string} [options.maxEnrollments] Specify the maximum number of enrollments. Defaults to 0.
+     * @param {string} [options.role] Specify the role of the new identity. Defaults to 'client'.
      * @param {object} [options.attributes] Specify other attributes for the identity
      * @return {Promise} A promise that is resolved with a generated user
      * secret once the new identity has been created, or rejected with an error.
@@ -889,11 +891,23 @@ class HLFConnection extends Connection {
                 //    value: 'client'
                 //});
             }
-            for (let attribute in options.attributes) {
+
+            let idAttributes = options.attributes;
+            if (typeof idAttributes === 'string') {
+                try {
+                    idAttributes = JSON.parse(idAttributes);
+                } catch(error) {
+                    const newError = new Error('attributes provided are not valid JSON. ' + error);
+                    LOG.error(method, newError);
+                    throw newError;
+                }
+            }
+
+            for (let attribute in idAttributes) {
                 LOG.debug(method, 'Adding attribute to request', attribute);
                 registerRequest.attrs.push({
                     name: attribute,
-                    value: options.attributes[attribute]
+                    value: idAttributes[attribute]
                 });
             }
 
@@ -907,7 +921,7 @@ class HLFConnection extends Connection {
                 })
                 .catch((error) => {
                     LOG.error(method, 'Register request failed trying to create identity', error);
-                    return reject(error);
+                    reject(error);
                 });
         });
     }

--- a/packages/composer-connector-hlfv1/test/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/test/hlfconnection.js
@@ -1676,7 +1676,7 @@ describe('HLFConnection', () => {
                 });
         });
 
-        it('should issue a request with user supplied attributes', () => {
+        it('should issue a request with user supplied attributes object', () => {
             mockCAClient.register.resolves('asecret');
             return connection.createIdentity(mockSecurityContext, 'auser', {attributes: {attr1: 'value1', attr2: 'value2'}})
                 .then((result) => {
@@ -1690,6 +1690,27 @@ describe('HLFConnection', () => {
                         attrs: [
                             {name: 'attr1', value: 'value1'},
                             {name: 'attr2', value: 'value2'}
+                        ],
+                        maxEnrollments: 0,
+                        role: 'client'
+                    }, mockUser);
+                });
+        });
+
+        it('should issue a request with user supplied attributes JSON string', () => {
+            mockCAClient.register.resolves('asecret');
+            return connection.createIdentity(mockSecurityContext, 'auser', {attributes: '{"attr1": "value1", "attr2": 20}'})
+                .then((result) => {
+                    result.should.deep.equal({
+                        userID: 'auser',
+                        userSecret: 'asecret'
+                    });
+                    sinon.assert.calledWith(mockCAClient.register, {
+                        enrollmentID: 'auser',
+                        affiliation: 'org1',
+                        attrs: [
+                            {name: 'attr1', value: 'value1'},
+                            {name: 'attr2', value: 20}
                         ],
                         maxEnrollments: 0,
                         role: 'client'


### PR DESCRIPTION
Also fixed problems with the command line where it could output
- Command Failed
Followed by
- Command Succeeded

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>

