### PR TITLE
Handle colon (:) in ID portion of resource URIs

### DIFF
--- a/packages/composer-common/lib/model/identifiable.js
+++ b/packages/composer-common/lib/model/identifiable.js
@@ -25,7 +25,7 @@ const Typed = require('./typed');
  * @class
  * @memberof module:composer-common
  */
-class Identifiable extends Typed{
+class Identifiable extends Typed {
     /**
      * Create an instance.
      * <p>
@@ -105,7 +105,7 @@ class Identifiable extends Typed{
      */
     toURI() {
         const identifier = new Identifier('resource', this.getNamespace(), this.getType(), this.getIdentifier());
-        const result = identifier.toUri();
+        const result = identifier.toURI();
         //console.log( '***** URI for ' + this.toString() + ' is ' + result );
         return result;
     }

--- a/packages/composer-common/lib/model/identifiable.js
+++ b/packages/composer-common/lib/model/identifiable.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const Identifier = require('./identifier');
 const Typed = require('./typed');
 
 /**
@@ -103,7 +104,8 @@ class Identifiable extends Typed{
      * @return {String} the URI for the identifiable
      */
     toURI() {
-        const result = 'resource:' + this.getFullyQualifiedType() + '#' + encodeURI(this.getIdentifier());
+        const identifier = new Identifier('resource', this.getNamespace(), this.getType(), this.getIdentifier());
+        const result = identifier.toUri();
         //console.log( '***** URI for ' + this.toString() + ' is ' + result );
         return result;
     }

--- a/packages/composer-common/lib/model/identifier.js
+++ b/packages/composer-common/lib/model/identifier.js
@@ -49,7 +49,7 @@ class Identifier {
      * @param {String} [defaultType] - Type to use if the URI does not specify one.
      * @return {Identifier} - An identifier.
      */
-    static fromUri(uri, defaultNamespace, defaultType) {
+    static fromURI(uri, defaultNamespace, defaultType) {
         // Format: "protocol:qualifiedType#identifier", where "protocol:" and "qualifiedType#" are optional.
         // This pattern should never fail to match.
         const pattern = /^(?:([^:#]+):)?(?:([^#]+)#)?(.*)$/;
@@ -73,7 +73,7 @@ class Identifier {
      * URI representation of this identifier.
      * @return {String} - A URI.
      */
-    toUri() {
+    toURI() {
         const encodedId = encodeURI(this.id);
         const qualifiedType = ModelUtils.getFullyQualifiedName(this.namespace, this.type);
         return `${this.protocol}:${qualifiedType}#${encodedId}`;

--- a/packages/composer-common/lib/model/identifier.js
+++ b/packages/composer-common/lib/model/identifier.js
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const ModelUtils = require('../modelutil');
+
+/**
+ * All the identifying properties of a resource.
+ * @private
+ * @class
+ * @memberof module:composer-common
+ * @property {String} protocol
+ * @property {String} namespace
+ * @property {String} type
+ * @property {String} id
+ */
+class Identifier {
+    /**
+     * <strong>Note: only for use by internal framework code.</strong>
+     * @param {String} protocol - Protocol.
+     * @param {String} namespace - Namespace containing the type.
+     * @param {String} type - Short type name.
+     * @param {String} id - Instance identifier.
+     * @private
+     */
+    constructor(protocol, namespace, type, id) {
+        this.protocol = protocol;
+        this.namespace = namespace;
+        this.type = type;
+        this.id = id;
+    }
+
+    /**
+     * Parse a URI into an identifier.
+     * @param {String} uri - Resource URI.
+     * @param {String} [defaultNamespace] - Namespace to use if the URI does not specify one.
+     * @param {String} [defaultType] - Type to use if the URI does not specify one.
+     * @return {Identifier} - An identifier.
+     */
+    static fromUri(uri, defaultNamespace, defaultType) {
+        // Format: "protocol:qualifiedType#identifier", where "protocol:" and "qualifiedType#" are optional.
+        // This pattern should never fail to match.
+        const pattern = /^(?:([^:#]+):)?(?:([^#]+)#)?(.*)$/;
+        const match = uri.match(pattern);
+
+        const protocol = match[1] || '';
+        const qualifiedType = match[2] || '';
+        const id = decodeURI(match[3] || '');
+
+        let namespace = defaultNamespace;
+        let type = defaultType;
+        if (qualifiedType) {
+            namespace = ModelUtils.getNamespace(qualifiedType);
+            type = ModelUtils.getShortName(qualifiedType);
+        }
+
+        return new Identifier(protocol, namespace, type, id);
+    }
+
+    /**
+     * URI representation of this identifier.
+     * @return {String} - A URI.
+     */
+    toUri() {
+        const encodedId = encodeURI(this.id);
+        const qualifiedType = ModelUtils.getFullyQualifiedName(this.namespace, this.type);
+        return `${this.protocol}:${qualifiedType}#${encodedId}`;
+    }
+
+}
+
+module.exports = Identifier;

--- a/packages/composer-common/lib/model/relationship.js
+++ b/packages/composer-common/lib/model/relationship.js
@@ -74,7 +74,7 @@ class Relationship extends Identifiable {
      * @return {Relationship} the relationship
      */
     static fromURI(modelManager, uriAsString, defaultNamespace, defaultType) {
-        const identifier = Identifier.fromUri(uriAsString, defaultNamespace, defaultType);
+        const identifier = Identifier.fromURI(uriAsString, defaultNamespace, defaultType);
 
         let modelFile = modelManager.getModelFile(identifier.namespace);
         if (!modelFile) {

--- a/packages/composer-common/lib/model/relationship.js
+++ b/packages/composer-common/lib/model/relationship.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const Identifiable = require('./identifiable');
-const ModelUtils = require('../modelutil');
+const Identifier = require('./identifier');
 const Globalize = require('../globalize');
 
 /**
@@ -69,69 +69,32 @@ class Relationship extends Identifiable {
      * Contructs a Relationship instance from a URI representation (created using toURI).
      * @param {ModelManager} modelManager - the model manager to bind the relationship to
      * @param {String} uriAsString - the URI as a string, generated using Identifiable.toURI()
-     * @param {String} defaultNamespace - default namespace to use for backwards compatability (optional)
-     * @param {String} defaultType - default type to use for backwards compatability (optional)
+     * @param {String} [defaultNamespace] - default namespace to use for backwards compatability (optional)
+     * @param {String} [defaultType] - default type to use for backwards compatability (optional)
      * @return {Relationship} the relationship
      */
     static fromURI(modelManager, uriAsString, defaultNamespace, defaultType) {
+        const identifier = Identifier.fromUri(uriAsString, defaultNamespace, defaultType);
 
-        // parse the URI, we do it by hand because we know the format
-        const indexOfColon = uriAsString.indexOf(':');
-        let protocol = null;
-        let id = uriAsString;
-        let type = null;
-        let ns = null;
-        let resource = null;
-
-        // protocol
-        if(indexOfColon > 0) {
-            protocol = uriAsString.substring(0, indexOfColon);
-            uriAsString = uriAsString.substr(indexOfColon+1);
-        }
-
-        // id and resource
-        const indexOfHash = uriAsString.indexOf('#');
-        if(indexOfHash > 0) {
-            id = uriAsString.substr(indexOfHash+1);
-            resource = uriAsString.substring(0,indexOfHash);
-        }
-
-        // old style relationships do not have a schema
-        if (protocol !== 'resource') {
-            if (resource) {
-                ns = ModelUtils.getNamespace(resource);
-                type = ModelUtils.getShortName(resource);
-            } else {
-                ns = defaultNamespace;
-                type = defaultType;
-                id = uriAsString;
-            }
-        } else {
-            ns = ModelUtils.getNamespace(resource);
-            type = ModelUtils.getShortName(resource);
-        }
-
-        id = decodeURI(id);
-
-        let modelFile = modelManager.getModelFile(ns);
-        if(!modelFile) {
+        let modelFile = modelManager.getModelFile(identifier.namespace);
+        if (!modelFile) {
             let formatter = Globalize.messageFormatter('factory-newrelationship-notregisteredwithmm');
 
             throw new Error(formatter({
-                namespace: ns
+                namespace: identifier.namespace
             }));
         }
 
-        if(!modelFile.isDefined(type)) {
+        if (!modelFile.isDefined(identifier.type)) {
             let formatter = Globalize.messageFormatter('factory-newinstance-typenotdeclaredinns');
 
             throw new Error(formatter({
-                namespace: ns,
-                type: type
+                namespace: identifier.namespace,
+                type: identifier.type
             }));
         }
 
-        let relationship = new Relationship(modelManager,ns,type,id);
+        let relationship = new Relationship(modelManager, identifier.namespace, identifier.type, identifier.id);
         return relationship;
     }
 }

--- a/packages/composer-common/test/model/relationship.js
+++ b/packages/composer-common/test/model/relationship.js
@@ -125,6 +125,13 @@ describe('Relationship', function () {
             rel.getIdentifier().should.equal('123');
         });
 
+        it('legacy fully qualified identifier including tricky characters', function() {
+            const rel = Relationship.fromURI(modelManager, 'org.acme.l1.Person#1.2:3#4' );
+            rel.getNamespace().should.equal('org.acme.l1');
+            rel.getType().should.equal('Person');
+            rel.getIdentifier().should.equal('1.2:3#4');
+        });
+
         it('check that relationships can be created from a legacy identifier', function() {
             const rel = Relationship.fromURI(modelManager, '123', 'org.acme.l1', 'Person' );
             rel.getNamespace().should.equal('org.acme.l1');
@@ -143,6 +150,12 @@ describe('Relationship', function () {
                 Relationship.fromURI(modelManager, 'resource:org.acme.l1.Unkown#123' );
             }).should.throw(/Cannot instantiate Type Unkown in namespace org.acme.l1/);
         });
+    });
 
+    describe('#toString', function() {
+        it('should include the ID', function() {
+            const relationship = new Relationship(modelManager, 'org.acme.l1', 'Person', '123' );
+            relationship.toString().should.include('123');
+        });
     });
 });


### PR DESCRIPTION
Composer identity issue fails for participant ids containing colons #1805

Signed-off-by: Mark S. Lewis <Mark_Lewis@uk.ibm.com>