### PR TITLE
Disable E2E tests

### DIFF
--- a/packages/composer-playground/protractor.conf.js
+++ b/packages/composer-playground/protractor.conf.js
@@ -8,7 +8,7 @@ exports.config = {
   directConnect: true,
   baseUrl: 'http://127.0.0.1:3001',
   specs: ['./e2e/specs/welcome.spec.ts',
-          './e2e/specs/editor-define.spec.ts'],
+          /* './e2e/specs/editor-define.spec.ts' */],
   capabilities: {
     'browserName': 'chrome',
     'chromeOptions': {


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?

## Issue/User story
<!--- What issue / user story is this for -->
Protractor proving to be unstable when using npm #1944

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
E2E tests are much unreliable, such sad but they must be disabled as it's killing our PR throughput.

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->