### PR TITLE
LoopBack wallet uses incorrect wallet identity query

### DIFF
--- a/packages/composer-rest-server/lib/loopbackwallet.js
+++ b/packages/composer-rest-server/lib/loopbackwallet.js
@@ -36,6 +36,16 @@ class LoopBackWallet extends Wallet {
     }
 
     /**
+     * Get the wallet identity from the LoopBack managed data source.
+     * @private
+     * @return {Promise} A promise that is resolved with the wallet identity,
+     * or rejected with an error.
+     */
+    getWalletIdentity() {
+        return this.app.models.WalletIdentity.findOne({ where: { walletId: this.wallet.id, enrollmentID: this.enrollmentID } });
+    }
+
+    /**
      * List all of the credentials in the wallet.
      * @abstract
      * @return {Promise} A promise that is resolved with
@@ -43,7 +53,7 @@ class LoopBackWallet extends Wallet {
      * error.
      */
     list() {
-        return this.app.models.WalletIdentity.findOne({ walletId: this.wallet.id, enrollmentID: this.enrollmentID })
+        return this.getWalletIdentity()
             .then((identity) => {
                 return Object.keys(identity.data).sort();
             });
@@ -59,7 +69,7 @@ class LoopBackWallet extends Wallet {
      * wallet, false otherwise.
      */
     contains(name) {
-        return this.app.models.WalletIdentity.findOne({ walletId: this.wallet.id, enrollmentID: this.enrollmentID })
+        return this.getWalletIdentity()
             .then((identity) => {
                 return identity.data.hasOwnProperty(name);
             });
@@ -73,7 +83,7 @@ class LoopBackWallet extends Wallet {
      * the named credentials, or rejected with an error.
      */
     get(name) {
-        return this.app.models.WalletIdentity.findOne({ where: { walletId: this.wallet.id, enrollmentID: this.enrollmentID } })
+        return this.getWalletIdentity()
             .then((identity) => {
                 return identity.data[name];
             });
@@ -88,7 +98,7 @@ class LoopBackWallet extends Wallet {
      * complete, or rejected with an error.
      */
     add(name, value) {
-        return this.app.models.WalletIdentity.findOne({ where: { walletId: this.wallet.id, enrollmentID: this.enrollmentID } })
+        return this.getWalletIdentity()
             .then((identity) => {
                 identity.data[name] = value;
                 return identity.save();
@@ -104,7 +114,7 @@ class LoopBackWallet extends Wallet {
      * complete, or rejected with an error.
      */
     update(name, value) {
-        return this.app.models.WalletIdentity.findOne({ where: { walletId: this.wallet.id, enrollmentID: this.enrollmentID } })
+        return this.getWalletIdentity()
             .then((identity) => {
                 identity.data[name] = value;
                 return identity.save();
@@ -119,7 +129,7 @@ class LoopBackWallet extends Wallet {
      * complete, or rejected with an error.
      */
     remove(name) {
-        return this.app.models.WalletIdentity.findOne({ walletId: this.wallet.id, enrollmentID: this.enrollmentID })
+        return this.getWalletIdentity()
             .then((identity) => {
                 delete identity.data[name];
                 return identity.save();

--- a/packages/composer-rest-server/test/lib/loopbackwallet.js
+++ b/packages/composer-rest-server/test/lib/loopbackwallet.js
@@ -62,11 +62,29 @@ describe('LoopBackWallet', () => {
                 WalletIdentityModel.create([
                     {
                         walletId: wallet.id,
-                        enrollmentID: 'testuser',
+                        enrollmentID: 'testuser0',
+                        enrollmentSecret: 'suchs3cret',
+                        data: {
+                            testA: 'i like biscuits',
+                            testB: 'everybody likes biscuits'
+                        }
+                    },
+                    {
+                        walletId: wallet.id,
+                        enrollmentID: 'testuser1',
                         enrollmentSecret: 'testpass',
                         data: {
                             test1: 'hello this is a cert',
                             test2: 'hello this is another cert'
+                        }
+                    },
+                    {
+                        walletId: wallet.id,
+                        enrollmentID: 'testuser2',
+                        enrollmentSecret: 'manypass',
+                        data: {
+                            testA1: 'i drive a blue car',
+                            testB2: 'you drive a green car'
                         }
                     }
                 ], (err) => {
@@ -78,14 +96,14 @@ describe('LoopBackWallet', () => {
             });
         })
         .then(() => {
-            lbWallet = new LoopBackWallet(app, wallet, 'testuser');
+            lbWallet = new LoopBackWallet(app, wallet, 'testuser1');
         });
     });
 
     describe('#list', () => {
 
         it('should return an empty array when no keys exist', () => {
-            return WalletIdentityModel.findOne({ where: { enrollmentID: 'testuser' } })
+            return WalletIdentityModel.findOne({ where: { enrollmentID: 'testuser1' } })
                 .then((identity) => {
                     identity.data = {};
                     return identity.save();
@@ -136,7 +154,7 @@ describe('LoopBackWallet', () => {
         it('should set the value for a key', () => {
             return lbWallet.add('testA', 'hello this is a test set cert')
                 .then(() => {
-                    return WalletIdentityModel.findOne({ where: { enrollmentID: 'testuser' } });
+                    return WalletIdentityModel.findOne({ where: { enrollmentID: 'testuser1' } });
                 })
                 .then((identity) => {
                     identity.data.testA.should.equal('hello this is a test set cert');
@@ -150,7 +168,7 @@ describe('LoopBackWallet', () => {
         it('should update the value for a key', () => {
             return lbWallet.update('test2', 'hello this is a test set cert')
                 .then(() => {
-                    return WalletIdentityModel.findOne({ where: { enrollmentID: 'testuser' } });
+                    return WalletIdentityModel.findOne({ where: { enrollmentID: 'testuser1' } });
                 })
                 .then((identity) => {
                     identity.data.test2.should.equal('hello this is a test set cert');
@@ -164,7 +182,7 @@ describe('LoopBackWallet', () => {
         it('should remove the key', () => {
             return lbWallet.remove('test2')
                 .then(() => {
-                    return WalletIdentityModel.findOne({ where: { enrollmentID: 'testuser' } });
+                    return WalletIdentityModel.findOne({ where: { enrollmentID: 'testuser1' } });
                 })
                 .then((identity) => {
                     should.equal(identity.data.test2, undefined);


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->
Time Elapsing Breaks Wallet Identities #1731
Secure REST server error - The current identity has not been registered #1784

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
When REST server security is enabled, the LoopBack connector goes into "multi-user" mode. This means that each authenticated user has their own business network connection, that uses their own identities from their wallet. The LoopBack connector maintains a pool of these connections, and expires them after 5 minutes.

The REST server provides a `Wallet` implementation, `LoopBackWallet` that provides a view into the `WalletIdentity` data source. However, most of the methods in `LoopBackWallet` do not use the LoopBack APIs correctly - the where clause is not specified, and they end up selecting the first `WalletIdentity` the data source returns.

When the LoopBack connector expires a connection from the pool, the next request reconnects, which results in a lookup of the wallet to retrieve the identity. The problem above causes it not to find the identity (which is still there and still valid), so the code attempts to re-enroll - if successful - another identity is added into the wallet, but it's likely not to be bound to a participant in the identity registry.

The fix fixes `LoopBackWallet` such that it uses the LoopBack APIs correctly, and also fixes the unit tests to detect and prevent this problem from occurring in the future.

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->