### PR TITLE
Improve build performance

### DIFF
--- a/.travis/before-install.sh
+++ b/.travis/before-install.sh
@@ -7,19 +7,13 @@ set -o pipefail
 # Install using pip as apt-get pulls the wrong version on Travis' trusty image
 # python requests 2.9.2 is essential prereq for linkchecker
 
-sudo pip install linkchecker
-sudo pip install linkchecker --upgrade
-sudo pip install requests==2.9.2
+pip install linkchecker requests==2.9.2
 linkchecker --version
 
 # Grab the parent (root) directory.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
-npm install -g npm@4
-npm install -g lerna@2
-npm install -g @alrra/travis-scripts
-
-npm install -g asciify
+npm install -g npm@4 lerna@2 @alrra/travis-scripts asciify
 
 
 echo "ABORT_BUILD=false" > ${DIR}/build.cfg

--- a/.travis/before-install.sh
+++ b/.travis/before-install.sh
@@ -37,6 +37,7 @@ linkchecker --version
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 npm install -g npm@4
+npm install -g lerna@2
 npm install -g @alrra/travis-scripts
 
 npm install -g asciify

--- a/.travis/before-install.sh
+++ b/.travis/before-install.sh
@@ -4,27 +4,6 @@
 set -ev
 set -o pipefail
 
-# Download specific version of docker-compose
-export DOCKER_COMPOSE_VERSION=1.11.2
-sudo rm /usr/local/bin/docker-compose
-curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-chmod +x docker-compose
-sudo mv docker-compose /usr/local/bin
-echo "Docker-compose version: "
-docker-compose --version
-
-# Update docker
-sudo apt-get update
-sudo apt-get remove docker docker-engine
-sudo apt-get install linux-image-extra-$(uname -r) linux-image-extra-virtual
-sudo apt-get install apt-transport-https ca-certificates curl software-properties-common
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-sudo apt-get update
-sudo apt-get install docker-ce
-echo "Docker version: "
-docker --version
-
 # Install using pip as apt-get pulls the wrong version on Travis' trusty image
 # python requests 2.9.2 is essential prereq for linkchecker
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -21,6 +21,6 @@ fi
   #exit 0;
 #fi
 
-
+# Use lerna bootstrap and not npm install; it's a lot faster in Travis.
 cd ${DIR}
-npm install 2>&1 | tee
+lerna bootstrap 2>&1 | tee


### PR DESCRIPTION
- Remove install of Docker and Docker Compose which takes AGES and they are already at the latest levels, possibly a result of recent upgrades to the Trusty build environment.
- Remove sudo for pip which spews warnings, and combine into a single pip command.
- Add lerna to npm install, and combine into a single npm command.
- Use lerna bootstrap instead of npm install which massively reduces install time.

It seems that npm install spends a long time doing something, where lerna bootstrap does not. It might be that npm is struggling to deal with the huge number of dependencies that lerna dumps into node_modules? 

I'm in favour of keeping npm install as is (automatically runs lerna bootstrap) as its easier for first time contributors to use, but we don't have to use it in the builds.