### PR TITLE
Enable styled dropdown for Id panel

### DIFF
--- a/packages/composer-playground/src/app/app.component.html
+++ b/packages/composer-playground/src/app/app.component.html
@@ -30,9 +30,9 @@
                         </a>
                     </li>
                 </ul>
-                <div class="drop-select" *ngIf="usingLocally">
+                <div class="drop-select" *ngIf="usingLocally" [routerLinkActive]="['active']" [ngClass]="{'dropListActive' : dropListActive}">
                     <div class="drop-select-item flex-container flex">
-                        <div ngbDropdown class="d-inline-block">
+                        <div ngbDropdown class="d-inline-block" (openChange)="onToggle($event)">
                             <button type="button" class="action" id="dropdownMenu1" ngbDropdownToggle>
                                 <span title="{{ identityService.currentIdentity | async }}">{{ identityService.currentIdentity | async }}</span>
                             </button>

--- a/packages/composer-playground/src/app/app.component.spec.ts
+++ b/packages/composer-playground/src/app/app.component.spec.ts
@@ -1006,4 +1006,22 @@ describe('AppComponent', () => {
         }));
     });
 
+    describe('onToggle', () => {
+
+        it('should set toggle down on true event', () => {
+            component['dropListActive'] = false;
+
+            component['onToggle'](true);
+
+            component['dropListActive'].should.be.true;
+        });
+
+        it('should set toggle up on false event', () => {
+            component['dropListActive'] = true;
+
+            component['onToggle'](false);
+
+            component['dropListActive'].should.be.false;
+        });
+    });
 });

--- a/packages/composer-playground/src/app/app.component.ts
+++ b/packages/composer-playground/src/app/app.component.ts
@@ -47,6 +47,7 @@ export class AppComponent implements OnInit, OnDestroy {
     private usingLocally = false;
     private showHeaderLinks = false;
     private showWelcome = true;
+    private dropListActive = false;
 
     private composerRuntimeVersion = '<none>';
     private participantFQI = '<none>';
@@ -207,6 +208,14 @@ export class AppComponent implements OnInit, OnDestroy {
     onEvent(eventStatus) {
         if (eventStatus) {
             this.modalService.open(ViewTransactionComponent);
+        }
+    }
+
+    onToggle(open) {
+        if (open) {
+            this.dropListActive = true;
+        } else {
+            this.dropListActive = false;
         }
     }
 

--- a/packages/composer-playground/src/assets/styles/elements/_header.scss
+++ b/packages/composer-playground/src/assets/styles/elements/_header.scss
@@ -11,7 +11,7 @@
       height: 100%;
 
       .navlogo {
-        min-width: 19rem;
+        min-width: 0;
         max-width: 19rem;
         background-color: $first-highlight;
         padding-left: 1.5rem;
@@ -19,9 +19,8 @@
         display: flex;
         align-items: center;
         position: relative;
-        flex: 1;
+        min-width: 0;
         p {
-            min-width: 0;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
@@ -30,6 +29,30 @@
 
       .navlogo:hover .tooltiptext {
         visibility: visible;
+        opacity: 0.8;
+      }
+
+      .navlogo .tooltiptext {
+        visibility: hidden;
+        background-color: black;
+        color: #fff;
+        text-align: center;
+        padding: 12px 12px;
+        border-radius: 6px;
+        position: absolute;
+        left: 5rem;
+        top : 3rem;
+      }
+
+      .navlogo .tooltiptext::after {
+        content: " ";
+        position: absolute;
+        bottom: 100%;
+        left: 10%;
+        margin-left: -8px;
+        border-width: 8px;
+        border-style: solid;
+        border-color: transparent transparent black transparent;
       }
 
       .drop-select{

--- a/packages/composer-playground/src/assets/styles/elements/_header.scss
+++ b/packages/composer-playground/src/assets/styles/elements/_header.scss
@@ -11,7 +11,7 @@
       height: 100%;
 
       .navlogo {
-        min-width: 0;
+        min-width: 19rem;
         max-width: 19rem;
         background-color: $first-highlight;
         padding-left: 1.5rem;
@@ -20,7 +20,9 @@
         align-items: center;
         position: relative;
         min-width: 0;
+        flex: 1;
         p {
+            min-width: 0;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
@@ -61,6 +63,15 @@
             max-width: 18rem;
             color:$third-highlight;
             background-color: $second-highlight;
+            border-bottom:  6px solid $first-highlight;
+
+            &.dropListActive {
+                border-bottom:  6px solid $white;
+            }
+
+            &.active, &:active, &:hover {
+                border-bottom:  6px solid $white;
+            }
 
             .action{
                 color:$third-highlight;
@@ -90,6 +101,8 @@
                 #footer {
                     color:$white-2;
                     background-color: $second-highlight;
+                    border-bottom-right-radius: 5px;
+                    border-bottom-left-radius: 5px;
 
                     &:hover {
                         background-color: $sixth-highlight;
@@ -99,10 +112,13 @@
 
             .dropdown {
                 display: flex;
-                // color:$third-highlight;
                 background-color: $first-highlight;
                 max-width: 18rem;
                 min-height: 63px;
+                background-color: $first-highlight;
+                max-width: 18rem;
+                min-height: 63px;
+                padding-top: 6px;
             }
 
             .dropdown-menu {
@@ -110,6 +126,40 @@
                 border-right: transparent;
                 border-bottom: transparent;
                 max-width: 18rem;
+                border-top: transparent;
+                border-top-right-radius: 5px;
+                border-top-left-radius: 5px;
+                overflow-x: visible;
+                overflow-y: visible;
+
+                top : 4.5rem;
+                max-width: 18rem;
+
+                &:before{
+                    content:"";
+                    position: absolute;
+                    right: 3rem;
+                    top: -0.5rem;
+                    width: 0;
+                    height: 0;
+                    border-style: solid;
+                    border-width: 0 0.5rem 0.5rem 0.5rem;
+                    border-color: transparent transparent $third-highlight transparent;
+                    z-index:9999;
+                }
+
+                &:after{
+                    content:"";
+                    position: absolute;
+                    right: 3rem;
+                    top: -0.5rem;
+                    width: 0;
+                    height: 0;
+                    border-style: solid;
+                    border-width: 0 0.5rem 0.5rem 0.5rem;
+                    border-color: transparent transparent $third-highlight transparent;
+                    z-index:9999;
+                }
             }
 
             .dropdown-toggle::after{


### PR DESCRIPTION
final component of #1571:
 - Provides mouseOver select indicator (border-bottom) and persists the select indicator on router navigation.
 - Restyle of the dropdown to provide "triangle" at top of drop container.