### PR TITLE
Change qualified names for connection profiles- identity cards

### DIFF
--- a/packages/composer-playground/package.json
+++ b/packages/composer-playground/package.json
@@ -179,6 +179,7 @@
     "ng2-codemirror": "1.1.2",
     "ngx-perfect-scrollbar": "^4.3.0",
     "node-sass": "^4.5.0",
+    "object-hash": "^1.1.8",
     "parse5": "^3.0.1",
     "protractor": "5.1.2",
     "random-words": "0.0.1",

--- a/packages/composer-playground/src/app/services/connectionprofile.service.spec.ts
+++ b/packages/composer-playground/src/app/services/connectionprofile.service.spec.ts
@@ -93,19 +93,40 @@ describe('ConnectionProfileService', () => {
     });
 
     describe('createProfile', () => {
-        it('should get result of createProfile from admin connection',
+        it('should get result of createProfile from admin connection if the profile does not exist',
+            fakeAsync(inject([ConnectionProfileService],
+                (connectionProfileService) => {
+                    connectionProfileService.should.be.ok;
+
+                    adminConnectionMock.getProfile.returns(Promise.reject('not exist'));
+                    let mockGetAdminConnection = sinon.stub(connectionProfileService, 'getAdminConnection').returns(adminConnectionMock);
+
+                    const nameArg: string = 'NAME';
+                    const connectionProfileArg: string = 'CONNECTION_PROFILE';
+                    connectionProfileService.createProfile(nameArg, connectionProfileArg);
+
+                    tick();
+
+                    mockGetAdminConnection.should.have.been.called;
+                    adminConnectionMock.getProfile.should.have.been.calledWith(nameArg);
+                    adminConnectionMock.createProfile.should.have.been.calledWith(nameArg, connectionProfileArg);
+                })));
+
+        it('should get result of getProfile from admin connection if the profile does exist',
             inject([ConnectionProfileService],
                 (connectionProfileService) => {
                     connectionProfileService.should.be.ok;
 
-                    const nameArg: string = 'NAME';
-                    const connectionProfileArg: string = 'CONNECTION_PROFILE';
+                    adminConnectionMock.getProfile.returns(Promise.resolve());
                     let mockGetAdminConnection = sinon.stub(connectionProfileService, 'getAdminConnection').returns(adminConnectionMock);
 
+                    const nameArg: string = 'NAME';
+                    const connectionProfileArg: string = 'CONNECTION_PROFILE';
                     connectionProfileService.createProfile(nameArg, connectionProfileArg);
 
                     mockGetAdminConnection.should.have.been.called;
-                    adminConnectionMock.createProfile.should.have.been.calledWith(nameArg, connectionProfileArg);
+                    adminConnectionMock.getProfile.should.have.been.calledWith(nameArg);
+                    adminConnectionMock.createProfile.should.not.have.been.called;
                 }));
     });
 

--- a/packages/composer-playground/src/app/services/connectionprofile.service.ts
+++ b/packages/composer-playground/src/app/services/connectionprofile.service.ts
@@ -30,7 +30,11 @@ export class ConnectionProfileService {
     }
 
     createProfile(name, connectionProfile): Promise<any> {
-        return this.getAdminConnection().createProfile(name, connectionProfile);
+        return this.getAdminConnection().getProfile(name)
+            .catch(() => {
+                // It doesn't exist, so create it.
+                return this.getAdminConnection().createProfile(name, connectionProfile);
+            });
     }
 
     getProfile(name): Promise<any> {

--- a/packages/composer-playground/src/app/services/identity-card.service.spec.ts
+++ b/packages/composer-playground/src/app/services/identity-card.service.spec.ts
@@ -10,6 +10,8 @@ import { ConnectionProfileService } from './connectionprofile.service';
 import { IdentityService } from './identity.service';
 import { WalletService } from './wallet.service';
 
+const hash = require('object-hash');
+
 import * as sinon from 'sinon';
 let should = chai.should();
 
@@ -259,11 +261,12 @@ describe('IdentityCardService', () => {
 
     describe('#deleteIdentityCard', () => {
         it('should delete an identity card', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
+            let mockConnectionProfile = {
+                name: 'hlfv1'
+            };
             let mockIdCard = sinon.createStubInstance(IdCard);
             mockIdCard.getName.returns('bcc');
-            mockIdCard.getConnectionProfile.returns({
-                name: 'hlfv1'
-            });
+            mockIdCard.getConnectionProfile.returns(mockConnectionProfile);
             mockIdCard.getEnrollmentCredentials.returns({
                 id: 'alice'
             });
@@ -275,9 +278,10 @@ describe('IdentityCardService', () => {
 
             tick();
 
+            let expectedProfileName = hash(mockConnectionProfile) + '-hlfv1';
             service['idCards'].size.should.equal(0);
-            mockWalletService.removeFromWallet.should.have.been.calledWith('test-hlfv1', 'alice');
-            mockConnectionProfileService.deleteProfile.should.have.been.calledWith('test-hlfv1');
+            mockWalletService.removeFromWallet.should.have.been.calledWith(expectedProfileName, 'alice');
+            mockConnectionProfileService.deleteProfile.should.have.been.calledWith(expectedProfileName);
             mockIdentityCardStorageService.remove.should.have.been.calledWith('test');
             mockIdentityCardStorageService.remove.should.have.been.calledWith('test-pd');
         })));
@@ -301,6 +305,7 @@ describe('IdentityCardService', () => {
         let mockFileWallet;
         let mockIdCard1;
         let mockIdCard2;
+        let mockConnectionProfile2;
         let mockCardMap;
 
         beforeEach(() => {
@@ -314,11 +319,12 @@ describe('IdentityCardService', () => {
 
             mockIdCard1 = sinon.createStubInstance(IdCard);
             mockIdCard1.getEnrollmentCredentials.returns({ id: 'admin'});
-            mockIdCard1.getConnectionProfile.returns({name: '$default'});
+            mockIdCard1.getConnectionProfile.returns({name: '$default', type: 'web'});
 
+            mockConnectionProfile2 = {name: 'hlfv1'};
             mockIdCard2 = sinon.createStubInstance(IdCard);
             mockIdCard2.getEnrollmentCredentials.returns({ id: 'admin'});
-            mockIdCard2.getConnectionProfile.returns({name: '$default'});
+            mockIdCard2.getConnectionProfile.returns(mockConnectionProfile2);
 
             mockCardMap = new Map<string, IdCard>();
             mockCardMap.set('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', mockIdCard1);
@@ -335,7 +341,7 @@ describe('IdentityCardService', () => {
             mockConnectionProfileService.createProfile.should.not.have.been.called;
             mockWalletService.getWallet.should.not.have.been.called;
             mockIdentityCardStorageService.set.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd', { current: true });
-            mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-$default');
+            mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('web-$default');
             mockIdentityService.setCurrentIdentity.should.have.been.calledWith('admin');
         })));
 
@@ -350,12 +356,13 @@ describe('IdentityCardService', () => {
 
             tick();
 
+            let expectedProfileName = hash(mockConnectionProfile2) + '-hlfv1';
             mockConnectionProfileService.createProfile.should.not.have.been.called;
             mockWalletService.getWallet.should.not.have.been.called;
             mockIdentityCardStorageService.set.should.have.been.calledTwice;
             mockIdentityCardStorageService.set.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd', {});
             mockIdentityCardStorageService.set.should.have.been.calledWith('uuid2xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd', { current: true });
-            mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('uuid2xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-$default');
+            mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith(expectedProfileName);
             mockIdentityService.setCurrentIdentity.should.have.been.calledWith('admin');
         })));
 
@@ -369,10 +376,10 @@ describe('IdentityCardService', () => {
 
             tick();
 
-            mockConnectionProfileService.createProfile.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-$default');
-            mockWalletService.getWallet.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-$default');
+            mockConnectionProfileService.createProfile.should.have.been.calledWith('web-$default');
+            mockWalletService.getWallet.should.have.been.calledWith('web-$default');
             mockIdentityCardStorageService.set.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd', { current: true });
-            mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-$default');
+            mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('web-$default');
             mockIdentityService.setCurrentIdentity.should.have.been.calledWith('admin');
         })));
 
@@ -387,10 +394,10 @@ describe('IdentityCardService', () => {
 
             tick();
 
-            mockConnectionProfileService.createProfile.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-$default');
-            mockWalletService.getWallet.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-$default');
+            mockConnectionProfileService.createProfile.should.have.been.calledWith('web-$default');
+            mockWalletService.getWallet.should.have.been.calledWith('web-$default');
             mockIdentityCardStorageService.set.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd', { current: true });
-            mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-$default');
+            mockConnectionProfileService.setCurrentConnectionProfile.should.have.been.calledWith('web-$default');
             mockIdentityService.setCurrentIdentity.should.have.been.calledWith('admin');
         })));
 
@@ -407,5 +414,79 @@ describe('IdentityCardService', () => {
 
             result.message.should.equal('Identity card does not exist');
         })));
+    });
+
+    describe('getIdentityCardsWithProfileAndRole', () => {
+        let mockIdCard1;
+        let mockIdCard2;
+        let mockIdCard3;
+        let mockConnectionProfile1;
+        let mockConnectionProfile2;
+        let mockConnectionProfile3;
+        let mockCardMap;
+
+        beforeEach(() => {
+            mockConnectionProfile1 = {name: 'myProfile'};
+            mockIdCard1 = sinon.createStubInstance(IdCard);
+            mockIdCard1.getName.returns('card1');
+            mockIdCard1.getConnectionProfile.returns(mockConnectionProfile1);
+            mockIdCard1.getRoles.returns(['myRole']);
+
+            mockConnectionProfile2 = {name: 'myOtherProfile'};
+            mockIdCard2 = sinon.createStubInstance(IdCard);
+            mockIdCard2.getName.returns('card2');
+            mockIdCard2.getConnectionProfile.returns(mockConnectionProfile2);
+            mockIdCard2.getRoles.returns(['myOtherRole']);
+
+            mockConnectionProfile3 = {name: 'myProfile'};
+            mockIdCard3 = sinon.createStubInstance(IdCard);
+            mockIdCard3.getName.returns('card3');
+            mockIdCard3.getConnectionProfile.returns(mockConnectionProfile3);
+            mockIdCard3.getRoles.returns(['myRole']);
+
+            mockCardMap = new Map<string, IdCard>();
+            mockCardMap.set('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', mockIdCard1);
+            mockCardMap.set('uuid2xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', mockIdCard2);
+            mockCardMap.set('uuid3xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', mockIdCard3);
+        });
+
+        it('should get an identity card with matching profile and role', inject([IdentityCardService], (service: IdentityCardService) => {
+            mockIdCard3.getRoles.returns(['myOtherRole']);
+            service['idCards'] = mockCardMap;
+
+            let connectionProfileName = hash(mockConnectionProfile1) + '-myProfile';
+            let result = service.getIdentityCardsWithProfileAndRole(connectionProfileName, 'myRole');
+
+            result.length.should.equal(1);
+            result[0].getName().should.equal('card1');
+        }));
+
+        it('should get all identity cards with matching profile and role', inject([IdentityCardService], (service: IdentityCardService) => {
+            mockIdCard2.getRoles.returns(['myRole']);
+            service['idCards'] = mockCardMap;
+
+            let connectionProfileName = hash(mockConnectionProfile1) + '-myProfile';
+            let result = service.getIdentityCardsWithProfileAndRole(connectionProfileName, 'myRole');
+
+            result.length.should.equal(2);
+            result[0].getName().should.equal('card1');
+            result[1].getName().should.equal('card3');
+        }));
+
+        it('should not get an identity card if there were no matching connection profiles', inject([IdentityCardService], (service: IdentityCardService) => {
+            service['idCards'] = mockCardMap;
+
+            let result = service.getIdentityCardsWithProfileAndRole('wotNoProfile', 'myRole');
+
+            result.should.be.empty;
+        }));
+
+        it('should not get an identity card if there were no matching roles', inject([IdentityCardService], (service: IdentityCardService) => {
+            service['idCards'] = mockCardMap;
+
+            let result = service.getIdentityCardsWithProfileAndRole('myProfile', 'wotNoRole');
+
+            result.should.be.empty;
+        }));
     });
 });

--- a/packages/composer-playground/src/app/services/identity-card.service.ts
+++ b/packages/composer-playground/src/app/services/identity-card.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@angular/core';
-import { LocalStorageService } from 'angular-2-local-storage';
 
 import { ConnectionProfileService } from './connectionprofile.service';
-import { IdentityService } from '../services/identity.service';
+import { IdentityService } from './identity.service';
 import { IdentityCardStorageService } from './identity-card-storage.service';
 import { WalletService } from './wallet.service';
 
@@ -11,7 +10,23 @@ import { IdCard, Logger } from 'composer-common';
 /* tslint:disable-next-line:no-var-requires */
 const uuid = require('uuid');
 
-const defaultCardProperties = JSON.parse('{"metadata":{"name":"admin","businessNetwork":"basic-sample-network","enrollmentId":"admin","enrollmentSecret":"adminpw"},"connectionProfile":{"name":"$default","type":"web"},"credentials":null}');
+/* tslint:disable-next-line:no-var-requires */
+const hash = require('object-hash');
+
+const defaultCardProperties = {
+    metadata: {
+        name: 'admin',
+        businessNetwork: 'basic-sample-network',
+        enrollmentId: 'admin',
+        enrollmentSecret: 'adminpw'
+    },
+    roles: ['PeerAdmin', 'ChannelAdmin'],
+    connectionProfile: {
+        name: '$default',
+        type: 'web'
+    },
+    credentials: null
+};
 
 @Injectable()
 export class IdentityCardService {
@@ -39,6 +54,18 @@ export class IdentityCardService {
         return this.getIdentityCard(this.currentCard);
     }
 
+    getIdentityCardsWithProfileAndRole(qualifiedProfileName: string, role: string): IdCard[] {
+        let cards: IdCard[] = [];
+        this.idCards.forEach((card, key) => {
+            let connectionProfile = card.getConnectionProfile();
+            if (qualifiedProfileName === this.getQualifiedProfileName(connectionProfile) && card.getRoles().includes(role)) {
+                cards.push(card);
+            }
+        });
+
+        return cards;
+    }
+
     loadIdentityCards(): Promise<number> {
         return new Promise((resolve, reject) => {
             this.idCards = this.identityCardStorageService
@@ -47,7 +74,7 @@ export class IdentityCardService {
                     // Only load IdCards, referenced by fixed length uuids,
                     // not associated playground data, which has a suffix
                     if (cardRef.length === 36) {
-                        let cardProperties: PropertyDescriptorMap = this.identityCardStorageService.get(cardRef);
+                        let cardProperties: any = this.identityCardStorageService.get(cardRef);
                         let cardObject = new IdCard(cardProperties.metadata, cardProperties.connectionProfile, cardProperties.credentials);
 
                         let data: any = this.identityCardStorageService.get(this.dataRef(cardRef));
@@ -132,7 +159,8 @@ export class IdentityCardService {
 
         let card = this.idCards.get(cardRef);
         let enrollmentId = card.getEnrollmentCredentials().id;
-        let connectionProfileName = this.getQualifiedProfileName(cardRef);
+        let connectionProfile = card.getConnectionProfile();
+        let connectionProfileName = this.getQualifiedProfileName(connectionProfile);
 
         this.walletService.removeFromWallet(connectionProfileName, enrollmentId);
         this.connectionProfileService.deleteProfile(connectionProfileName);
@@ -165,15 +193,22 @@ export class IdentityCardService {
         let enrollmentId = card.getEnrollmentCredentials().id;
 
         return this.activateIdentityCard(cardRef).then(() => {
-            this.connectionProfileService.setCurrentConnectionProfile(this.getQualifiedProfileName(cardRef));
+            let connectionProfile = card.getConnectionProfile();
+            this.connectionProfileService.setCurrentConnectionProfile(this.getQualifiedProfileName(connectionProfile));
             this.identityService.setCurrentIdentity(enrollmentId);
 
             return card;
         });
     }
 
-    private getQualifiedProfileName(cardRef: string): string {
-        return cardRef + '-' + this.idCards.get(cardRef).getConnectionProfile().name;
+    private getQualifiedProfileName(connectionProfile: any): string {
+        let prefix = hash(connectionProfile);
+
+        if ('web' === connectionProfile.type) {
+            return 'web-' + connectionProfile.name;
+        } else {
+            return prefix + '-' + connectionProfile.name;
+        }
     };
 
     private dataRef(cardRef: string): string {
@@ -183,7 +218,7 @@ export class IdentityCardService {
     private setIdentity(connectionProfileName: string, enrollmentId: string, enrollmentSecret: string): Promise<any> {
         let wallet = this.walletService.getWallet(connectionProfileName);
 
-        return wallet.contains(connectionProfileName)
+        return wallet.contains(enrollmentId)
             .then((contains) => {
                 if (contains) {
                     return wallet.update(enrollmentId, enrollmentSecret);
@@ -202,7 +237,7 @@ export class IdentityCardService {
 
             let card = this.idCards.get(cardRef);
             let connectionProfile = card.getConnectionProfile();
-            let connectionProfileName = this.getQualifiedProfileName(cardRef);
+            let connectionProfileName = this.getQualifiedProfileName(connectionProfile);
 
             // Hmmm, suspicious... is the enrollement ID really the identity?!
             let enrollmentCredentials = card.getEnrollmentCredentials();


### PR DESCRIPTION
with a web profile now share a fixed connection profile, and
other connection profile names are now prefixed with a hash of
the connection profile object.

Also adds a function to get an idcard with required role and
updates the connection profile service to avoid overwriting
existing connection profiles.

Contributes to #902

Signed-off-by: James Taylor <jamest@uk.ibm.com>
