### PR TITLE
Restrict use of identity cards in web playground

### DIFF
--- a/packages/composer-playground/src/app/app.component.html
+++ b/packages/composer-playground/src/app/app.component.html
@@ -5,8 +5,8 @@
                 <p><b>{{ composerBanner[0] }}</b> {{ composerBanner[1] }}</p>
                 <div class="tooltiptext">{{ composerBanner[0] }} {{ composerBanner[1] }}</div>
             </div>
-            <div *ngIf="showHeaderLinks" class="flex-container flex">
-                <ul class="links navleft">
+            <div class="navmain" [ngClass]="{'rightonly' : !showHeaderLinks && !usingLocally }">
+                <ul *ngIf="showHeaderLinks" class="links navleft">
                     <li>
                         <button id='app_definebutton' class="action" [routerLink]="['editor']"
                                 [routerLinkActive]="['active']">Define
@@ -18,14 +18,9 @@
                         </button>
                     </li>
                 </ul>
-                <ul class="links navright" *ngIf="!usingLocally">
-                    <li class="withseparator">
-                        <button class="action" [routerLink]="['identity']" [routerLinkActive]="['active']">
-                            <span class="currentid" title="{{ identityService.currentIdentity | async }}">{{ identityService.currentIdentity | async }}</span>
-                        </button>
-                    </li>
+                <ul *ngIf="!showHeaderLinks && !usingLocally" class="links navright">
                     <li>
-                        <a href="https://hyperledger.github.io/composer/installing/using-playground-locally.html"
+                        <a href="https://hyperledger.github.io/composer/installing/installing-index.html"
                            target="_blank">
                             <svg class="nav-icon" aria-hidden="true">
                                 <use xlink:href="#icon-simple_docker"></use>
@@ -34,7 +29,7 @@
                         </a>
                     </li>
                 </ul>
-                <div class="drop-select" *ngIf="usingLocally" [routerLinkActive]="['active']" [ngClass]="{'dropListActive' : dropListActive}">
+                <div *ngIf="showHeaderLinks" class="drop-select navright" [routerLinkActive]="['active']" [ngClass]="{'dropListActive' : dropListActive}">
                     <div class="drop-select-item flex-container flex">
                         <div ngbDropdown class="d-inline-block" (openChange)="onToggle($event)">
                             <button type="button" class="action" id="dropdownMenu1" ngbDropdownToggle>

--- a/packages/composer-playground/src/app/login/identity-card/identity-card.component.html
+++ b/packages/composer-playground/src/app/login/identity-card/identity-card.component.html
@@ -26,7 +26,7 @@
                 <use xlink:href="#icon-trash_32"></use>
             </svg>
         </button>
-        <button type="button" class="action circular export"
+        <button *ngIf="'web' !== identity.getConnectionProfile().type" type="button" class="action circular export"
                 (click)="export()">
             <svg class="ibm-icon vertical-top" aria-hidden="true">
                 <use xlink:href="#icon-download_32"></use>

--- a/packages/composer-playground/src/app/login/identity-card/identity-card.component.scss
+++ b/packages/composer-playground/src/app/login/identity-card/identity-card.component.scss
@@ -120,8 +120,8 @@
                 border-color: transparent;
             }
 
-            button:first-child {
-                margin-right: $space-large;
+            button {
+                margin: 0 $space-medium 0 $space-medium;
             }
 
             svg {

--- a/packages/composer-playground/src/app/login/identity-card/identity-card.component.ts
+++ b/packages/composer-playground/src/app/login/identity-card/identity-card.component.ts
@@ -46,7 +46,7 @@ export class IdentityCardComponent {
         this.onExport.emit(this.identity.getName());
     }
 
-    getInitials<String>() {
+    getInitials(): string {
         let result;
         let userId = this.identity.getName();
         let regexp = /^(\S)\S*\s*(\S?)/i;

--- a/packages/composer-playground/src/app/login/login.component.html
+++ b/packages/composer-playground/src/app/login/login.component.html
@@ -1,10 +1,10 @@
 <section *ngIf="!showSubScreen" class="header">
     <h1 class="left-align">My Wallet</h1>
     <div class="right-align" *ngIf="!showSubScreen">
-        <button type="button" class="secondary" (click)="importIdentity()">
+        <button *ngIf="usingLocally" type="button" class="secondary" (click)="importIdentity()">
             <span>Import ID Card</span>
         </button>
-        <button type="button" class="secondary" (click)="createIdCard()">
+        <button *ngIf="usingLocally" type="button" class="secondary" (click)="createIdCard()">
             <span>Create ID Card</span>
         </button>
     </div>

--- a/packages/composer-playground/src/app/login/login.component.spec.ts
+++ b/packages/composer-playground/src/app/login/login.component.spec.ts
@@ -183,11 +183,11 @@ describe(`LoginComponent`, () => {
         component = fixture.componentInstance;
     });
 
-    describe('ngOnInit', () => {
-        it('should create the component', () => {
-            component.should.be.ok;
-        });
+    it('should create the component', () => {
+        component.should.be.ok;
+    });
 
+    describe('ngOnInit', () => {
         it('should load identity cards', fakeAsync(() => {
             mockInitializationService.initialize.returns(Promise.resolve());
             let loadIdentityCardsStub = sinon.stub(component, 'loadIdentityCards');
@@ -197,6 +197,18 @@ describe(`LoginComponent`, () => {
 
             mockInitializationService.initialize.should.have.been.called;
             loadIdentityCardsStub.should.have.been.called;
+        }));
+
+        it('should check if playground is hosted or being used locally', fakeAsync(() => {
+            mockInitializationService.initialize.returns(Promise.resolve());
+            mockInitializationService.isWebOnly.returns(true);
+            let loadIdentityCardsStub = sinon.stub(component, 'loadIdentityCards');
+            component.ngOnInit();
+
+            tick();
+
+            mockInitializationService.isWebOnly.should.have.been.called;
+            component['usingLocally'].should.be.false;
         }));
     });
 

--- a/packages/composer-playground/src/app/login/login.component.ts
+++ b/packages/composer-playground/src/app/login/login.component.ts
@@ -23,6 +23,7 @@ import { saveAs } from 'file-saver';
 })
 export class LoginComponent implements OnInit {
 
+    private usingLocally: boolean = false;
     private connectionProfileRefs: string[];
     private connectionProfileNames: Map<string, string>;
     private connectionProfiles: Map<string, string>;
@@ -47,6 +48,8 @@ export class LoginComponent implements OnInit {
     ngOnInit(): Promise<void> {
         return this.initializationService.initialize()
             .then(() => {
+                this.usingLocally = !this.initializationService.isWebOnly();
+
                 return this.loadIdentityCards();
             });
     }

--- a/packages/composer-playground/src/app/services/identity-card.service.ts
+++ b/packages/composer-playground/src/app/services/identity-card.service.ts
@@ -82,7 +82,7 @@ export class IdentityCardService {
         return cardRefs;
     }
 
-    loadIdentityCards(): Promise<number> {
+    loadIdentityCards(webOnly: boolean): Promise<number> {
         this.currentCard = null;
 
         return new Promise((resolve, reject) => {
@@ -93,9 +93,13 @@ export class IdentityCardService {
                     // not associated playground data, which has a suffix
                     if (cardRef.length === 36) {
                         let cardProperties: any = this.identityCardStorageService.get(cardRef);
+
+                        if (webOnly && cardProperties.connectionProfile.type !== 'web') {
+                            return;
+                        }
+
                         let cardObject = new IdCard(cardProperties.metadata, cardProperties.connectionProfile);
                         cardObject.setCredentials(cardProperties.credentials);
-
                         let data: any = this.identityCardStorageService.get(this.dataRef(cardRef));
                         if (data && data.current) {
                             this.currentCard = cardRef;
@@ -124,13 +128,7 @@ export class IdentityCardService {
     }
 
     getIdentityCards(): Promise<Map<string, IdCard>> {
-        if (this.idCards.size > 0) {
-            return Promise.resolve(this.idCards);
-        }
-
-        return this.loadIdentityCards().then(() => {
-            return this.idCards;
-        });
+        return Promise.resolve(this.idCards);
     }
 
     addInitialIdentityCards(initialCards?: IdCard[]): Promise<string | void> {

--- a/packages/composer-playground/src/app/services/initialization.service.ts
+++ b/packages/composer-playground/src/app/services/initialization.service.ts
@@ -34,13 +34,13 @@ export class InitializationService {
 
         this.initializingPromise = Promise.resolve()
             .then(() => {
-                return this.identityCardService.loadIdentityCards();
-            })
-            .then(() => {
                 return this.loadConfig();
             })
             .then((config) => {
                 this.config = config;
+                return this.identityCardService.loadIdentityCards(this.isWebOnly());
+            })
+            .then(() => {
                 // TODO pass in array of identity cards via config.json somehow
                 return this.identityCardService.addInitialIdentityCards();
             })

--- a/packages/composer-playground/src/assets/styles/elements/_header.scss
+++ b/packages/composer-playground/src/assets/styles/elements/_header.scss
@@ -57,6 +57,25 @@
         border-color: transparent transparent black transparent;
       }
 
+      .navmain {
+        display: flex;
+        justify-content: space-between;
+        flex: 1;
+
+        &.rightonly {
+          justify-content: flex-end;
+        }
+
+        .navleft {
+          margin-left: 2rem;
+        }
+
+        .navright {
+          justify-content: flex-end;
+          margin-right: 2rem;
+        }
+      }
+
       .drop-select{
             display: flex;
             align-items: center;
@@ -225,16 +244,6 @@
             border-bottom: 0px;
             border-radius: 0px;
           }
-        }
-
-        &.navleft {
-          flex: 1;
-          margin-left: 2rem;
-        }
-
-        &.navright {
-          justify-content: flex-end;
-          margin-right: 2rem;
         }
       }
     }


### PR DESCRIPTION
Restrict use of identity cards when playground is not being used locally

Closes #1885

Signed-off-by: James Taylor <jamest@uk.ibm.com>
