### PR TITLE
1744 - Make spinner/text consistent size on action buttons

### DIFF
--- a/packages/composer-playground/src/app/directives/check-scroll/check-scroll.directive.spec.ts
+++ b/packages/composer-playground/src/app/directives/check-scroll/check-scroll.directive.spec.ts
@@ -1,0 +1,74 @@
+/* tslint:disable:no-unused-variable */
+/* tslint:disable:no-unused-expression */
+/* tslint:disable:no-var-requires */
+/* tslint:disable:max-classes-per-file */
+import { ComponentFixture, TestBed, async, fakeAsync, tick, inject } from '@angular/core/testing';
+import { Component, Renderer, } from '@angular/core';
+import { By } from '@angular/platform-browser';
+
+import * as sinon from 'sinon';
+import * as chai from 'chai';
+import { CheckScrollDirective } from './check-scroll.directive';
+
+let should = chai.should();
+
+@Component({
+    selector: 'test',
+    template: `<div checkScroll (hasScroll)=hasScroll($event)></div>`
+})
+
+class TestComponent {
+
+    scroll: boolean = false;
+
+    hasScroll(scroll: boolean) {
+        this.scroll = scroll;
+    }
+}
+
+describe('CheckScrollDirective', () => {
+
+    let component: TestComponent;
+    let fixture: ComponentFixture<TestComponent>;
+
+    let mockRenderer;
+
+    beforeEach(async(() => {
+        mockRenderer = sinon.createStubInstance(Renderer);
+        // mockRenderer.listen = sinon.stub();
+        // sinon.createStubInstance(Renderer);
+
+        TestBed.configureTestingModule({
+            declarations: [TestComponent, CheckScrollDirective],
+            providers: [
+               // {provide: Renderer, useValue: mockRenderer}
+                Renderer
+            ]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    }));
+
+    it('should create the directive', async(fakeAsync(() => {
+        component.should.be.ok;
+    })));
+
+    describe('checkScroll', () => {
+        it('should emit false when scrollTop is 0', async(fakeAsync(inject([Renderer], (renderer: Renderer) => {
+
+            let directiveEl = fixture.debugElement.query(By.directive(CheckScrollDirective));
+            let directiveInstance = directiveEl.injector.get(CheckScrollDirective);
+
+            renderer.setElementAttribute(directiveEl.nativeElement, 'scrollTop', '0px');
+            fixture.detectChanges();
+
+            directiveInstance.checkScroll();
+
+            tick();
+
+            component.scroll.should.be.false;
+        }))));
+    });
+});

--- a/packages/composer-playground/src/app/directives/check-scroll/check-scroll.directive.ts
+++ b/packages/composer-playground/src/app/directives/check-scroll/check-scroll.directive.ts
@@ -1,0 +1,30 @@
+import {
+    Directive,
+    ElementRef,
+    EventEmitter,
+    Output,
+    Renderer
+} from '@angular/core';
+
+@Directive({
+    selector: '[checkScroll]',
+})
+
+export class CheckScrollDirective {
+
+    @Output()
+    public hasScroll: EventEmitter<boolean> = new EventEmitter<boolean>();
+
+    private _thing = null;
+    private _expanded = false;
+
+    constructor(private el: ElementRef, private renderer: Renderer) {
+        renderer.listen(el.nativeElement, 'scroll', () => {
+            this.checkScroll();
+        });
+    }
+
+    checkScroll() {
+        this.hasScroll.emit(this.el.nativeElement.scrollTop > 0);
+    }
+}

--- a/packages/composer-playground/src/app/directives/directives.module.ts
+++ b/packages/composer-playground/src/app/directives/directives.module.ts
@@ -2,15 +2,16 @@ import { NgModule }           from '@angular/core';
 import { CommonModule }       from '@angular/common';
 
 import { CheckOverFlowDirective } from './check-overflow/check-overflow.directive';
+import { CheckScrollDirective } from './check-scroll/check-scroll.directive';
 import { DebounceDirective } from './debounce/debounce.directive';
 import { FocusHereDirective } from './focus-here/focus-here.directive';
 import { ScrollToElementDirective } from './scroll/scroll-to-element.directive';
 
 @NgModule({
     imports: [CommonModule],
-    declarations: [CheckOverFlowDirective, DebounceDirective, FocusHereDirective, ScrollToElementDirective],
+    declarations: [CheckOverFlowDirective, CheckScrollDirective, DebounceDirective, FocusHereDirective, ScrollToElementDirective],
     providers: [],
-    exports: [CheckOverFlowDirective, DebounceDirective, FocusHereDirective, ScrollToElementDirective]
+    exports: [CheckOverFlowDirective, CheckScrollDirective, DebounceDirective, FocusHereDirective, ScrollToElementDirective]
 })
 
 export class DirectivesModule {

--- a/packages/composer-playground/src/assets/styles/elements/_button.scss
+++ b/packages/composer-playground/src/assets/styles/elements/_button.scss
@@ -35,7 +35,7 @@
         }
 
         .ibm-spinner-indeterminate {
-            padding: 12%;
+            height: 40px;
         }
 
         h1 {


### PR DESCRIPTION
- Use height instead of padding to match the height of the text that the spinner replaces
- Tried `padding: 5% 12%`, but inconsistent results
- insert missing `checkScroll` directive that had been accidentally removed in a recent `git merge`