### PR TITLE
Add new id card creation flow to identities 

### DIFF
--- a/packages/composer-playground/src/app/connection-profile/add-connection-profile/add-connection-profile.component.html
+++ b/packages/composer-playground/src/app/connection-profile/add-connection-profile/add-connection-profile.component.html
@@ -1,44 +1,49 @@
-<div class="import" fileDragDrop (fileDragDropFileAccepted)="fileAccepted($event)"
-     (fileDragDropFileRejected)="fileRejected($event)"
-     (fileDragDropDragOver)="fileDetected($event)" (fileDragDropDragLeave)="fileLeft($event)"
-     [maxFileSize]="maxFileSize" [supportedFileTypes]="supportedFileTypes">
-  <div class="modal-header">
-    <h1>Import/Create a Connection Profile</h1>
-    <button class="icon modal-exit" (click)="activeModal.dismiss()">
-      <svg class="ibm-icon" aria-hidden="true">
-        <use xlink:href="#icon-close_new"></use>
-      </svg>
-    </button>
-  </div>
-  <section class="modal-body">
-    <span>Upload a Connection Profile from your computer</span>
-    <file-importer *ngIf="!currentFile" (fileAccepted)="fileAccepted($event)" (fileRejected)="fileRejected($event)" [expandInput]="expandInput"
-                   [maxFileSize]="maxFileSize" [supportedFileTypes]="supportedFileTypes" [ngClass]="{'expandFile': expandInput}" [svgName]="'#icon-CTO_JS_Upload'"></file-importer>
-    <span>Or create a connection profile, select your Blockchain platform:</span>
-    <form class="file-types-list" #f="ngForm" *ngIf="!expandInput">
-      <div class="file-types-list-item">
-        <input type="radio" id="file-type-v06" name="file-type" [(ngModel)]="version" value="v06"
-               (change)="changeCurrentFileType()">
-        <label class="radio-label" for="file-type-v06">Hyperledger Fabric v0.6</label>
-        <div class="description">
-          v0.6 Connection Profile.
-        </div>
-      </div>
-      <div class="file-types-list-item">
-        <input type="radio" id="file-type-v1" name="file-type" [(ngModel)]="version" value="v1"
-               (change)="changeCurrentFileType()">
-        <label class="radio-label" for="file-type-v1">Hyperledger Fabric v1.0</label>
-        <div class="description">
-          v1.0 Connection Profile.
-        </div>
-      </div>
-    </form>
+<div class="add-connection">
+  <h1>Create ID Card</h1>
+  <section class="profiles">
+    <div class="description"><b>SELECT BLOCKCHAIN DEPLOYMENT</b></div>
+    <div>
+        <form #optionForm="ngForm">
+            <div class="create-route">
+                <p>Create ID for a Blockchain you already use with Composer:</p>
+                <div class="file-types-list">
+                    <div class="file-types-list-item" *ngFor="let profile of connectionProfiles; let i=index" >
+                            <input [checked]="connectionProfile && this.connectionProfile.name && this.connectionProfile.name.valueOf() === profile.name"
+                            type="radio" id="{{ i }}" name="file-type"
+                                (change)="setConnectionProfile(profile.name)"/>
+                            <label class="radio-label" for="{{ i }}"><h3>{{profile.name === '$default' ? 'Web Browser' : profile.name }}</h3></label>
+                            <div class="description"><p>{{ profile.description }}</p></div>
+                    </div>
+                </div>
+            </div>
+            <div class="create-route">
+                <p>Or Create ID for Blockchain you have not connected to before:</p>
+                <div class="file-types-list">
+                    <div class="file-types-list-item">
+                        <input type="radio" id="new-v1" name="file-type"
+                            (change)="setConnectionProfile('_$v1')">
+                        <label class="radio-label" for="new-v1"><h3>Hyperledger Fabric v1.0</h3></label>
+                        <div class="description"><p>Connect to a new v1.0 Blockchain</p></div>
+                    </div>
+                    <div class="file-types-list-item">
+                        <input type="radio" id="new-v06" name="file-type"
+                            (change)="setConnectionProfile('_$v06')">
+                        <label class="radio-label" for="new-v06"><h3>Hyperledger Fabric v0.6</h3></label>
+                        <div class="description"><p>Connect to a new v0.6 Blockchain</p></div>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
   </section>
   <footer>
-    <button type="button" class="secondary" (click)="activeModal.dismiss();">
+    <button type="button" class="secondary" (click)="dismiss();">
       <span>Cancel</span>
     </button>
-    <button type="button" class="primary" (click)="addConnectionProfile()" [disabled]="!version">
+    <button *ngIf = "newDefault" type="button" class="primary" (click)="initiateAddWithProfile()" [disabled]="!connectionProfile">
+      <span>Add</span>
+    </button>
+    <button *ngIf = "!newDefault" type="button" class="primary" (click)="initiateAddToProfile()" [disabled]="!connectionProfile">
       <span>Add</span>
     </button>
   </footer>

--- a/packages/composer-playground/src/app/connection-profile/add-connection-profile/add-connection-profile.component.scss
+++ b/packages/composer-playground/src/app/connection-profile/add-connection-profile/add-connection-profile.component.scss
@@ -1,41 +1,71 @@
 @import '../../../assets/styles/base/colors';
 @import '../../../assets/styles/base/variables';
 
-.import {
-  width: 660px;
-  height: 450px;
-
+.add-connection {
   display: flex;
   flex-direction: column;
+  background-color: $white;
+  margin-bottom: $space-large;
+  margin-top: $space-large;
+  border:$border-width-small solid $keyline-highlight;
+  border-radius: $radius-medium;
 
-  .file-types-list {
-    max-height: 200px;
-    margin-top: 16px;
+  h1 {
+      margin-top: $space-medium;
+      margin-bottom: $space-large;
+      margin-left: $space-medium;
+      font-size: 20px;
+      color: $primary-text;
+      letter-spacing:0;
+      text-align:left;
+  }
 
-    .file-types-list-item {
-      background-color: $third-highlight;
-      padding: $space-medium;
-      &:nth-child(even) {
-        background-color: $white;
-      }
+  .profiles {
+      display: flex;
+      flex-direction: row;
+      margin-left: $space-medium;
 
       .description {
-        font-style: italic;
-        padding-left: 2em;
+        margin-right: $space-xlarge;
+        margin-top: $space-small;
+        font-size: 0.7rem;
+        color:$tertiary-text;
       }
 
-      label.radio-label {
-        font-weight: bold;
+      .create-route {
+          margin-bottom: $space-large;
 
-        &::before {
-          top: 8px;
-        }
+          p {
+              color:$primary-text;
+              margin-top: 0;
+              margin-bottom: 0;
+              font-weight: 300;
+          }
 
-        &::after {
-          top: 13px;
+          .file-types-list {
+              display: flex;
+              flex-direction: row;
+              margin-top: $space-large;
+              margin-bottom: $space-mlarge;
+              flex-wrap: wrap;
+
+              .file-types-list-item {
+                    background-color: $white;
+                    padding: $space-medium;
+                    max-width: 25rem;
+                    min-width: 22rem;
+
+                .description {
+                    color:$primary-text;
+                    margin-left: $space-large;
+                }
+
+                label.radio-label {
+                    font-weight: 600;
+                }
+            }
         }
       }
-    }
   }
 
   section {
@@ -49,71 +79,8 @@
       color: $secondary-text;
     }
 
-    .chosen-file {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-      background-color: $third-highlight;
-      padding: $space-medium;
-
-      .title {
-        font-weight: bold;
-      }
-
-      .file-info {
-        display: flex;
-        justify-content: space-between;
-        border-bottom: 1px solid $fifth-highlight;
-        padding-bottom: $space-medium;
-        align-items: center;
-
-        svg {
-          fill: $first-highlight;
-          width: 76px;
-          height: 76px;
-          margin-right: $space-medium;
-        }
-
-        .file-title {
-          display: flex;
-          flex-direction: column;
-          justify-content: center;
-
-          span {
-            color: $primary-text;
-            font-style: italic;
-          }
-        }
-      }
-
-      .file-content {
-        margin-top: $space-medium;
-        flex: 1;
-        display: flex;
-        justify-content: space-between;
-
-        .network-part {
-          margin-bottom: $space-smedium;
-        }
-      }
-    }
-
-    .github-spinner {
-      height: 200px;
-      width: 465px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-
-      .circle-path {
-        stroke: $first-highlight;
-      }
-    }
-
     form {
-      max-height: 200px;
       overflow-y: auto;
-      margin-top: $space-medium;
     }
   }
 }

--- a/packages/composer-playground/src/app/connection-profile/add-connection-profile/add-connection-profile.component.spec.ts
+++ b/packages/composer-playground/src/app/connection-profile/add-connection-profile/add-connection-profile.component.spec.ts
@@ -13,678 +13,242 @@ import { BusinessNetworkDefinition, AdminConnection } from 'composer-admin';
 import { AlertService } from '../../basic-modals/alert.service';
 import { AdminService } from '../../services/admin.service';
 import { ConnectionProfileService } from '../../services/connectionprofile.service';
+import { IdentityService } from '../../services/identity.service';
 import { BehaviorSubject, Subject } from 'rxjs/Rx';
 
 import * as sinon from 'sinon';
 import { expect } from 'chai';
 
-class MockAdminService {
-    getAdminConnection(): AdminConnection {
-        return new AdminConnection();
-    }
-
-    ensureConnection(): Promise<any> {
-        return new Promise((resolve, reject) => {
-            resolve(true);
-        });
-    }
-
-    deploy(): Promise<any> {
-        return new Promise((resolve, reject) => {
-            resolve(new BusinessNetworkDefinition('org-acme-biznet@0.0.1', 'Acme Business Network'));
-        });
-    }
-
-    update(): Promise<any> {
-        return new Promise((resolve, reject) => {
-            resolve(new BusinessNetworkDefinition('org-acme-biznet@0.0.1', 'Acme Business Network'));
-        });
-    }
-
-    generateDefaultBusinessNetwork(): BusinessNetworkDefinition {
-        return new BusinessNetworkDefinition('org-acme-biznet@0.0.1', 'Acme Business Network');
-    }
-
-    isInitialDeploy(): boolean {
-        return true;
-    }
-}
-
-class MockAlertService {
-    public errorStatus$: Subject<string> = new BehaviorSubject<string>(null);
-    public busyStatus$: Subject<string> = new BehaviorSubject<string>(null);
-}
-
-class MockConnectionProfileService {
-    getAllProfiles(): Promise<any> {
-        return new Promise((resolve, reject) => {
-            resolve({profile0: 'a', profile2: 'c', profile1: 'b'});
-        });
-    }
-}
-
-@Directive({
-    selector: '[fileDragDrop]'
-})
-class MockDragDropDirective {
-    @Output()
-    public fileDragDropFileAccepted: EventEmitter<File> = new EventEmitter<File>();
-    @Output()
-    public fileDragDropFileRejected: EventEmitter<string> = new EventEmitter<string>();
-    @Output()
-    public fileDragDropDragOver: EventEmitter<string> = new EventEmitter<string>();
-    @Output()
-    public fileDragDropDragLeave: EventEmitter<string> = new EventEmitter<string>();
-
-    @Input()
-    public supportedFileTypes: string[] = [];
-    @Input()
-    maxFileSize: number = 0;
-}
-
-@Directive({
-    selector: 'file-importer'
-})
-class MockFileImporterDirective {
-    @Output()
-    public fileAccepted: EventEmitter<File> = new EventEmitter<File>();
-
-    @Output()
-    public fileRejected: EventEmitter<File> = new EventEmitter<File>();
-
-    @Input()
-    public expandInput: boolean = false;
-
-    @Input()
-    public svgName: string = '#icon-BNA_Upload';
-
-    @Input()
-    public maxFileSize: number = 0;
-
-    @Input()
-    public supportedFileTypes: string[] = [];
-}
-
 describe('AddConnectionProfileComponent', () => {
-    let sandbox;
+
     let component: AddConnectionProfileComponent;
     let fixture: ComponentFixture<AddConnectionProfileComponent>;
 
-    const NAME = 'New Profile';
-    const DESC = 'Test Description';
-    const MS_URL = 'msurl';
-    const PEER_URL = 'peerurl';
-    const EH_URL = 'ehurl';
-    const KEY_VAL_STORE = 'kvs';
-    const DEPLOY_TIME = 100;
-    const WAIT_TIME = 999;
-    const TIMEOUT = 134;
-    const CERT = 'cert';
-    const CERT_PATH = 'certpath';
-    const PEERS = ['peers'];
-    const ORDERERS = ['orderers'];
-    const CA = 'ca';
-    const CHANNEL = 'channel';
-    const MSPID = 'mspID';
+    let mockConnectionProfileService;
+    let mockIdentityService;
+    let mockAlertService;
 
     beforeEach(() => {
+
+        mockConnectionProfileService = sinon.createStubInstance(ConnectionProfileService);
+        mockIdentityService = sinon.createStubInstance(IdentityService);
+        mockAlertService = sinon.createStubInstance(AlertService);
+        mockAlertService.successStatus$ = {next: sinon.stub()};
+        mockAlertService.busyStatus$ = {next: sinon.stub()};
+        mockAlertService.errorStatus$ = {next: sinon.stub()};
+
         TestBed.configureTestingModule({
             declarations: [
-                AddConnectionProfileComponent, MockDragDropDirective, MockFileImporterDirective
+                AddConnectionProfileComponent
             ],
             imports: [
                 FormsModule
             ],
             providers: [
-                {provide: AlertService, useClass: MockAlertService},
-                NgbActiveModal,
-                {provide: AdminService, useClass: MockAdminService},
-                {provide: ConnectionProfileService, useClass: MockConnectionProfileService}
+                {provide: AlertService, useValue: mockAlertService},
+                {provide: ConnectionProfileService, useValue: mockConnectionProfileService},
+                {provide: IdentityService, useValue: mockIdentityService}
             ]
         });
 
-        sandbox = sinon.sandbox.create();
         fixture = TestBed.createComponent(AddConnectionProfileComponent);
         component = fixture.componentInstance;
     });
 
-    afterEach(() => {
-        sandbox.restore();
-    });
+    describe('#ngOnInit', () => {
+        it('should call updateConnectionProfiles', () => {
+            let updateConnectionProfilesStub = sinon.stub(component, 'updateConnectionProfiles');
 
-    describe('#removeFile', () => {
-        it('should reset current settings when removeFile is called', () => {
-            component.removeFile();
-            expect(component.expandInput).to.be.false;
-            expect(component.currentFile).to.be.null;
-            expect(component.currentFileName).to.be.null;
-            expect(component.version).to.equal('');
+            component['ngOnInit']();
+
+            updateConnectionProfilesStub.should.have.been.called;
         });
     });
 
-    describe('#fileDetected', () => {
-        it('should change this.expandInput to true', () => {
-            component.fileDetected();
-            expect(component.expandInput).to.be.true;
-        });
-    });
+    describe('updateConnectionProfiles', () => {
+        it('should update all connection profiles', fakeAsync(() => {
+            mockConnectionProfileService.getAllProfiles.returns(Promise.resolve({myProfile: {name: 'myProfile'}}));
 
-    describe('#fileLeft', () => {
-        it('should change this.expectedInput to false', () => {
-            component.fileLeft();
-            expect(component.expandInput).to.be.false;
-        });
-    });
+            mockIdentityService.getIdentities.returns(Promise.resolve(['bob']));
 
-    describe('#fileAccepted', () => {
+            component.updateConnectionProfiles();
 
-        it('should call this.createProfile', fakeAsync(() => {
-            let b = new Blob(['/**Connection Profile*/'], {type: 'json'});
-            let file = new File([b], 'New Profile.json');
-
-            let createMock = sandbox.stub(component, 'createProfile');
-            let dataBufferMock = sandbox.stub(component, 'getDataBuffer')
-            .returns(Promise.resolve('some data'));
-
-            component.fileAccepted(file);
             tick();
-            createMock.called;
-        }));
-
-        it('should call this.fileRejected when there is an error reading the file', fakeAsync(() => {
-            let b = new Blob(['/**CTO File*/'], {type: 'text/plain'});
-            let file = new File([b], 'newfile.cto');
-
-            let createMock = sandbox.stub(component, 'fileRejected');
-            let dataBufferMock = sandbox.stub(component, 'getDataBuffer')
-            .returns(Promise.reject('some data'));
-
-            component.fileAccepted(file);
-            tick();
-            createMock.called;
-        }));
-
-        it('should throw when given incorrect file type', fakeAsync(() => {
-
-            let b = new Blob(['/**PNG File*/'], {type: 'text/plain'});
-            let file = new File([b], 'newfile.png');
-
-            let createMock = sandbox.stub(component, 'fileRejected');
-            let dataBufferMock = sandbox.stub(component, 'getDataBuffer')
-            .returns(Promise.resolve('some data'));
-
-            component.fileAccepted(file);
-            tick();
-            createMock.called;
+            mockConnectionProfileService.getAllProfiles.should.have.been.called;
+            mockIdentityService.getIdentities.should.have.been.calledWith('myProfile');
+            component['connectionProfiles'].should.deep.equal([{
+                name: 'myProfile',
+                profile: {name: 'myProfile'},
+                default: false,
+                description: 'Default connection profile',
+                identities: [{
+                    userId: 'bob',
+                    businessNetwork: 'org-acme-biznet'
+                }]
+            }]);
         }));
     });
 
-    describe('#fileRejected', () => {
-        it('should return an error status', async(() => {
-            component.fileRejected('long reason to reject file');
+    describe('#generateProfileName', () => {
+        it('should generate a base name', () => {
+            component['generateProfileName']().should.equal('New Connection Profile');
+        });
 
-            component['alertService'].errorStatus$.subscribe(
-                (message) => {
-                    expect(message).to.be.equal('long reason to reject file');
-                }
-            );
-        }));
+        it('should generate an incremented base name if one exists already', () => {
+            component['connectionProfiles'] = ['New Connection Profile', 'New Connection Profile1'];
+            component['generateProfileName']().should.equal('New Connection Profile2');
+        });
+
+        it('should generate an incremented base name accounting for skipped indicies', () => {
+            component['connectionProfiles'] = ['New Connection Profile', 'New Connection Profile1', 'New Connection Profile2', 'New Connection Profile4'];
+            component['generateProfileName']().should.equal('New Connection Profile3');
+        });
     });
 
-    describe('#getDataBuffer', () => {
-        let file;
-        let mockFileReadObj;
-        let mockBuffer;
-        let mockFileRead;
-        let content;
+    describe('#retrieveConnectionProfileByName', () => {
+        it('should retrieve a profile by name if it exists', fakeAsync(() => {
+            let myProfile = {myProfile: {profile: 'myProfile'}};
+            mockConnectionProfileService.getAllProfiles.returns(Promise.resolve(myProfile));
 
-        beforeEach(() => {
-            content = 'hello world';
-            let data = new Blob([content], {type: 'text/plain'});
-            file = new File([data], 'mock.bna');
-
-            mockFileReadObj = {
-                readAsArrayBuffer: sandbox.stub(),
-                result: content,
-                onload: sinon.stub(),
-                onerror: sinon.stub()
-            };
-
-            mockFileRead = sinon.stub(window, 'FileReader');
-            mockFileRead.returns(mockFileReadObj);
-        });
-
-        afterEach(() => {
-            mockFileRead.restore();
-        });
-
-        it('should return data from a file', () => {
-            let promise = component.getDataBuffer(file);
-            mockFileReadObj.onload();
-            return promise
-            .then((data) => {
-                data.toString().should.equal(content);
-            });
-        });
-
-        it('should give error in promise chain', () => {
-            let promise = component.getDataBuffer(file);
-            mockFileReadObj.onerror('error');
-            return promise
-            .then((data) => {
-                data.should.be.null;
+            component['retrieveConnectionProfileByName']('myProfile')
+            .then((result) => {
+                result.should.deep.equal({profile: 'myProfile'});
             })
-            .catch((err) => {
-                err.should.equal('error');
-            });
-        });
-    });
-
-    describe('#createProfile', () => {
-        let V06_INPUT = {
-            description: DESC,
-            type: 'hlf',
-            membershipServicesURL: MS_URL,
-            peerURL: PEER_URL,
-            eventHubURL: EH_URL,
-            keyValStore: KEY_VAL_STORE,
-            deployWaitTime: DEPLOY_TIME,
-            invokeWaitTime: WAIT_TIME,
-            certificate: CERT,
-            certificatePath: CERT_PATH
-        };
-
-        let V1_INPUT = {
-            description: DESC,
-            type: 'hlfv1',
-            orderers: ORDERERS,
-            ca: CA,
-            peers: PEERS,
-            keyValStore: KEY_VAL_STORE,
-            timeout: TIMEOUT,
-            channel: CHANNEL,
-            mspID: MSPID,
-        };
-
-        let BAD_INPUT = 'This is not valid input';
-
-        let INVALID_VERSION = {
-            description: 'test',
-            type: 'hlfv100',
-        };
-
-        it('should process json data for v0.6 hlf', fakeAsync(() => {
-            let createMock = sandbox.stub(component, 'setV06Defaults').returns(Promise.resolve('some data'));
-            let addMock = sandbox.stub(component, 'addConnectionProfile');
-            let data = JSON.stringify(V06_INPUT);
-            component.createProfile(data);
-            tick();
-            createMock.should.have.been.called;
-            component['addConnectionProfileDescription'].should.equal(DESC);
-            component['addConnectionProfileType'].should.equal('hlf');
-            component['addConnectionProfileMembershipServicesURL'].should.equal(MS_URL);
-            component['addConnectionProfilePeerURL'].should.equal(PEER_URL);
-            component['addConnectionProfileEventHubURL'].should.equal(EH_URL);
-            component['addConnectionProfileKeyValStore'].should.equal(KEY_VAL_STORE);
-            component['addConnectionProfileDeployWaitTime'].should.equal(DEPLOY_TIME);
-            component['addConnectionProfileInvokeWaitTime'].should.equal(WAIT_TIME);
-            component['addConnectionProfileCertificate'].should.equal(CERT);
-            component['addConnectionProfileCertificatePath'].should.equal(CERT_PATH);
-            addMock.should.have.been.called;
-        }));
-
-        it('should process json data for v1 hlf', fakeAsync(() => {
-            let createMock = sandbox.stub(component, 'setV1Defaults').returns(Promise.resolve('some data'));
-            let addMock = sandbox.stub(component, 'addConnectionProfile');
-            let data = JSON.stringify(V1_INPUT);
-            component.createProfile(data);
-            tick();
-            createMock.should.have.been.called;
-            component['addConnectionProfileDescription'].should.equal(DESC);
-            component['addConnectionProfileType'].should.equal('hlfv1');
-            component['addConnectionProfileOrderers'].should.deep.equal(ORDERERS);
-            component['addConnectionProfileCertificateAuthority'].should.equal(CA);
-            component['addConnectionProfilePeers'].should.deep.equal(PEERS);
-            component['addConnectionProfileKeyValStore'].should.equal(KEY_VAL_STORE);
-            component['addConnectionProfileChannel'].should.equal(CHANNEL);
-            component['addConnectionProfileMspId'].should.equal(MSPID);
-            component['addConnectionProfileTimeout'].should.equal(TIMEOUT);
-            addMock.should.have.been.called;
-        }));
-
-        it('should throw an error for bad input', fakeAsync(() => {
-            try {
-                component.createProfile(BAD_INPUT);
-            } catch (e) {
-                e.message.should.contain('Parse error');
-            }
-        }));
-
-        it('should throw an error for an invalid type', fakeAsync(() => {
-            let data = JSON.stringify(INVALID_VERSION);
-            try {
-                component.createProfile(data);
-            } catch (e) {
-                e.message.should.contain('Invalid type in profile');
-            }
-        }));
-
-    });
-
-    describe('#changeCurrentFileType', () => {
-        let TEST_DESC = 'Test Description';
-        beforeEach(() => {
-            component['addConnectionProfileDescription'] = TEST_DESC;
-        });
-
-        it('should deal with the version being 0.6', fakeAsync(() => {
-            let setMock = sandbox.stub(component, 'setV06Defaults').returns(Promise.resolve());
-            component['version'] = 'v06';
-            component.changeCurrentFileType();
-            tick();
-            setMock.should.have.been.called;
-            expect(component.currentFile).to.be.null;
-            component['newConnectionProfile'].type.should.equal('hlf');
-            component['newConnectionProfile'].description.should.equal(TEST_DESC);
-        }));
-
-        it('should deal with the addConnectionProfileType being hlf ', fakeAsync(() => {
-            let setMock = sandbox.stub(component, 'setV06Defaults').returns(Promise.resolve());
-            component['addConnectionProfileType'] = 'hlf';
-            component.changeCurrentFileType();
-            tick();
-            setMock.should.have.been.called;
-            expect(component.currentFile).to.be.null;
-            component['newConnectionProfile'].type.should.equal('hlf');
-            component['newConnectionProfile'].description.should.equal(TEST_DESC);
-        }));
-
-        it('should deal with the version being v1', fakeAsync(() => {
-            let setMock = sandbox.stub(component, 'setV1Defaults').returns(Promise.resolve());
-            component['version'] = 'v1';
-            component.changeCurrentFileType();
-            tick();
-            setMock.should.have.been.called;
-            expect(component.currentFile).to.be.null;
-            component['newConnectionProfile'].type.should.equal('hlfv1');
-            component['newConnectionProfile'].description.should.equal(TEST_DESC);
-        }));
-
-        it('should throw an error when no version or connection type', fakeAsync(() => {
-            component['version'] = 'BAD';
-            try {
-                component.changeCurrentFileType();
-            } catch (e) {
-                e.message.should.contain('Unsupported version');
-            }
-        }));
-    });
-
-    describe('#setV06Defaults', () => {
-        it('should create a new profile and set defaults for a v0.6 fabric', fakeAsync(() => {
-            let mockUpdate = sandbox.stub(component, 'updateConnectionProfiles').returns(Promise.resolve());
-            component['connectionProfiles'] = [];
-            component.setV06Defaults().then(() => {
-                component['addConnectionProfileName'].should.equal('New Connection Profile');
-                verifyUnchangeableDefaults();
+            .catch((error) => {
+                fail('should not error');
             });
         }));
 
-        it('should create a new profile with a new name and set defaults for a v0.6 fabric', fakeAsync(() => {
-            let mockUpdate = sandbox.stub(component, 'updateConnectionProfiles').returns(Promise.resolve());
-            component['connectionProfiles'] = [{name: 'New Connection Profile'}];
-            component.setV06Defaults().then(() => {
-                component['addConnectionProfileName'].should.equal('New Connection Profile 2');
-                verifyUnchangeableDefaults();
+        it('should return an error if a profile by name does not exist', fakeAsync(() => {
+            let myProfile = [{myProfile: {name: 'myProfile'}}];
+            mockConnectionProfileService.getAllProfiles.returns(Promise.resolve(myProfile));
+            component['retrieveConnectionProfileByName']('notThisProfile')
+            .then((result) => {
+                fail('should throw error');
+            })
+            .catch((error) => {
+                error.toString().should.equal('Error: Unknown connection profile name: notThisProfile');
             });
         }));
 
-        function verifyUnchangeableDefaults() {
-            component['addConnectionProfileDescription'].should.equal('A description for a V0.6 Profile');
-            component['addConnectionProfileType'].should.equal('hlf');
-            component['addConnectionProfilePeerURL'].should.equal('grpc://localhost:7051');
-            component['addConnectionProfileMembershipServicesURL'].should.equal('grpc://localhost:7054');
-            component['addConnectionProfileEventHubURL'].should.equal('grpc://localhost:7053');
-            component['addConnectionProfileKeyValStore'].should.equal('/tmp/keyValStore');
-            component['addConnectionProfileDeployWaitTime'].should.equal(300);
-            component['addConnectionProfileInvokeWaitTime'].should.equal(30);
-            expect(component['addConnectionProfileCertificate']).to.be.null;
-            expect(component['addConnectionProfileCertificatePath']).to.be.null;
-        }
     });
 
-    describe('#setV1Defaults', () => {
+    describe('#setConnectionProfile', () => {
+        it('should be able to set default v1 profile', fakeAsync(() => {
+            let updateConnectionProfilesStub = sinon.stub(component, 'updateConnectionProfiles');
+            updateConnectionProfilesStub.returns(Promise.resolve({}));
 
-        it('should create a new profile and set defaults for a v1 fabric 1', fakeAsync(() => {
-            let mockUpdate = sandbox.stub(component, 'updateConnectionProfiles').returns(Promise.resolve());
-            component['connectionProfiles'] = [];
-            component.setV1Defaults();
+            component.setConnectionProfile('_$v1');
+
             tick();
 
-            component['addConnectionProfileName'].should.equal('New Connection Profile');
-            verifyUnchangeableDefaults();
+            let profile = { description: 'A description for a V1 Profile',
+                            type: 'hlfv1',
+                            orderers: [{
+                                        url: 'grpc://localhost:7050',
+                                        cert: ''
+                                        }],
+                            ca: {
+                                    url: 'http://localhost:7054',
+                                    name: ''
+                                },
+                            peers: [{
+                                        requestURL: 'grpc://localhost:7051',
+                                        eventURL: 'grpc://localhost:7053',
+                                        cert: ''
+                                    }],
+                            keyValStore: '/tmp/keyValStore',
+                            channel: 'composerchannel',
+                            mspID: 'Org1MSP',
+                            timeout: 300
+                        };
+
+            let expectedConstruct = {name: 'New Connection Profile',
+                                     profile: profile,
+                                     default: false };
+
+            component['connectionProfile'].should.deep.equal(expectedConstruct);
         }));
 
-        it('should create a new profile and set defaults for a v1 fabric 2', fakeAsync(() => {
-            let mockUpdate = sandbox.stub(component, 'updateConnectionProfiles').returns(Promise.resolve());
-            component['connectionProfiles'] = [{name: 'New Connection Profile'}];
-            component.setV1Defaults();
+        it('should be able to set default v0.6 profile', fakeAsync(() => {
+            let updateConnectionProfilesStub = sinon.stub(component, 'updateConnectionProfiles');
+            updateConnectionProfilesStub.returns(Promise.resolve({}));
+
+            component.setConnectionProfile('_$v06');
+
             tick();
-            component['addConnectionProfileName'].should.equal('New Connection Profile 2');
-            verifyUnchangeableDefaults();
+
+            let profile = {
+                            description: 'A description for a V0.6 Profile',
+                            type: 'hlf',
+                            membershipServicesURL: 'grpc://localhost:7054',
+                            peerURL: 'grpc://localhost:7051',
+                            eventHubURL: 'grpc://localhost:7053',
+                            keyValStore: '/tmp/keyValStore',
+                            deployWaitTime: 5 * 60,
+                            invokeWaitTime: 30,
+                            certificate: null,
+                            certificatePath: null
+                        };
+
+            let expectedConstruct = {name: 'New Connection Profile',
+                                     profile: profile,
+                                     default: false };
+
+            component['connectionProfile'].should.deep.equal(expectedConstruct);
         }));
 
-        function verifyUnchangeableDefaults() {
-            component['addConnectionProfileDescription'].should.equal('A description for a V1 Profile');
-            component['addConnectionProfileType'].should.equal('hlfv1');
-            component['addConnectionProfileOrderers'].should.deep.equal([{
-                url: 'grpc://localhost:7050',
-                cert: ''
-            }]);
+        it('should be able to set named profile', fakeAsync(() => {
+            let updateConnectionProfilesStub = sinon.stub(component, 'updateConnectionProfiles');
+            updateConnectionProfilesStub.returns(Promise.resolve({}));
 
-            component['addConnectionProfileCertificateAuthority'].url.should.equal('http://localhost:7054');
-            component['addConnectionProfileCertificateAuthority'].name.should.equal('');
-            component['addConnectionProfilePeers'].should.deep.equal([{
-                requestURL: 'grpc://localhost:7051',
-                eventURL: 'grpc://localhost:7053',
-                cert: ''
-            }]);
-            component['addConnectionProfileKeyValStore'].should.equal('/tmp/keyValStore');
-            component['addConnectionProfileChannel'].should.equal('composerchannel');
-            component['addConnectionProfileMspId'].should.equal('Org1MSP');
-            component['addConnectionProfileTimeout'].should.equal(300);
-        }
+            let targetProfile = { name: 'Pingu', type: 'Penguin'};
 
+            let retrieveConnectionProfileByNameStub = sinon.stub(component, 'retrieveConnectionProfileByName');
+            retrieveConnectionProfileByNameStub.returns(targetProfile);
+
+            component.setConnectionProfile('selectMe');
+
+            tick();
+
+            let expectedConstruct = {name: 'selectMe',
+                                     profile: targetProfile,
+                                     default: true };
+
+            component['connectionProfile'].should.deep.equal(expectedConstruct);
+        }));
     });
 
-    describe('#updateConnectionProfiles', () => {
+    describe('#dismiss', () => {
+        it('should trigger cancelAdd.emit ', () => {
+            let spy = sinon.spy(component.cancelAdd, 'emit');
 
-        it('should update/refresh the list of connection profiles', fakeAsync(() => {
-            component.updateConnectionProfiles().then(() => {
-                component['connectionProfiles'].should.deep.equal([
-                    {name: 'profile0', profile: 'a', default: false},
-                    {name: 'profile1', profile: 'b', default: false},
-                    {name: 'profile2', profile: 'c', default: false}
-                ]);
-            });
-        }));
+            component.dismiss();
+
+            spy.should.have.been.calledWith(true);
+        });
     });
 
-    describe('#addConnectionProfile', () => {
-        let mockModalSpy;
+    describe('#initiateAddToProfile', () => {
+        it('should trigger profileToUse.emit with the connection profile name', () => {
+            component['connectionProfile'] = {name: 'bob'};
+            let spy = sinon.spy(component.profileToUse, 'emit');
 
-        beforeEach(inject([NgbActiveModal], (activeModal: NgbActiveModal) => {
-            mockModalSpy = sinon.spy(activeModal, 'close');
+            component.initiateAddToProfile();
 
-            component['addConnectionProfileName'] = NAME;
-            component['addConnectionProfileDescription'] = DESC;
-            component['addConnectionProfileMembershipServicesURL'] = MS_URL;
-            component['addConnectionProfilePeerURL'] = PEER_URL;
-            component['addConnectionProfileEventHubURL'] = EH_URL;
-            component['addConnectionProfileKeyValStore'] = KEY_VAL_STORE;
-            component['addConnectionProfileDeployWaitTime'] = DEPLOY_TIME;
-            component['addConnectionProfileInvokeWaitTime'] = WAIT_TIME;
-            component['addConnectionProfileCertificate'] = CERT;
-            component['addConnectionProfileCertificatePath'] = CERT_PATH;
-            component['addConnectionProfileOrderers'] = ORDERERS;
-            component['addConnectionProfileCertificateAuthority'] = CA;
-            component['addConnectionProfilePeers'] = PEERS;
-            component['addConnectionProfileChannel'] = CHANNEL;
-            component['addConnectionProfileMspId'] = MSPID;
-            component['addConnectionProfileTimeout'] = TIMEOUT;
-        }));
-
-        it('should deal with the version being 0.6 and a certificate', () => {
-            let EXP = {
-                default: false,
-                name: 'New Profile',
-                profile: {
-                    certificate: CERT + '\n',
-                    certificatePath: CERT_PATH,
-                    deployWaitTime: DEPLOY_TIME,
-                    description: DESC,
-                    eventHubURL: EH_URL,
-                    invokeWaitTime: WAIT_TIME,
-                    keyValStore: KEY_VAL_STORE,
-                    membershipServicesURL: MS_URL,
-                    peerURL: PEER_URL,
-                    type: 'hlf'
-                }
-            };
-
-            component['version'] = 'v06';
-            component.addConnectionProfile();
-            mockModalSpy.should.have.been.calledWith(EXP);
+            spy.should.have.been.calledWith('bob');
         });
+    });
 
-        it('should deal with the version being 0.6 and without a certificate', () => {
-            component['addConnectionProfileCertificate'] = null;
+    describe('#initiateAddWithProfile', () => {
+        it('should trigger profileToEdit.emit with the connection profile', () => {
+            let myProfile = {name: 'bob', penguins : ['pingu', 'poppy']};
+            component['connectionProfile'] = myProfile;
+            let spy = sinon.spy(component.profileToEdit, 'emit');
 
-            let EXP = {
-                default: false,
-                name: 'New Profile',
-                profile: {
-                    certificate: null,
-                    certificatePath: CERT_PATH,
-                    deployWaitTime: DEPLOY_TIME,
-                    description: DESC,
-                    eventHubURL: EH_URL,
-                    invokeWaitTime: WAIT_TIME,
-                    keyValStore: KEY_VAL_STORE,
-                    membershipServicesURL: MS_URL,
-                    peerURL: PEER_URL,
-                    type: 'hlf'
-                }
-            };
+            component.initiateAddWithProfile();
 
-            component['version'] = 'v06';
-            component.addConnectionProfile();
-            mockModalSpy.should.have.been.calledWith(EXP);
-        });
-
-        it('should deal with the version being 1', () => {
-            let EXP = {
-                default: false,
-                name: 'New Profile',
-                profile: {
-                    ca: CA,
-                    channel: CHANNEL,
-                    timeout: TIMEOUT,
-                    description: DESC,
-                    keyValStore: KEY_VAL_STORE,
-                    mspID: MSPID,
-                    orderers: [{url: 'orderers', cert: ''}],
-                    peers: PEERS,
-                    type: 'hlfv1'
-                }
-            };
-
-            component['version'] = 'v1';
-            component.addConnectionProfile();
-            mockModalSpy.should.have.been.calledWith(EXP);
-        });
-
-        it('should deal with the version being 0.6 and with a certificate just whitespace', () => {
-            component['addConnectionProfileCertificate'] = ' ';
-
-            let EXP = {
-                default: false,
-                name: 'New Profile',
-                profile: {
-                    certificate: ' ',
-                    certificatePath: CERT_PATH,
-                    deployWaitTime: DEPLOY_TIME,
-                    description: DESC,
-                    eventHubURL: EH_URL,
-                    invokeWaitTime: WAIT_TIME,
-                    keyValStore: KEY_VAL_STORE,
-                    membershipServicesURL: MS_URL,
-                    peerURL: PEER_URL,
-                    type: 'hlf'
-                }
-            };
-
-            component['version'] = 'v06';
-            component.addConnectionProfile();
-            mockModalSpy.should.have.been.calledWith(EXP);
-        });
-
-        it('should deal with the version being 0.6 and with a certificate with new line char', () => {
-            component['addConnectionProfileCertificate'] = 'bob \n';
-
-            let EXP = {
-                default: false,
-                name: 'New Profile',
-                profile: {
-                    certificate: 'bob \n',
-                    certificatePath: CERT_PATH,
-                    deployWaitTime: DEPLOY_TIME,
-                    description: DESC,
-                    eventHubURL: EH_URL,
-                    invokeWaitTime: WAIT_TIME,
-                    keyValStore: KEY_VAL_STORE,
-                    membershipServicesURL: MS_URL,
-                    peerURL: PEER_URL,
-                    type: 'hlf'
-                }
-            };
-
-            component['version'] = 'v06';
-            component.addConnectionProfile();
-            mockModalSpy.should.have.been.calledWith(EXP);
-        });
-
-        it('should deal with the version being 1 with object orderers', () => {
-            component['addConnectionProfileOrderers'] = [{url: 'http://localhost', cert: 'bob'}];
-
-            let EXP = {
-                default: false,
-                name: 'New Profile',
-                profile: {
-                    ca: CA,
-                    channel: CHANNEL,
-                    timeout: TIMEOUT,
-                    description: DESC,
-                    keyValStore: KEY_VAL_STORE,
-                    mspID: MSPID,
-                    orderers: [{url: 'http://localhost', cert: 'bob'}],
-                    peers: PEERS,
-                    type: 'hlfv1'
-                }
-            };
-
-            component['version'] = 'v1';
-            component.addConnectionProfile();
-            mockModalSpy.should.have.been.calledWith(EXP);
-        });
-
-        it('should deal with an invalid version', () => {
-            try {
-                component['version'] = 'badversion';
-                component.addConnectionProfile();
-            } catch (e) {
-                e.message.should.contain('Unknown connection profile version selected');
-            }
+            spy.should.have.been.calledWith(myProfile);
         });
     });
 });

--- a/packages/composer-playground/src/app/connection-profile/connection-profile.module.ts
+++ b/packages/composer-playground/src/app/connection-profile/connection-profile.module.ts
@@ -11,10 +11,10 @@ import { FileImporterModule } from '../common/file-importer/file-importer.module
 
 @NgModule({
     imports: [CommonModule, FormsModule, NgbModule, ReactiveFormsModule, FileImporterModule],
-    entryComponents: [AddCertificateComponent, AddConnectionProfileComponent, ViewCertificateComponent],
+    entryComponents: [AddCertificateComponent, ViewCertificateComponent],
     declarations: [ConnectionProfileComponent, AddCertificateComponent, AddConnectionProfileComponent, ViewCertificateComponent],
     providers: [],
-    exports: [ConnectionProfileComponent]
+    exports: [ConnectionProfileComponent, AddConnectionProfileComponent]
 })
 
 export class ConnectionProfileModule {

--- a/packages/composer-playground/src/app/identity/add-identity/add-identity.component.html
+++ b/packages/composer-playground/src/app/identity/add-identity/add-identity.component.html
@@ -1,32 +1,49 @@
 <section class="add-identity">
-  <header class="modal-header">
-    <h1>Add Identity</h1>
-    <button class="icon modal-exit" (click)="activeModal.close()">
-      <svg class="ibm-icon" aria-hidden="true">
-       <use xlink:href="#icon-close_new"></use>
-      </svg>
-    </button>
-  </header>
-  <section class="modal-body">
-    <p>Add an existing ID to your wallet</p>
-
-    <form #addIdentityForm="ngForm" id="add-identity-form" (ngSubmit)="addIdentity()">
-      <div class="justified-input">
-        <label for="userID" class="required">User ID<abbr title="required">*</abbr></label>
-        <input required type="text" [(ngModel)]="userID" id="userID" name="userID" autocomplete="off">
-      </div>
-
-      <div class="justified-input">
-        <label for="userSecret" class="required">User Secret<abbr title="required">*</abbr></label>
-        <input required type="password" [(ngModel)]="userSecret" id="userSecret" name="userSecret" autocomplete="off">
-      </div>
-    </form>
+    <h1>Create ID Card</h1>
+  <section class="profiles">
+    <div class="description"><b>PROVIDE SECURITY CREDENTIALS</b></div>
+    <div class="holding-div">
+        <div class="create-route">
+            <p>You must provide one of two types of information to create an ID card:</p>
+            <div class="file-types-list">
+                <div class="file-types-list-item">
+                    <input type="radio" id="noCert" name="file-type" [checked]="true"
+                        (change)="useCertificates(false)">
+                    <label class="radio-label" for="noCert"><h3>ID and Secret</h3></label>
+                    <div class="description"><p>These can be created when accessing a business network.</p></div>
+                </div>
+                <div class="file-types-list-item">
+                    <input type="radio" id="useCert" name="file-type" [disabled]="true"
+                        (change)="useCertificates(true)">
+                    <label class="radio-label" for="useCert" style="color:grey"><h3>Certificates</h3></label>
+                    <div class="description" style="color:grey"><p>Required here are public and private certificate files.</p></div>
+                </div>
+            </div>
+        </div>
+        <div *ngIf="!useCerts" class="noCerts">
+            <p>An ID and Secret must be created by someone who already has access to the Business Network you are connecting to.</p>
+            <form #addIdentityForm="ngForm" id="add-identity-form" (ngSubmit)="addIdentity()">
+                <div class="option">
+                    <label for="userId"><h3>User ID</h3></label>
+                    <input required type="text" [(ngModel)]="userId" id="userId" name="userId" autocomplete="off">
+                </div>
+                <div class="option">
+                    <label for="userSecret"><h3>User Secret</h3></label>
+                    <input required type="password" [(ngModel)]="userSecret" id="userSecret" name="userSecret" autocomplete="off">
+                </div>
+                <div class="option">
+                    <label for="busNetName"><h3>Name of Business Network</h3></label>
+                    <input required type="text" [(ngModel)]="busNetName" id="busNetName" name="busNetName" autocomplete="off">
+                </div>
+            </form>
+        </div>
+    </div>
   </section>
   <footer>
-    <button type="button" class="secondary" (click)="activeModal.close();">
+    <button type="button" class="secondary" (click)="close();">
       <span>Cancel</span>
     </button>
-    <button type="submit" form="add-identity-form" class="primary" [disabled]="!addIdentityForm.form.valid || addInProgress">
+    <button type="submit" form="add-identity-form" class="primary" [disabled]="!validContents()">
       <div *ngIf="!addInProgress">
         <span>Add</span>
       </div>
@@ -40,3 +57,5 @@
     </button>
   </footer>
 </section>
+
+

--- a/packages/composer-playground/src/app/identity/add-identity/add-identity.component.scss
+++ b/packages/composer-playground/src/app/identity/add-identity/add-identity.component.scss
@@ -1,10 +1,53 @@
 @import '../../../assets/styles/base/colors';
 @import '../../../assets/styles/base/variables';
+@import '../../connection-profile/add-connection-profile/add-connection-profile.component';
 
-add-identity-modal {
-  .add-identity {
-    p {
-      color: $secondary-text;
+.add-identity {
+
+  // Take main styling from add-connection-profile
+  @extend .add-connection;
+
+    .profiles {
+         .create-route {
+            margin-right: $space-xlarge;
+            margin-bottom: $space-mlarge;
+            border-bottom: $border-width-small solid $fourth-highlight;
+         }
+    }
+
+    .noCerts {
+        display: flex;
+        flex-direction: column;
+        margin-bottom: $space-large;
+        margin-right: $space-xlarge;
+
+        .option {
+            display: flex;
+            flex-direction: row;
+            align-content: center;
+            margin-top: $space-medium;
+        }
+
+        p {
+              color:$primary-text;
+              line-height:19px;
+              margin-top: 0;
+              margin-bottom: 0;
+              font-weight: 300;
+          }
+    }
+
+    label {
+        display: flex;
+        align-self: center;
+        min-width: 10rem;
+    }
+
+    input[type='text'], input[type='password'] {
+        display: flex;
+        align-self: center;
+        color:$primary-text;
+        margin-bottom: 0;
     }
 
     footer {
@@ -15,4 +58,3 @@ add-identity-modal {
       width: 100%;
     }
   }
-}

--- a/packages/composer-playground/src/app/identity/add-identity/add-identity.component.spec.ts
+++ b/packages/composer-playground/src/app/identity/add-identity/add-identity.component.spec.ts
@@ -12,6 +12,7 @@ import { Wallet } from 'composer-common';
 import { AddIdentityComponent } from './add-identity.component';
 import { ConnectionProfileService } from '../../services/connectionprofile.service';
 import { WalletService } from '../../services/wallet.service';
+import { AlertService } from '../../basic-modals/alert.service';
 
 describe('AddIdentityComponent', () => {
     let sandbox;
@@ -21,19 +22,25 @@ describe('AddIdentityComponent', () => {
     let mockActiveModal;
     let mockConnectionProfileService;
     let mockWalletService;
+    let mockAlertService;
 
     beforeEach(() => {
         mockActiveModal = sinon.createStubInstance(NgbActiveModal);
         mockConnectionProfileService = sinon.createStubInstance(ConnectionProfileService);
         mockWalletService = sinon.createStubInstance(WalletService);
+        mockAlertService = sinon.createStubInstance(AlertService);
+
+        mockAlertService.successStatus$ = {next: sinon.stub()};
+        mockAlertService.busyStatus$ = {next: sinon.stub()};
+        mockAlertService.errorStatus$ = {next: sinon.stub()};
 
         TestBed.configureTestingModule({
             imports: [FormsModule],
             declarations: [AddIdentityComponent],
             providers: [
-                {provide: NgbActiveModal, useValue: mockActiveModal},
                 {provide: ConnectionProfileService, useValue: mockConnectionProfileService},
-                {provide: WalletService, useValue: mockWalletService}
+                {provide: WalletService, useValue: mockWalletService},
+                {provide: AlertService, useValue: mockAlertService}
             ]
         })
         .compileComponents();
@@ -59,8 +66,10 @@ describe('AddIdentityComponent', () => {
             mockWalletService.getWallet.returns(mockWallet);
         });
 
-        it('should add an identity to the wallet', fakeAsync(() => {
+        it('should add an identity to the wallet and inform success', fakeAsync(() => {
             mockWallet.contains.returns(Promise.resolve(false));
+            mockWallet.add.returns(Promise.resolve());
+            let spy = sinon.spy(component.identityAdded, 'emit');
 
             component.addIdentity();
 
@@ -68,11 +77,18 @@ describe('AddIdentityComponent', () => {
 
             mockWallet.update.should.not.have.been.called;
             mockWallet.add.should.have.been.called.once;
-            // TODO called with?
+            mockAlertService.successStatus$.next.should.have.been.calledWith({
+                                title: 'ID Card Added',
+                                text: 'The ID card was successfully added to My Wallet.',
+                                icon: '#icon-role_24'
+                            });
+            spy.should.have.been.calledWith({success: true});
         }));
 
         it('should update an identity in the wallet', fakeAsync(() => {
             mockWallet.contains.returns(Promise.resolve(true));
+            mockWallet.update.returns(Promise.resolve());
+            let spy = sinon.spy(component.identityAdded, 'emit');
 
             component.addIdentity();
 
@@ -80,11 +96,17 @@ describe('AddIdentityComponent', () => {
 
             mockWallet.add.should.not.have.been.called;
             mockWallet.update.should.have.been.called.once;
-            // TODO called with?
+            mockAlertService.successStatus$.next.should.have.been.calledWith({
+                                title: 'ID Card Updated',
+                                text: 'The ID card was successfully updated within My Wallet.',
+                                icon: '#icon-role_24'
+                            });
+            spy.should.have.been.calledWith({success: true});
         }));
 
-        it('should handle an error', fakeAsync(() => {
+        it('should handle an error and inform the user', fakeAsync(() => {
             mockWallet.contains.returns(Promise.reject('test error'));
+            let spy = sinon.spy(component.identityAdded, 'emit');
 
             component.addIdentity();
 
@@ -92,8 +114,82 @@ describe('AddIdentityComponent', () => {
 
             mockWallet.add.should.not.have.been.called;
             mockWallet.update.should.not.have.been.called;
-            mockActiveModal.dismiss.should.have.been.called.once;
-            // TODO called with?
+            component['addInProgress'].should.be.false;
+            mockAlertService.errorStatus$.next.should.have.been.calledWith('test error');
+            spy.should.have.been.calledWith({success: false});
         }));
+    });
+
+    describe('#validContents', () => {
+
+        it('should not enable validation if trying to set certificates', () => {
+            // Certs path
+            component['useCerts'] = true;
+            component['validContents']().should.be.false;
+        });
+
+        it('should not validate if a userID field is empty when specifying user ID/Secret', () => {
+            // Secret/ID path
+            component['useCerts'] = false;
+            component['addInProgress'] = false;
+            component['userId'] = null;
+            component['userSecret'] = 'mySecret';
+            component['busNetName'] = 'myName';
+
+            component['validContents']().should.be.false;
+        });
+
+        it('should not validate if a userSecret field is empty when specifying user ID/Secret', () => {
+            // Secret/ID path
+            component['useCerts'] = false;
+            component['addInProgress'] = false;
+            component['userId'] = 'myID';
+            component['userSecret'] = null;
+            component['busNetName'] = 'myName';
+
+            component['validContents']().should.be.false;
+        });
+
+        it('should validate if a Business Network Name field is empty when specifying user ID/Secret', () => {
+            // Secret/ID path
+            component['useCerts'] = false;
+            component['addInProgress'] = false;
+            component['userId'] = 'myID';
+            component['userSecret'] = 'mySecret';
+            component['busNetName'] = null;
+
+            component['validContents']().should.be.true;
+        });
+
+        it('should validate if all text fields are added when specifying user ID/Secret', () => {
+            // Secret/ID path
+            component['useCerts'] = false;
+            component['addInProgress'] = false;
+            component['userId'] = 'myID';
+            component['userSecret'] = 'mySecret';
+            component['busNetName'] = 'myName';
+
+            component['validContents']().should.be.true;
+        });
+    });
+
+    describe('#useCertificates', () => {
+        it('should set flag to false when passed false', () => {
+            component['useCertificates'](false);
+            component['useCerts'].should.be.false;
+        });
+
+        it('should set flag to true when passed true', () => {
+            component['useCertificates'](true);
+            component['useCerts'].should.be.true;
+        });
+    });
+
+    describe('#close', () => {
+        it('should emit on close', () => {
+            let spy = sinon.spy(component.cancelAdd, 'emit');
+            component['close']();
+            spy.should.have.been.calledWith(true);
+        });
     });
 });

--- a/packages/composer-playground/src/app/identity/add-identity/add-identity.component.ts
+++ b/packages/composer-playground/src/app/identity/add-identity/add-identity.component.ts
@@ -1,48 +1,95 @@
-import { Component } from '@angular/core';
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { ConnectionProfileService } from '../../services/connectionprofile.service';
+import { AlertService } from '../../basic-modals/alert.service';
 import { WalletService } from '../../services/wallet.service';
 
 @Component({
-    selector: 'add-identity-modal',
+    selector: 'add-identity',
     templateUrl: './add-identity.component.html',
     styleUrls: ['./add-identity.component.scss'.toString()]
 })
 
 export class AddIdentityComponent {
 
-    private userID: string = null;
+    @Input() targetProfileName: string;
+    @Output() identityAdded = new EventEmitter<any>();
+    @Output() cancelAdd = new EventEmitter<any>();
+
+    private userId: string = null;
     private userSecret: string = null;
+    private busNetName: string = null;
     private addInProgress: boolean = false;
+    private useCerts: boolean = false;
 
     constructor(private connectionProfileService: ConnectionProfileService,
                 private walletService: WalletService,
-                private activeModal: NgbActiveModal) {
+                private alertService: AlertService) {
 
+    }
+
+    close() {
+        this.cancelAdd.emit(true);
+    }
+
+    useCertificates(option: boolean) {
+        this.useCerts = option;
+    }
+
+    validContents(): boolean {
+        if (this.useCerts) {
+            return false;
+        } else {
+            return ((this.userId !== null && this.userId.length !== 0 &&
+                     this.userSecret !== null && this.userSecret.length !== 0) ||
+                     this.addInProgress);
+        }
     }
 
     addIdentity() {
         this.addInProgress = true;
-
-        let connectionProfile = this.connectionProfileService.getCurrentConnectionProfile();
-        let wallet = this.walletService.getWallet(connectionProfile);
-
-        return wallet.contains(this.userID)
+        let wallet = this.walletService.getWallet(this.targetProfileName);
+        return wallet.contains(this.userId)
         .then((contains) => {
             if (contains) {
-                return wallet.update(this.userID, this.userSecret);
+                this.alertService.busyStatus$.next({
+                        title: 'Updating ID card',
+                        text: 'updating the ID card ' + this.userId
+                    });
+                return wallet.update(this.userId, this.userSecret)
+                .then(() => {
+                        this.alertService.busyStatus$.next(null);
+                        this.alertService.successStatus$.next({
+                            title: 'ID Card Updated',
+                            text: 'The ID card was successfully updated within My Wallet.',
+                            icon: '#icon-role_24'
+                        });
+                        this.addInProgress = false;
+                        this.identityAdded.emit({success: true});
+                    });
+
             } else {
-                return wallet.add(this.userID, this.userSecret);
+                this.alertService.busyStatus$.next({
+                        title: 'Adding ID card',
+                        text: 'adding ID card ' + this.userId
+                    });
+                return wallet.add(this.userId, this.userSecret)
+                .then(() => {
+                        this.alertService.busyStatus$.next(null);
+                        this.alertService.successStatus$.next({
+                            title: 'ID Card Added',
+                            text: 'The ID card was successfully added to My Wallet.',
+                            icon: '#icon-role_24'
+                        });
+                        this.addInProgress = false;
+                        this.identityAdded.emit({success: true});
+                    });
             }
         })
-        .then(() => {
-            this.addInProgress = false;
-            this.activeModal.close();
-        })
         .catch((error) => {
-            this.activeModal.dismiss(error);
+            this.alertService.busyStatus$.next(null);
+            this.alertService.errorStatus$.next(error);
             this.addInProgress = false;
+            this.identityAdded.emit({success: false});
         });
     }
 }

--- a/packages/composer-playground/src/app/identity/identity.component.html
+++ b/packages/composer-playground/src/app/identity/identity.component.html
@@ -2,11 +2,6 @@
     <div class="flex">
         <div class="flex-container">
             <h1 class="flex">My Wallet</h1>
-
-            <button type="button" class="secondary" (click)="addId()">
-                <span>+ Add to Wallet</span>
-            </button>
-
             <button type="button" class="primary" (click)="issueNewId()">
                 <span>+ Issue New Identity</span>
             </button>

--- a/packages/composer-playground/src/app/identity/identity.component.spec.ts
+++ b/packages/composer-playground/src/app/identity/identity.component.spec.ts
@@ -120,55 +120,6 @@ describe(`IdentityComponent`, () => {
         }));
     });
 
-    describe('addId', () => {
-        it('should add the id', fakeAsync(() => {
-            mockModal.open = sinon.stub().returns({
-                result: Promise.resolve()
-            });
-
-            let mockLoadIdentities = sinon.stub(component, 'loadIdentities');
-
-            component.addId();
-
-            tick();
-
-            mockLoadIdentities.should.have.been.called;
-            mockModal.open.should.have.been.called;
-        }));
-
-        it('should handle an error', fakeAsync(() => {
-            mockModal.open = sinon.stub().returns({
-                result: Promise.reject('some error')
-            });
-
-            let mockLoadIdentities = sinon.stub(component, 'loadIdentities');
-
-            component.addId();
-
-            tick();
-
-            mockAlertService.errorStatus$.next.should.have.been.called;
-            mockLoadIdentities.should.not.have.been.called;
-            mockModal.open.should.have.been.called;
-        }));
-
-        it('should handle escape being pressed', fakeAsync(() => {
-            mockModal.open = sinon.stub().returns({
-                result: Promise.reject(1)
-            });
-
-            let mockLoadIdentities = sinon.stub(component, 'loadIdentities');
-
-            component.addId();
-
-            tick();
-
-            mockAlertService.errorStatus$.next.should.not.have.been.called;
-            mockLoadIdentities.should.not.have.been.called;
-            mockModal.open.should.have.been.called;
-        }));
-    });
-
     describe('issueNewId', () => {
         beforeEach(() => {
             mockModal.open.reset();

--- a/packages/composer-playground/src/app/identity/identity.component.ts
+++ b/packages/composer-playground/src/app/identity/identity.component.ts
@@ -51,16 +51,6 @@ export class IdentityComponent implements OnInit {
             });
     }
 
-    addId() {
-        this.modalService.open(AddIdentityComponent).result.then((result) => {
-            return this.loadIdentities();
-        }, (reason) => {
-            if (reason && reason !== 1) { // someone hasn't pressed escape
-                this.alertService.errorStatus$.next(reason);
-            }
-        });
-    }
-
     issueNewId() {
         this.modalService.open(IssueIdentityComponent).result.then((result) => {
             if (result) {

--- a/packages/composer-playground/src/app/identity/identity.module.ts
+++ b/packages/composer-playground/src/app/identity/identity.module.ts
@@ -15,9 +15,10 @@ import { FooterModule } from '../footer/footer.module';
 
 @NgModule({
     imports: [CommonModule, FormsModule, NgbModule, FileImporterModule, IdentityRoutingModule, FooterModule],
-    entryComponents: [AddIdentityComponent, IdentityIssuedComponent, IssueIdentityComponent],
+    entryComponents: [IdentityIssuedComponent, IssueIdentityComponent],
     declarations: [AddIdentityComponent, IdentityIssuedComponent, IssueIdentityComponent, IdentityComponent],
-    providers: []
+    providers: [],
+    exports: [AddIdentityComponent]
 })
 
 export class IdentityModule {

--- a/packages/composer-playground/src/app/login/login.component.html
+++ b/packages/composer-playground/src/app/login/login.component.html
@@ -1,11 +1,13 @@
 <section *ngIf="!showSubScreen" class="header">
-    <header class="flex-container">
-        <h1 class="flex">My Wallet</h1>
-
+    <div class="left-align">My Wallet</div>
+    <div class="right-align" *ngIf="!showSubScreen">
         <button type="button" class="secondary">
             <span>Import ID Card</span>
         </button>
-    </header>
+        <button type="button" class="secondary" (click)="createIdCard()">
+            <span>Create ID Card</span>
+        </button>
+    </div>
 </section>
 <section *ngIf="!showSubScreen" class="main-view">
     <div class="connection-profile" *ngFor="let connectionProfile of connectionProfiles; let profileIndex = index">
@@ -43,13 +45,24 @@
             <span>My Wallet</span>
         </button>
     </div>
-    <div *ngIf="editingConectionProfile">
-        <connection-profile (profileUpdated)="finishedEditingConnectionProfile()"
-                            [connectionProfile]="editingConectionProfile"></connection-profile>
-    </div>
     <div *ngIf="showDeployNetwork">
         <import-business-network class="deploy" [deployNetwork]="true"
                                  (finishedSampleImport)="finishedDeploying()"></import-business-network>
+    </div>
+    <div *ngIf="editingConnectionProfile">
+        <connection-profile (profileUpdated)="finishedEditingConnectionProfile($event)"
+                            [connectionProfile]="editingConnectionProfile"></connection-profile>
+    </div>
+    <div *ngIf="creatingIdCard">
+        <add-connection-profile (profileToUse)="addIdToExistingProfileName($event)"
+                                (profileToEdit)="addIdToNewProfile($event)"
+                                (cancelAdd) = "closeSubView()"
+                                [connectionProfiles]="connectionProfiles"></add-connection-profile>
+    </div>
+    <div *ngIf="editingIdCard">
+        <add-identity (identityAdded)="completeCardAddition()"
+                      (cancelAdd) = "closeSubView()"
+                      [targetProfileName]="targetProfileName"></add-identity>
     </div>
 </section>
 <app-footer></app-footer>

--- a/packages/composer-playground/src/app/login/login.component.scss
+++ b/packages/composer-playground/src/app/login/login.component.scss
@@ -6,7 +6,17 @@ app-login {
     background-color: $fourth-highlight;
 
     section.header {
+        display: flex;
         padding: $space-large $space-large $space-medium $space-large;
+        align-items: center;
+
+        div.left-align {
+            flex: 1;
+        }
+
+        div.right-align {
+            margin-right: $space-medium;
+        }
     }
 
     section.main-view {
@@ -50,6 +60,24 @@ app-login {
     section.sub-view {
         padding: $space-large;
         height: calc(100vh - 63px - 55px);
+        overflow-y: auto;
+
+        .header {
+            button {
+                .rotate {
+                    transform: rotate(-180deg);
+                }
+
+                span {
+                    margin-left: $space-smedium
+                }
+            }
+        }
+    }
+
+    section.edit-connection-profile {
+        padding: $space-large ;
+        height: calc(100vh - 63px);
         overflow-y: auto;
 
         .header {

--- a/packages/composer-playground/src/app/login/login.component.spec.ts
+++ b/packages/composer-playground/src/app/login/login.component.spec.ts
@@ -69,8 +69,8 @@ class RouterStub {
     selector: 'connection-profile',
     template: ''
 })
-class MockConnectionProfileComponent {
 
+class MockConnectionProfileComponent {
     @Input()
     public connectionProfile;
     @Output()
@@ -97,288 +97,384 @@ class MockFooterComponent {
 
 }
 
+@Component({
+    selector: 'add-connection-profile',
+    template: ''
+})
+class MockAddConnectionProfileComponent {
+    @Input()
+    public connectionProfiles;
+    @Output()
+    public profileToUse: EventEmitter<any> = new EventEmitter<any>();
+    @Output()
+    public profileToEdit: EventEmitter<any> = new EventEmitter<any>();
+    @Output()
+    public cancelAdd: EventEmitter<any> = new EventEmitter<any>();
+}
+
+@Component({
+    selector: 'add-identity',
+    template: ''
+})
+class MockAddIdentityComponent {
+    @Input()
+    public targetProfileName;
+    @Output()
+    public identityAdded: EventEmitter<any> = new EventEmitter<any>();
+    @Output()
+    public cancelAdd: EventEmitter<any> = new EventEmitter<any>();
+}
+
+@Component({
+    selector: 'identity-card',
+    template: ''
+})
+class MockIdentityCardComponent {
+    @Input() identity: any;
+}
+
 describe(`LoginComponent`, () => {
-    @Component({
-        selector: 'identity-card',
-        template: ''
-    })
-    class MockIdentityCardComponent {
-        @Input() identity: any;
-    }
 
-    describe(`LoginComponent`, () => {
+    let component: LoginComponent;
+    let fixture: ComponentFixture<LoginComponent>;
 
-        let component: LoginComponent;
-        let fixture: ComponentFixture<LoginComponent>;
+    let mockAdminService;
+    let mockIdentityService;
+    let mockClientService;
+    let mockConnectionProfileService;
+    let mockInitializationService;
+    let routerStub;
+    let mockAlertService;
+    let mockWalletService;
+    let mockModal;
+    let mockDrawer;
 
-        let mockAdminService;
-        let mockIdentityService;
-        let mockClientService;
-        let mockConnectionProfileService;
-        let mockInitializationService;
-        let routerStub;
-        let mockAlertService;
-        let mockWalletService;
-        let mockModal;
-        let mockDrawer;
+    beforeEach(() => {
 
-        beforeEach(() => {
+        mockIdentityService = sinon.createStubInstance(IdentityService);
+        mockClientService = sinon.createStubInstance(ClientService);
+        mockConnectionProfileService = sinon.createStubInstance(ConnectionProfileService);
+        mockAdminService = sinon.createStubInstance(AdminService);
+        mockInitializationService = sinon.createStubInstance(InitializationService);
+        mockAlertService = sinon.createStubInstance(AlertService);
+        mockWalletService = sinon.createStubInstance(WalletService);
+        mockDrawer = sinon.createStubInstance(DrawerService);
+        mockModal = sinon.createStubInstance(NgbModal);
 
-            mockIdentityService = sinon.createStubInstance(IdentityService);
-            mockClientService = sinon.createStubInstance(ClientService);
-            mockConnectionProfileService = sinon.createStubInstance(ConnectionProfileService);
-            mockAdminService = sinon.createStubInstance(AdminService);
-            mockInitializationService = sinon.createStubInstance(InitializationService);
-            mockAlertService = sinon.createStubInstance(AlertService);
-            mockWalletService = sinon.createStubInstance(WalletService);
-            mockDrawer = sinon.createStubInstance(DrawerService);
-            mockModal = sinon.createStubInstance(NgbModal);
+        routerStub = new RouterStub();
 
-            routerStub = new RouterStub();
+        mockAlertService.successStatus$ = {next: sinon.stub()};
+        mockAlertService.busyStatus$ = {next: sinon.stub()};
+        mockAlertService.errorStatus$ = {next: sinon.stub()};
 
-            mockAlertService.successStatus$ = {next: sinon.stub()};
-            mockAlertService.busyStatus$ = {next: sinon.stub()};
-            mockAlertService.errorStatus$ = {next: sinon.stub()};
+        mockWalletService.removeFromWallet = sinon.stub().returns(Promise.resolve(true));
 
-            mockWalletService.removeFromWallet = sinon.stub().returns(Promise.resolve(true));
+        TestBed.configureTestingModule({
+            declarations: [
+                LoginComponent,
+                MockConnectionProfileComponent,
+                MockIdentityCardComponent,
+                MockFooterComponent,
+                MockAddConnectionProfileComponent,
+                MockImportComponent,
+                MockAddIdentityComponent
+            ],
+            providers: [
+                {provide: IdentityService, useValue: mockIdentityService},
+                {provide: ClientService, useValue: mockClientService},
+                {provide: ConnectionProfileService, useValue: mockConnectionProfileService},
+                {provide: Router, useValue: routerStub},
+                {provide: AdminService, useValue: mockAdminService},
+                {provide: InitializationService, useValue: mockInitializationService},
+                {provide: AlertService, useValue: mockAlertService},
+                {provide: WalletService, useValue: mockWalletService},
+                {provide: DrawerService, useValue: mockDrawer},
+                {provide: NgbModal, useValue: mockModal}
+            ]
+        });
 
-            TestBed.configureTestingModule({
-                declarations: [
-                    LoginComponent,
-                    MockConnectionProfileComponent,
-                    MockIdentityCardComponent,
-                    MockImportComponent,
-                    MockFooterComponent
-                ],
-                providers: [
-                    {provide: IdentityService, useValue: mockIdentityService},
-                    {provide: ClientService, useValue: mockClientService},
-                    {provide: ConnectionProfileService, useValue: mockConnectionProfileService},
-                    {provide: Router, useValue: routerStub},
-                    {provide: AdminService, useValue: mockAdminService},
-                    {provide: InitializationService, useValue: mockInitializationService},
-                    {provide: AlertService, useValue: mockAlertService},
-                    {provide: WalletService, useValue: mockWalletService},
-                    {provide: DrawerService, useValue: mockDrawer},
-                    {provide: NgbModal, useValue: mockModal}
-                ]
+        fixture = TestBed.createComponent(LoginComponent);
+        component = fixture.componentInstance;
+        });
+
+    describe('ngOnInit', () => {
+        it('should create the component', () => {
+            component.should.be.ok;
+        });
+
+        it('should load identities', fakeAsync(() => {
+            mockInitializationService.initialize.returns(Promise.resolve());
+            let loadConnectionProfilesStub = sinon.stub(component, 'loadConnectionProfiles');
+            component.ngOnInit();
+
+            tick();
+
+            mockInitializationService.initialize.should.have.been.called;
+            loadConnectionProfilesStub.should.have.been.called;
+        }));
+    });
+
+    describe('loadConnectionProfiles', () => {
+        it('should load the connection profile', fakeAsync(() => {
+            mockConnectionProfileService.getAllProfiles.returns(Promise.resolve({myProfile: {name: 'myProfile'}}));
+
+            mockIdentityService.getIdentities.returns(Promise.resolve(['bob']));
+
+            component.loadConnectionProfiles();
+
+            tick();
+
+            mockConnectionProfileService.getAllProfiles.should.have.been.called;
+
+            mockIdentityService.getIdentities.should.have.been.calledWith('myProfile');
+            component['connectionProfiles'].should.deep.equal([{
+                name: 'myProfile',
+                profile: {name: 'myProfile'},
+                default: false,
+                description: 'Default connection profile',
+                identities: [{
+                    userId: 'bob',
+                    businessNetwork: 'org-acme-biznet'
+                }]
+            }]);
+        }));
+    });
+
+    describe('changeIdentity', () => {
+        it('should change identity', fakeAsync(() => {
+            mockAdminService.list.returns(Promise.resolve(['myNetwork']));
+            mockClientService.ensureConnected.returns(Promise.resolve());
+
+            component.changeIdentity('myProfile', 'bob');
+
+            tick();
+
+            mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('myProfile');
+            mockIdentityService.setCurrentIdentity.should.have.been.calledWith('bob');
+            mockAdminService.list.should.have.been.called;
+            mockClientService.ensureConnected.should.have.been.calledWith('myNetwork', true);
+
+            mockIdentityService.setLoggedIn.should.have.been.calledWith(true);
+            routerStub.navigate.should.have.been.calledWith(['editor']);
+        }));
+
+        it('should handle error', fakeAsync(() => {
+            mockAdminService.list.returns(Promise.reject('some error'));
+            mockClientService.ensureConnected.returns(Promise.resolve());
+
+            component.changeIdentity('myProfile', 'bob');
+
+            tick();
+
+            mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('myProfile');
+            mockIdentityService.setCurrentIdentity.should.have.been.calledWith('bob');
+            mockAdminService.list.should.have.been.called;
+            mockClientService.ensureConnected.should.not.have.been.called;
+
+            mockIdentityService.setLoggedIn.should.not.have.been.called;
+            routerStub.navigate.should.not.have.been.called;
+            mockAlertService.errorStatus$.next.should.have.been.calledWith('some error');
+        }));
+    });
+
+    describe('editConnectionProfile', () => {
+        it('should edit the connection profile', () => {
+            component.should.be.ok;
+            component.editConnectionProfile('myProfile');
+
+            component['editingConnectionProfile'].should.equal('myProfile');
+        });
+    });
+
+    describe('finishedEditingConnectionProfile', () => {
+        it('should close editing connection profile screen if not adding ID with connection profile', () => {
+            let loadConnectionProfilesStub = sinon.stub(component, 'loadConnectionProfiles');
+
+            component.finishedEditingConnectionProfile({update : true});
+
+            should.not.exist(component['editingConectionProfile']);
+            loadConnectionProfilesStub.should.have.been.called;
+        });
+
+        it('should close editing connection profile screen if cancelling while adding ID with connection profile', () => {
+            let loadConnectionProfilesStub = sinon.stub(component, 'loadConnectionProfiles');
+            let addIdToExistingProfileStub = sinon.stub(component, 'addIdToExistingProfile');
+            component['creatingIdWithProfile'] = true;
+
+            component.finishedEditingConnectionProfile({update : false});
+
+            should.not.exist(component['editingConectionProfile']);
+            loadConnectionProfilesStub.should.have.been.called;
+            addIdToExistingProfileStub.should.not.have.been.called;
+        });
+
+        it('should pass connection profile to addIdToExistingProfile if successfull and addding ID with connection profile', () => {
+            let loadConnectionProfilesStub = sinon.stub(component, 'loadConnectionProfiles');
+            let addIdToExistingProfileNameStub = sinon.stub(component, 'addIdToExistingProfileName');
+            component['creatingIdWithProfile'] = true;
+
+            component.finishedEditingConnectionProfile({update : true, connectionProfile : { name: 'bob' }});
+
+            should.not.exist(component['editingConectionProfile']);
+            loadConnectionProfilesStub.should.not.have.been.called;
+            addIdToExistingProfileNameStub.should.have.been.calledWith('bob');
+        });
+    });
+
+    describe('createIdCard', () => {
+        it('should open the ID card screen', () => {
+            component['createIdCard']();
+            component['showSubScreen'].should.be.true;
+            component['creatingIdCard'].should.be.true;
+        });
+    });
+
+    describe('addIdToExistingProfileName', () => {
+        it('should set the target profile name and open the ID edit panel', () => {
+            component['addIdToExistingProfileName']('bob');
+
+            component['targetProfileName'].should.be.equal('bob');
+            component['creatingIdCard'].should.be.false;
+            component['editingIdCard'].should.be.true;
+        });
+    });
+
+    describe('addIdToNewProfile', () => {
+        it('should set the connection profile to edit and set the creatingIdWithProfile boolean', () => {
+            let myProfile = { wow: 'such profile', avarian: 'penguin' };
+
+            component['addIdToNewProfile'](myProfile);
+
+            component['editingConnectionProfile'].should.be.deep.equal(myProfile);
+            component['creatingIdCard'].should.be.false;
+            component['creatingIdWithProfile'].should.be.true;
+        });
+    });
+
+    describe('completeCardAddition', () => {
+        it('should close the subscreen and refresh connection profiles', () => {
+            let loadConnectionProfilesStub = sinon.stub(component, 'loadConnectionProfiles');
+            let closeSubViewStub = sinon.stub(component, 'closeSubView');
+
+            component['completeCardAddition']();
+
+            component['editingIdCard'].should.be.false;
+            component['showSubScreen'].should.be.false;
+            should.not.exist(component['editingConectionProfile']);
+            loadConnectionProfilesStub.should.have.been.called;
+            closeSubViewStub.should.have.been.called;
+        });
+    });
+
+    describe('removeIdentity', () => {
+        it('should open the delete-confirm modal', fakeAsync(() => {
+            mockModal.open = sinon.stub().returns({
+                componentInstance: {},
+                result: Promise.resolve(0)
             });
 
-            fixture = TestBed.createComponent(LoginComponent);
+            component.removeIdentity('profile', 'name');
+            tick();
+            mockModal.open.should.have.been.called;
+        }));
 
-            component = fixture.componentInstance;
-        });
-
-        describe('ngOnInit', () => {
-            it('should create the component', () => {
-                component.should.be.ok;
+        it('should open delete-confirm modal and handle error', fakeAsync(() => {
+            mockModal.open = sinon.stub().returns({
+                componentInstance: {},
+                result: Promise.reject('some error')
             });
 
-            it('should load identities', fakeAsync(() => {
-                mockInitializationService.initialize.returns(Promise.resolve());
-                let loadConnectionProfilesStub = sinon.stub(component, 'loadConnectionProfiles');
-                component.ngOnInit();
+            component.removeIdentity('profile', 'name');
+            tick();
+            mockAlertService.busyStatus$.next.should.have.been.called;
+            mockAlertService.errorStatus$.next.should.have.been.called;
+        }));
 
-                tick();
-
-                mockInitializationService.initialize.should.have.been.called;
-                loadConnectionProfilesStub.should.have.been.called;
-            }));
-        });
-
-        describe('loadConnectionProfiles', () => {
-            it('should load the connection profile', fakeAsync(() => {
-                mockConnectionProfileService.getAllProfiles.returns(Promise.resolve({myProfile: {name: 'myProfile'}}));
-
-                mockIdentityService.getIdentities.returns(Promise.resolve(['bob']));
-
-                component.loadConnectionProfiles();
-
-                tick();
-
-                mockConnectionProfileService.getAllProfiles.should.have.been.called;
-
-                mockIdentityService.getIdentities.should.have.been.calledWith('myProfile');
-
-                component['connectionProfiles'].should.deep.equal([{
-                    name: 'myProfile',
-                    profile: {name: 'myProfile'},
-                    default: false,
-                    identities: [{
-                        userId: 'bob',
-                        businessNetwork: 'org-acme-biznet'
-                    }]
-                }]);
-            }));
-        });
-
-        describe('changeIdentity', () => {
-            it('should change identity', fakeAsync(() => {
-                mockAdminService.list.returns(Promise.resolve(['myNetwork']));
-                mockClientService.ensureConnected.returns(Promise.resolve());
-
-                component.changeIdentity('myProfile', 'bob');
-
-                tick();
-
-                mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('myProfile');
-                mockIdentityService.setCurrentIdentity.should.have.been.calledWith('bob');
-                mockAdminService.list.should.have.been.called;
-                mockClientService.ensureConnected.should.have.been.calledWith('myNetwork', true);
-
-                mockIdentityService.setLoggedIn.should.have.been.calledWith(true);
-                routerStub.navigate.should.have.been.calledWith(['editor']);
-            }));
-
-            it('should handle error', fakeAsync(() => {
-                mockAdminService.list.returns(Promise.reject('some error'));
-                mockClientService.ensureConnected.returns(Promise.resolve());
-
-                component.changeIdentity('myProfile', 'bob');
-
-                tick();
-
-                mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('myProfile');
-                mockIdentityService.setCurrentIdentity.should.have.been.calledWith('bob');
-                mockAdminService.list.should.have.been.called;
-                mockClientService.ensureConnected.should.not.have.been.called;
-
-                mockIdentityService.setLoggedIn.should.not.have.been.called;
-                routerStub.navigate.should.not.have.been.called;
-
-                mockAlertService.errorStatus$.next.should.have.been.calledWith('some error');
-            }));
-        });
-
-        describe('editConnectionProfile', () => {
-            it('should edit the connection profile', () => {
-                component.should.be.ok;
-                component.editConnectionProfile('myProfile');
-
-                component['editingConectionProfile'].should.equal('myProfile');
+        it('should open delete-confirm modal and handle cancel', fakeAsync(() => {
+            mockModal.open = sinon.stub().returns({
+                componentInstance: {},
+                result: Promise.reject(null)
             });
-        });
 
-        describe('finishedEditingConnectionProfile', () => {
-            it('should close editing connection profile screen', () => {
-                let loadConnectionProfilesStub = sinon.stub(component, 'loadConnectionProfiles');
-                component.finishedEditingConnectionProfile();
+            component.removeIdentity('profile', 'name');
+            tick();
+            mockAlertService.busyStatus$.next.should.not.have.been.called;
+            mockAlertService.errorStatus$.next.should.not.have.been.called;
+        }));
 
-                should.not.exist(component['editingConectionProfile']);
-                loadConnectionProfilesStub.should.have.been.called;
+        it('should refresh the connection profiles after successfully calling walletService.removeFromWallet()', fakeAsync(() => {
+            mockModal.open = sinon.stub().returns({
+                componentInstance: {},
+                result: Promise.resolve(true)
             });
-        });
 
-        describe('removeIdentity', () => {
-            it('should open the delete-confirm modal', fakeAsync(() => {
-                mockModal.open = sinon.stub().returns({
-                    componentInstance: {},
-                    result: Promise.resolve(0)
-                });
+            component.loadConnectionProfiles = sinon.stub();
 
-                component.removeIdentity('profile', 'name');
-                tick();
-                mockModal.open.should.have.been.called;
-            }));
+            component.removeIdentity('profile', 'name');
+            tick();
 
-            it('should open delete-confirm modal and handle error', fakeAsync(() => {
-                mockModal.open = sinon.stub().returns({
-                    componentInstance: {},
-                    result: Promise.reject('some error')
-                });
+            // check services called
+            component.loadConnectionProfiles.should.have.been.called;
+            mockAlertService.busyStatus$.next.should.have.been.called;
+            mockAlertService.successStatus$.next.should.have.been.called;
 
-                component.removeIdentity('profile', 'name');
-                tick();
-                mockAlertService.busyStatus$.next.should.have.been.called;
-                mockAlertService.errorStatus$.next.should.have.been.called;
-            }));
+            mockAlertService.errorStatus$.next.should.not.have.been.called;
+        }));
 
-            it('should open delete-confirm modal and handle cancel', fakeAsync(() => {
-                mockModal.open = sinon.stub().returns({
-                    componentInstance: {},
-                    result: Promise.reject(null)
-                });
-
-                component.removeIdentity('profile', 'name');
-                tick();
-                mockAlertService.busyStatus$.next.should.not.have.been.called;
-                mockAlertService.errorStatus$.next.should.not.have.been.called;
-            }));
-
-            it('should refresh the connection profiles after successfully calling walletService.removeFromWallet()', fakeAsync(() => {
-                mockModal.open = sinon.stub().returns({
-                    componentInstance: {},
-                    result: Promise.resolve(true)
-                });
-
-                component.loadConnectionProfiles = sinon.stub();
-
-                component.removeIdentity('profile', 'name');
-                tick();
-
-                // check services called
-                component.loadConnectionProfiles.should.have.been.called;
-                mockAlertService.busyStatus$.next.should.have.been.called;
-                mockAlertService.successStatus$.next.should.have.been.called;
-
-                mockAlertService.errorStatus$.next.should.not.have.been.called;
-            }));
-
-            it('should handle errors when calling walletService.removeFromWallet()', fakeAsync(() => {
-                mockModal.open = sinon.stub().returns({
-                    componentInstance: {},
-                    result: Promise.resolve(true)
-                });
-
-                component.loadConnectionProfiles = sinon.stub();
-                mockWalletService.removeFromWallet = sinon.stub().returns(Promise.reject('some error'));
-
-                component.removeIdentity('profile', 'name');
-                tick();
-
-                // check services called
-                mockAlertService.busyStatus$.next.should.have.been.called;
-                mockAlertService.errorStatus$.next.should.have.been.called;
-
-                mockAlertService.successStatus$.next.should.not.have.been.called;
-                component.loadConnectionProfiles.should.not.have.been.called;
-            }));
-        });
-
-        describe('closeSubView', () => {
-            it('should close the subview', () => {
-                component['showSubScreen'] = true;
-                component['showDeployNetwork'] = true;
-                component['editingConnectionProfile'] = {profile: 'myProfile'};
-                component.closeSubView();
-
-                component['showSubScreen'].should.equal(false);
-                should.not.exist(component['editingConectionProfile']);
-                component['showDeployNetwork'].should.equal(false);
+        it('should handle errors when calling walletService.removeFromWallet()', fakeAsync(() => {
+            mockModal.open = sinon.stub().returns({
+                componentInstance: {},
+                result: Promise.resolve(true)
             });
+
+            component.loadConnectionProfiles = sinon.stub();
+            mockWalletService.removeFromWallet = sinon.stub().returns(Promise.reject('some error'));
+
+            component.removeIdentity('profile', 'name');
+            tick();
+
+            // check services called
+            mockAlertService.busyStatus$.next.should.have.been.called;
+            mockAlertService.errorStatus$.next.should.have.been.called;
+
+            mockAlertService.successStatus$.next.should.not.have.been.called;
+            component.loadConnectionProfiles.should.not.have.been.called;
+        }));
+    });
+
+    describe('closeSubView', () => {
+        it('should close the subview', () => {
+            component['showSubScreen'] = true;
+            component['showDeployNetwork'] = true;
+            component['editingConnectionProfile'] = {profile: 'myProfile'};
+            component.closeSubView();
+
+            component['showSubScreen'].should.equal(false);
+            should.not.exist(component['editingConectionProfile']);
+            component['showDeployNetwork'].should.equal(false);
         });
+    });
 
-        describe('deployNetwork', () => {
-            it('should deploy a new business network', () => {
-                component.deployNetwork({name: 'bob'});
-                mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('bob');
+    describe('deployNetwork', () => {
+        it('should deploy a new business network', () => {
+            component.deployNetwork({name: 'bob'});
+            mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('bob');
 
-                mockIdentityService.setCurrentIdentity.should.have.been.calledWith('admin');
-                component['showSubScreen'].should.equal(true);
-                component['showDeployNetwork'].should.equal(true);
-            });
+            mockIdentityService.setCurrentIdentity.should.have.been.calledWith('admin');
+            component['showSubScreen'].should.equal(true);
+            component['showDeployNetwork'].should.equal(true);
         });
+    });
 
-        describe('finishedDeploying', () => {
-            it('should finish deploying', () => {
-                component['showSubScreen'] = true;
+    describe('finishedDeploying', () => {
+        it('should finish deploying', () => {
+            component['showSubScreen'] = true;
 
-                component['showDeployNetwork'] = true;
-                component.finishedDeploying();
+            component['showDeployNetwork'] = true;
+            component.finishedDeploying();
 
-                component['showSubScreen'].should.equal(false);
-                component['showDeployNetwork'].should.equal(false);
-            });
+            component['showSubScreen'].should.equal(false);
+            component['showDeployNetwork'].should.equal(false);
         });
     });
 });

--- a/packages/composer-playground/src/app/login/login.component.ts
+++ b/packages/composer-playground/src/app/login/login.component.ts
@@ -22,9 +22,14 @@ import { ImportIdentityComponent } from './import-identity';
 export class LoginComponent implements OnInit {
 
     private connectionProfiles = [];
-    private editingConectionProfile = null;
-    private showSubScreen: boolean = false;
     private showDeployNetwork: boolean = false;
+    private editingConnectionProfile = null;
+    private targetProfileName: string = null;
+    private addIdCard: boolean = false;
+    private creatingIdCard: boolean = false;
+    private editingIdCard: boolean = false;
+    private creatingIdWithProfile: boolean = false;
+    private showSubScreen: boolean = false;
 
     constructor(private identityService: IdentityService,
                 private router: Router,
@@ -67,6 +72,7 @@ export class LoginComponent implements OnInit {
                                 name: key,
                                 profile: connectionProfile,
                                 default: key === '$default',
+                                description: 'Default connection profile',
                                 identities: identityList
                             });
                         });
@@ -95,19 +101,49 @@ export class LoginComponent implements OnInit {
 
     editConnectionProfile(connectionProfile): void {
         this.showSubScreen = true;
-        this.editingConectionProfile = connectionProfile;
+        this.editingConnectionProfile = connectionProfile;
     }
 
-    finishedEditingConnectionProfile(): Promise<void> {
-        this.showSubScreen = false;
-        delete this.editingConectionProfile;
-        return this.loadConnectionProfiles();
+    finishedEditingConnectionProfile(result): Promise<void> {
+        if (result.update === false || !this.creatingIdWithProfile) {
+            this.closeSubView();
+            return this.loadConnectionProfiles();
+        } else {
+            delete this.editingConnectionProfile;
+            this.addIdToExistingProfileName(result.connectionProfile.name);
+        }
     }
 
     closeSubView(): void {
         this.showSubScreen = false;
-        delete this.editingConectionProfile;
         this.showDeployNetwork = false;
+        this.creatingIdCard = false;
+        this.editingIdCard = false;
+        this.creatingIdWithProfile = false;
+        delete this.editingConnectionProfile;
+        delete this.targetProfileName;
+    }
+
+    createIdCard(): void {
+        this.showSubScreen = true;
+        this.creatingIdCard = true;
+    }
+
+    addIdToExistingProfileName(connectionProfileName): void {
+        this.targetProfileName = connectionProfileName;
+        this.creatingIdCard = false;
+        this.editingIdCard = true;
+    }
+
+    addIdToNewProfile(connectionProfile): void {
+        this.editingConnectionProfile = connectionProfile;
+        this.creatingIdCard = false;
+        this.creatingIdWithProfile = true;
+    }
+
+    completeCardAddition() {
+        this.closeSubView();
+        return this.loadConnectionProfiles();
     }
 
     deployNetwork(connectionProfile) {

--- a/packages/composer-playground/src/app/login/login.module.ts
+++ b/packages/composer-playground/src/app/login/login.module.ts
@@ -12,9 +12,10 @@ import { FileImporterModule } from '../common/file-importer/file-importer.module
 import { ConnectionProfileModule } from '../connection-profile/connection-profile.module';
 import { ImportModule } from '../import/import.module';
 import { FooterModule } from '../footer/footer.module';
+import { IdentityModule } from '../identity/identity.module';
 
 @NgModule({
-    imports: [CommonModule, FormsModule, NgbModule, LoginRoutingModule, ConnectionProfileModule, FooterModule, FileImporterModule, DrawerModule, ImportModule],
+    imports: [CommonModule, FormsModule, NgbModule, LoginRoutingModule, ConnectionProfileModule, FooterModule, FileImporterModule, DrawerModule, ImportModule, IdentityModule],
     entryComponents: [IdentityCardComponent],
     declarations: [LoginComponent, IdentityCardComponent]
 })

--- a/packages/composer-playground/src/assets/styles/base/_variables.scss
+++ b/packages/composer-playground/src/assets/styles/base/_variables.scss
@@ -18,8 +18,12 @@ $space-xsmall: 2px;
 $space-small: 4px;
 $space-smedium: 8px;
 $space-medium: 16px;
+$space-mlarge: 24px;
 $space-large: 32px;
 $space-xlarge: 64px;
+
+// Radius
+$radius-medium: 4px;
 
 // Animation
 @mixin transition($properties...) {

--- a/packages/composer-playground/src/assets/svg/action-based/role_24.svg
+++ b/packages/composer-playground/src/assets/svg/action-based/role_24.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#F0F0F0;}
+	.st1{fill:#323232;}
+</style>
+<g id="Guides">
+</g>
+<g id="Name">
+</g>
+<g id="Icon">
+	<g>
+		<path class="st1" d="M4,1v22h16V1H4z M18,21H6V3h12V21z"/>
+		<path class="st1" d="M9.5,14C8.7,14,8,14.7,8,15.5V17h8v-1.5c0-0.8-0.7-1.5-1.5-1.5H9.5z"/>
+	</g>
+	<path class="st1" d="M12,7c-1.7,0-3,1.3-3,3s1.3,3,3,3s3-1.3,3-3S13.7,7,12,7z"/>
+</g>
+</svg>


### PR DESCRIPTION
Addition of ID card to identities:
 - Create ID card botton added to login page (removed from identities registry page)
 - Flow enables creation of ID based on UserId and Secret only
 - Flow enable targeting existing Connection Profile, or may take user through creation of new Connection Profile prior to binding ID card to that newly defined profile


## Issue/User story
#1423 


## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Automated Tests
Tests refactored and added where appropriate


## Design of the fix
Followed the design from parent issue
