### PR TITLE
Resets the "Test" environment upon deployment #1796

### DIFF
--- a/packages/composer-playground/config/webpack.dev.js
+++ b/packages/composer-playground/config/webpack.dev.js
@@ -146,7 +146,8 @@ module.exports = function (options) {
       historyApiFallback : true,
       watchOptions : {
         aggregateTimeout : 300,
-        poll : 1000
+        poll : 1000,
+        ignored: /node_modules/
       }
     },
 

--- a/packages/composer-playground/src/app/test/test.component.ts
+++ b/packages/composer-playground/src/app/test/test.component.ts
@@ -50,7 +50,10 @@ export class TestComponent implements OnInit, OnDestroy {
                 }
             });
 
-            return this.clientService.getBusinessNetworkConnection().getAllAssetRegistries()
+            return this.clientService.reset()
+            .then(() => { 
+                return this.clientService.getBusinessNetworkConnection().getAllAssetRegistries();
+            })
             .then((assetRegistries) => {
                 assetRegistries.forEach((assetRegistry) => {
                     let index = assetRegistry.id.lastIndexOf('.');

--- a/packages/composer-playground/src/app/test/test.component.ts
+++ b/packages/composer-playground/src/app/test/test.component.ts
@@ -51,7 +51,7 @@ export class TestComponent implements OnInit, OnDestroy {
             });
 
             return this.clientService.reset()
-            .then(() => { 
+            .then(() => {
                 return this.clientService.getBusinessNetworkConnection().getAllAssetRegistries();
             })
             .then((assetRegistries) => {


### PR DESCRIPTION
This is a fix for #1796. When "Deploy" is pressed, the function "reset" is called to clear the current asset registries.