### PR TITLE
Fix Yeoman generator sample application .cto

### DIFF
--- a/packages/generator-hyperledger-composer/generators/businessnetwork/templates/lib/logic.js
+++ b/packages/generator-hyperledger-composer/generators/businessnetwork/templates/lib/logic.js
@@ -11,7 +11,7 @@
 function onChangeAssetValue(changeAssetValue) {
     var assetRegistry;
     var id = changeAssetValue.relatedAsset.assetId;
-    return getAssetRegistry('<%= namespace%>.Asset')
+    return getAssetRegistry('<%= namespace%>.SampleAsset')
         .then(function(ar) {
             assetRegistry = ar;
             return assetRegistry.get(id);

--- a/packages/generator-hyperledger-composer/generators/businessnetwork/templates/models/namespace.cto
+++ b/packages/generator-hyperledger-composer/generators/businessnetwork/templates/models/namespace.cto
@@ -8,13 +8,12 @@ participant User identified by email {
   o String email
 }
 
-asset Asset identified by assetId {
+asset SampleAsset identified by assetId {
   o String assetId
   o String value
 }
 
 transaction ChangeAssetValue {
-  o String transactionId
   o String newValue
   --> Asset relatedAsset
 }

--- a/packages/generator-hyperledger-composer/generators/businessnetwork/templates/test/logic.js
+++ b/packages/generator-hyperledger-composer/generators/businessnetwork/templates/test/logic.js
@@ -15,6 +15,8 @@ require('chai').should();
 var bfs_fs = BrowserFS.BFSRequire('fs');
 var NS = '<%= namespace%>';
 
+var assetType = 'SampleAsset';
+
 describe('#'+NS, function() {
 
     var businessNetworkConnection;
@@ -42,7 +44,7 @@ describe('#'+NS, function() {
 
     describe('ChangeAssetValue()', function() {
 
-        it('should change the value property of Asset to newValue', () => {
+        it('should change the value property of ' + assetType + ' to newValue', () => {
 
             var factory = businessNetworkConnection.getBusinessNetwork().getFactory();
 
@@ -50,15 +52,15 @@ describe('#'+NS, function() {
             var user = factory.newResource(NS, 'User', '<%= appauthor%>');
 
             // create the asset
-            var asset = factory.newResource(NS, 'Asset', 'ASSET_001');
+            var asset = factory.newResource(NS, assetType, 'ASSET_001');
             asset.value = 'old-value';
 
             var changeAssetValue = factory.newTransaction(NS, 'ChangeAssetValue');
-            changeAssetValue.relatedAsset = factory.newRelationship(NS, 'Asset', asset.$identifier);
+            changeAssetValue.relatedAsset = factory.newRelationship(NS, assetType, asset.$identifier);
             changeAssetValue.newValue = 'new-value';
 
             // Get the asset registry.
-            return businessNetworkConnection.getAssetRegistry(NS + '.Asset')
+            return businessNetworkConnection.getAssetRegistry(NS + '.' + assetType)
             .then(function(registry) {
 
                 // Add the Asset to the asset registry.
@@ -74,7 +76,7 @@ describe('#'+NS, function() {
                     return businessNetworkConnection.submitTransaction(changeAssetValue);
                 })
                 .then(function() {
-                    return businessNetworkConnection.getAssetRegistry(NS + '.Asset');
+                    return businessNetworkConnection.getAssetRegistry(NS + '.' + assetType);
                 })
                 .then(function(registry) {
                     // get the listing


### PR DESCRIPTION
- Rename asset from `Asset` to `SampleAsset`, as Asset is a reserved word.
- Remove transactionId field from transaction as now defined in system model for transactions.

Signed-off-by: Mark S. Lewis <Mark_Lewis@uk.ibm.com>