### PR TITLE
use card to retrieve business network name on login

### DIFF
--- a/packages/composer-playground/src/app/app.component.ts
+++ b/packages/composer-playground/src/app/app.component.ts
@@ -116,7 +116,7 @@ export class AppComponent implements OnInit, OnDestroy {
                     let card: IdCard = this.identityCardService.getCurrentIdentityCard();
                     let connectionProfile = card.getConnectionProfile();
                     let profileName = 'web' === connectionProfile.type ? 'Web' : connectionProfile.name;
-                    let busNetName = this.clientService.getBusinessNetworkName();
+                    let busNetName = card.getBusinessNetworkName() === null ? 'un-named' : card.getBusinessNetworkName();
                     this.composerBanner = [profileName, busNetName];
                 });
         }


### PR DESCRIPTION
Solution to #1943 

## Design of the fix
Instead of using clientService to retrieve business network name, use the card held bn-name, conditioned for possible future eventuality where the bn-name *might* be null

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
