### PR TITLE
More useful error message for connector not loaded problems

### DIFF
--- a/packages/composer-common/lib/connectionprofilemanager.js
+++ b/packages/composer-common/lib/connectionprofilemanager.js
@@ -147,8 +147,9 @@ class ConnectionProfileManager {
                         }
                     }
                 } catch (e) {
-                    LOG.debug(METHOD,e);
-                    throw new Error(`Failed to load connector module "${mod}" for connection profile "${connectionProfile}"`);
+                    const newError = new Error(`Failed to load connector module "${mod}" for connection profile "${connectionProfile}". ${e}`);
+                    LOG.error(METHOD, newError);
+                    throw newError;
                 }
                 connectionManagers[data.type] = connectionManager;
             }


### PR DESCRIPTION
Better error message and correct logging if connector module cannot be loaded.

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
