### PR TITLE
Modify protractor tests to increase reliability

### DIFF
--- a/packages/composer-playground/e2e/component/import.ts
+++ b/packages/composer-playground/e2e/component/import.ts
@@ -3,9 +3,12 @@ import { ExpectedConditions } from 'protractor';
 import { dragDropFile } from '../utils/fileUtils';
 import { OperationsHelper } from '../utils/operations-helper';
 
-let scrollMe = (target) => {
-    target.scrollIntoView(true);
-};
+// Initialise known tile orderings
+let baseTiles = ['basic-sample-network', 'empty-business-network', 'drag-drop'];
+
+let npmTiles = ['animaltracking-network', 'bond-network', 'carauction-network',
+                'digitalproperty-network', 'marbles-network', 'perishable-network',
+                'pii-network', 'trade-network', 'vehicle-lifecycle-network'];
 
 export class Import {
 
@@ -34,7 +37,7 @@ export class Import {
   // Deploy default Tile option
   static selectDefaultBusinessDefinitionTileOption() {
     // Wait for poplation of sample-network-list-item(s)
-    OperationsHelper.retriveMatchingElementsByCSS('.sample-network-list-container', '.sample-network-list-item', 3)
+    this.retrieveBaseTileOptions()
     .then((options) => {
         let confirmElement = element(by.id('import_confirm'));
         browser.executeScript('arguments[0].scrollIntoView();', confirmElement.getWebElement());
@@ -42,22 +45,52 @@ export class Import {
     });
   }
 
-  // Deploy selected Tile option
-  static selectBusinessDefinitionTileOption(option) {
+  // Deploy selected Tile option from Base tiles
+  static selectBaseImportOption(importOption: string) {
     // Wait for poplation of sample-network-list-item(s)
-    OperationsHelper.retriveMatchingElementsByCSS('.sample-network-list-container', '.sample-network-list-item', 3)
+    this.retrieveBaseTileOptions()
     .then((options) => {
-        options[option].getWebElement().click();
+        // Figure out which one we want
+        let index = baseTiles.findIndex((tile) => tile === importOption);
+        let optionElement = options[index].getWebElement();
+        // Scroll into view
+        browser.executeScript('arguments[0].scrollIntoView();', optionElement);
+
+        // Click
+        optionElement.click();
+
+        // Confirm
         let confirmElement = element(by.id('import_confirm'));
-        browser.executeScript('arguments[0].scrollIntoView();', confirmElement.getWebElement());
+        browser.executeScript('arguments[0].scrollIntoView();', confirmElement);
+        OperationsHelper.click(confirmElement);
+    });
+  }
+
+  // Deploy selected Tile option from NPM tiles
+  static selectNpmImportOption(importOption: string) {
+    // Wait for poplation of sample-network-list-item(s)
+    this.retrieveNpmTileOptions()
+    .then((options) => {
+        // Figure out which one we want
+        let index = npmTiles.findIndex((tile) => tile === importOption);
+        let optionElement = options[index].getWebElement();
+        // Scroll into view
+        browser.executeScript('arguments[0].scrollIntoView();', optionElement);
+
+        // Click
+        optionElement.click();
+
+        // Confirm
+        let confirmElement = element(by.id('import_confirm'));
+        browser.executeScript('arguments[0].scrollIntoView();', confirmElement);
         OperationsHelper.click(confirmElement);
     });
   }
 
   // Confirm import
   static confirmImport() {
-    // Import drawer should be present and populated
-    browser.wait(ExpectedConditions.visibilityOf(element(by.css('.drawer'))), 10000)
+    // Import drawer should be present and populated with chosen-network div
+    browser.wait(ExpectedConditions.visibilityOf(element(by.css('.chosen-network'))), 10000);
 
     // Wait for poplation of sample-network-list-item(s)
     OperationsHelper.retriveMatchingElementsByCSS('.sample-network-list-container', '.sample-network-list-item', 3)
@@ -70,8 +103,8 @@ export class Import {
 
   // Cancel import
   static cancelImport() {
-      // Import drawer should be present, button should be visible
-      browser.wait(ExpectedConditions.visibilityOf(element(by.css('.drawer'))), 5000);
+      // Import drawer should be present, button should be visible within chosen-network div
+      browser.wait(ExpectedConditions.visibilityOf(element(by.css('.chosen-network'))), 5000);
 
       // Wait for poplation of sample-network-list-item(s)
       OperationsHelper.retriveMatchingElementsByCSS('.sample-network-list-container', '.sample-network-list-item', 3)
@@ -90,5 +123,24 @@ export class Import {
   static waitToDisappear() {
       browser.wait(ExpectedConditions.invisibilityOf(element(by.css('.drawer'))), 5000);
   }
+
+  static waitToLoadBaseOptions() {
+      browser.wait(OperationsHelper.elementsPresent(element(by.id('base-samples')).all(by.css('.sample-network-list-item')), baseTiles.length), 20000);
+  }
+
+  static waitToLoadNpmOptions() {
+      browser.wait(OperationsHelper.elementsPresent(element(by.id('npm-samples')).all(by.css('.sample-network-list-item')), npmTiles.length), 20000);
+  }
+
+  static retrieveBaseTileOptions() {
+    this.waitToLoadBaseOptions();
+    return element(by.id('base-samples')).all(by.css('.sample-network-list-item'));
+  }
+
+  static retrieveNpmTileOptions() {
+    this.waitToLoadNpmOptions();
+    return element(by.id('npm-samples')).all(by.css('.sample-network-list-item'));
+  }
+
 
 }

--- a/packages/composer-playground/e2e/specs/editor-define.spec.ts
+++ b/packages/composer-playground/e2e/specs/editor-define.spec.ts
@@ -16,17 +16,14 @@ import * as JSZip from 'jszip';
 
 let expect = chai.expect;
 
-
-
 describe('Editor Define', (() => {
 
-  let tileItems: Array<string> = null;
+  let baseTiles: Array<string> = null;
+  let npmTiles: Array<string> = null;
+  let sampleOptions;
 
   // Navigate to Editor base page and move past welcome splash
   beforeAll(() =>  {
-    // Initialise known tile orderings
-    this.tileItems = ['basic-sample-network', 'empty-business-network', 'file-import'];
-
     // Important angular configuration and intial step passage to reach editor
     browser.waitForAngularEnabled(false);
     OperationsHelper.navigatePastWelcome();
@@ -106,6 +103,8 @@ describe('Editor Define', (() => {
     // Press the 'Import' button
     beforeEach(() =>  {
         Editor.clickImportBND();
+        Import.waitToLoadBaseOptions();
+        Import.waitToLoadNpmOptions();
     });
 
     it('should enable to close/cancel import slide out', (() => {
@@ -158,10 +157,9 @@ describe('Editor Define', (() => {
 
     }));
 
-
     it('should enable empty BNA import via tile selection', (() => {
         // Select Empty BNA
-        Import.selectBusinessDefinitionTileOption(this.tileItems.findIndex((tile) => tile === 'empty-business-network'));
+        Import.selectBaseImportOption('empty-business-network');
 
         // Replace confirm should show, confirm it
         Replace.confirmReplace();
@@ -188,7 +186,7 @@ describe('Editor Define', (() => {
 
     it('should enable populated BNA import via file selection', (() => {
          // Select Basic Sample Network BNA
-        Import.selectBusinessDefinitionTileOption(this.tileItems.findIndex((tile) => tile === 'basic-sample-network'));
+        Import.selectBaseImportOption('basic-sample-network');
 
         // Replace confirm should show, confirm it
         Replace.confirmReplace();
@@ -198,7 +196,7 @@ describe('Editor Define', (() => {
         Import.waitToDisappear();
         // -success message
         OperationsHelper.processExpectedSuccess();
-        // -expected files in navigator (Just a readme)
+        // -expected files in navigator
         Editor.retrieveNavigatorFileNames()
         .then((filelist: any) => {
             let expectedFiles = ['About\nREADME.md', 'Model File\nmodels/sample.cto', 'Script File\nlib/sample.js', 'Access Control\npermissions.acl'];
@@ -215,6 +213,106 @@ describe('Editor Define', (() => {
             expect(buttonlist[1]).to.deep.equal({text: 'Deploy', enabled: false});
         });
     }));
+
+    it('should enable import of npm hosted animaltracking-network', (() => {
+        // Select & Confirm
+        Import.selectNpmImportOption('animaltracking-network');
+        Replace.confirmReplace();
+
+        // Expect success
+        Import.waitToDisappear();
+        OperationsHelper.processExpectedSuccess();
+
+    }));
+
+    it('should enable import of npm hosted bond-network', (() => {
+        // Select & Confirm
+        Import.selectNpmImportOption('bond-network');
+        Replace.confirmReplace();
+
+        // Expect success
+        Import.waitToDisappear();
+        OperationsHelper.processExpectedSuccess();
+
+    }));
+
+    it('should enable import of npm hosted carauction-network', (() => {
+        // Select & Confirm
+        Import.selectNpmImportOption('carauction-network');
+        Replace.confirmReplace();
+
+        // Expect success
+        Import.waitToDisappear();
+        OperationsHelper.processExpectedSuccess();
+
+    }));
+
+    it('should enable import of npm hosted digitalproperty-network', (() => {
+        // Select & Confirm
+        Import.selectNpmImportOption('digitalproperty-network');
+        Replace.confirmReplace();
+
+        // Expect success
+        Import.waitToDisappear();
+        OperationsHelper.processExpectedSuccess();
+
+    }));
+
+    it('should enable import of npm hosted marbles-network', (() => {
+        // Select & Confirm
+        Import.selectNpmImportOption('marbles-network');
+        Replace.confirmReplace();
+
+        // Expect success
+        Import.waitToDisappear();
+        OperationsHelper.processExpectedSuccess();
+
+    }));
+
+    it('should enable import of npm hosted perishable-network', (() => {
+        // Select & Confirm
+        Import.selectNpmImportOption('perishable-network');
+        Replace.confirmReplace();
+
+        // Expect success
+        Import.waitToDisappear();
+        OperationsHelper.processExpectedSuccess();
+
+    }));
+
+    it('should enable import of npm hosted pii-network', (() => {
+        // Select & Confirm
+        Import.selectNpmImportOption('pii-network');
+        Replace.confirmReplace();
+
+        // Expect success
+        Import.waitToDisappear();
+        OperationsHelper.processExpectedSuccess();
+
+    }));
+
+    it('should enable import of npm hosted trade-network', (() => {
+        // Select & Confirm
+        Import.selectNpmImportOption('trade-network');
+        Replace.confirmReplace();
+
+        // Expect success
+        Import.waitToDisappear();
+        OperationsHelper.processExpectedSuccess();
+
+    }));
+
+    it('should enable import of npm hosted vehicle-lifecycle-network', (() => {
+        // Select & Confirm
+        Import.selectNpmImportOption('vehicle-lifecycle-network');
+        Replace.confirmReplace();
+
+        // Expect success
+        Import.waitToDisappear();
+        OperationsHelper.processExpectedSuccess();
+
+    }));
+
   }));
 
   describe('Add File button', (() => {
@@ -229,7 +327,7 @@ describe('Editor Define', (() => {
 
     afterEach(() =>  {
         // Reset network to basic sample network
-        OperationsHelper.importBusinessNetworkArchiveFromTile(this.tileItems.findIndex((tile) => tile === 'basic-sample-network'));
+        OperationsHelper.importBusinessNetworkArchiveFromTile('basic-sample-network', true);
     });
 
     it('should bring up an AddFile modal that can be closed by cancel button', (() => {
@@ -521,7 +619,7 @@ describe('Editor Define', (() => {
 
     it('should enable the addition of an ACL file via radio button selection', (() => {
         AddFile.clickCancelAdd();
-        OperationsHelper.importBusinessNetworkArchiveFromTile(this.tileItems.findIndex((tile) => tile === 'empty-business-network'));
+        OperationsHelper.importBusinessNetworkArchiveFromTile('empty-business-network', true);
 
         Editor.clickAddFile();
         AddFile.waitToAppear();

--- a/packages/composer-playground/e2e/utils/operations-helper.ts
+++ b/packages/composer-playground/e2e/utils/operations-helper.ts
@@ -12,6 +12,8 @@ export class OperationsHelper {
     browser.wait(ExpectedConditions.presenceOf(elm), 10000);
     browser.wait(ExpectedConditions.visibilityOf(elm), 10000);
     browser.wait(ExpectedConditions.elementToBeClickable(elm), 10000);
+    // Scroll into view
+    browser.executeScript('arguments[0].scrollIntoView();', elm);
     return browser.wait(() => {
         return elm.click()
         .then(() => true)
@@ -30,7 +32,7 @@ export class OperationsHelper {
 
   // Retrieve an array of all matching elements
   static retriveMatchingElementsByCSS(type: string, subset: string, minCount) {
-    browser.wait(this.elementsPresent(element(by.css(type)).all(by.css(subset)), minCount), 5000);
+    browser.wait(this.elementsPresent(element(by.css(type)).all(by.css(subset)), minCount), 10000);
     return element(by.css(type)).all(by.css(subset));
   }
 
@@ -39,7 +41,7 @@ export class OperationsHelper {
     let hasCount = (() => {
       return elementArrayFinder.count()
       .then((count) => {
-        return count > minCount;
+        return count >= minCount;
       });
     });
     return ExpectedConditions.and(ExpectedConditions.presenceOf(elementArrayFinder), hasCount);
@@ -63,15 +65,23 @@ export class OperationsHelper {
 
   static importBusinessNetworkArchiveFromFile(fileName: string) {
     Editor.clickImportBND();
+    Import.waitToLoadBaseOptions();
+    Import.waitToLoadNpmOptions();
     Import.selectBusinessNetworkDefinitionFromFile(fileName);
     Replace.confirmReplace();
     Import.waitToDisappear();
     this.processExpectedSuccess();
   }
 
-  static importBusinessNetworkArchiveFromTile(option) {
+  static importBusinessNetworkArchiveFromTile(option: string, isBaseOption: boolean) {
     Editor.clickImportBND();
-    Import.selectBusinessDefinitionTileOption(option);
+    Import.waitToLoadBaseOptions();
+    Import.waitToLoadNpmOptions();
+    if (isBaseOption) {
+        Import.selectBaseImportOption(option);
+    } else {
+        Import.selectNpmImportOption(option);
+    }
     Replace.confirmReplace();
     Import.waitToDisappear();
     this.processExpectedSuccess();

--- a/packages/composer-playground/src/app/import/import.component.html
+++ b/packages/composer-playground/src/app/import/import.component.html
@@ -35,7 +35,8 @@
             </div>
             <div *ngIf="!npmInProgress" class="sample-network-list-container">
                 <div class="sample-network-list"
-                     [ngClass]="{'selected-network' : sampleNetworks[0].name === chosenNetwork.name}">
+                     [ngClass]="{'selected-network' : sampleNetworks[0].name === chosenNetwork.name}"
+                     id="base-samples">
                     <div class="sample-network-list-item"
                          [ngClass]="{'selected-network' : sampleNetworks[1].name === chosenNetwork.name}"
                          (click)="selectNetwork(sampleNetworks[1])">
@@ -70,7 +71,7 @@
 
                 <h3>Samples on npm</h3>
 
-                <div class="sample-network-list">
+                <div class="sample-network-list" id="npm-samples">
                     <div class="sample-network-list-item"
                          [ngClass]="{'selected-network' : sampleNetwork.name === chosenNetwork.name}"
                          *ngFor=" let sampleNetwork of sampleNetworks | slice:2; let networkIndex=index"


### PR DESCRIPTION
The switch to using npm to host BNAs would appear to be causing unreliability in the protractor test suite, as described/outlined in #1944, this PR:
 - explicit 'scroll-to' prior to click operation
 - provides an explicit check on base sample types
 - provides an explicit check on npm hosted sample types
 - provides an import select via named sample
 - increases tests to include import of all known sample networks

Note: to reduce binding to possible changes in npm samples, the only action checked in the import is that it succeeds - we are not checking installed files at this time
