### PR TITLE
Use file system connection profile store in web only mode

### DIFF
--- a/packages/composer-playground/src/app/app.component.spec.ts
+++ b/packages/composer-playground/src/app/app.component.spec.ts
@@ -21,6 +21,7 @@ import { ActivatedRoute, Router, NavigationEnd, NavigationStart } from '@angular
 import { BusinessNetworkConnection } from 'composer-client';
 import { AdminService } from './services/admin.service';
 import { AboutService } from './services/about.service';
+import { ConfigService } from './services/config.service';
 
 import { IdCard } from 'composer-common';
 
@@ -154,6 +155,7 @@ describe('AppComponent', () => {
     let mockIdentityCardService;
     let mockLocalStorageService;
     let mockAboutService;
+    let mockConfigService;
     let mockAdminConnection;
     let mockWindow;
 
@@ -177,6 +179,7 @@ describe('AppComponent', () => {
         mockIdentityCardService.getCurrentIdentityCard.returns(mockIdCard);
         mockLocalStorageService = sinon.createStubInstance(LocalStorageService);
         mockAboutService = sinon.createStubInstance(AboutService);
+        mockConfigService = sinon.createStubInstance(ConfigService);
         mockAdminConnection = sinon.createStubInstance(AdminConnection);
 
         mockAlertService = new MockAlertService();
@@ -203,7 +206,8 @@ describe('AppComponent', () => {
                 {provide: IdentityService, useValue: mockIdentityService},
                 {provide: IdentityCardService, useValue: mockIdentityCardService},
                 {provide: LocalStorageService, useValue: mockLocalStorageService},
-                {provide: AboutService, useValue: mockAboutService}
+                {provide: AboutService, useValue: mockAboutService},
+                {provide: ConfigService, useValue: mockConfigService}
             ]
         })
 
@@ -508,7 +512,7 @@ describe('AppComponent', () => {
 
         it('should initialise playground and set use locally to true', fakeAsync(() => {
             mockInitializationService.initialize.returns(Promise.resolve());
-            mockInitializationService.isWebOnly.returns(Promise.resolve(false));
+            mockConfigService.isWebOnly.returns(false);
             activatedRoute.testParams = {};
 
             updateComponent();
@@ -525,7 +529,7 @@ describe('AppComponent', () => {
 
         it('should initialise playground and set use locally to false', fakeAsync(() => {
             mockInitializationService.initialize.returns(Promise.resolve());
-            mockInitializationService.isWebOnly.returns(Promise.resolve(true));
+            mockConfigService.isWebOnly.returns(true);
 
             activatedRoute.testParams = {};
 

--- a/packages/composer-playground/src/app/app.component.ts
+++ b/packages/composer-playground/src/app/app.component.ts
@@ -14,6 +14,7 @@ import { WelcomeComponent } from './welcome';
 import { VersionCheckComponent } from './version-check/version-check.component';
 import { LocalStorageService } from 'angular-2-local-storage';
 import { AboutService } from './services/about.service';
+import { ConfigService } from './services/config.service';
 import { ViewTransactionComponent } from './test/view-transaction';
 
 import { IdCard } from 'composer-common';
@@ -57,7 +58,8 @@ export class AppComponent implements OnInit, OnDestroy {
                 private alertService: AlertService,
                 private modalService: NgbModal,
                 private localStorageService: LocalStorageService,
-                private aboutService: AboutService) {
+                private aboutService: AboutService,
+                private configService: ConfigService) {
     }
 
     ngOnInit() {
@@ -128,14 +130,7 @@ export class AppComponent implements OnInit, OnDestroy {
         // Initialise playground
         return this.initializationService.initialize()
             .then(() => {
-                return this.initializationService.isWebOnly();
-            })
-            .then((webOnly) => {
-                if (webOnly) {
-                    this.usingLocally = false;
-                } else {
-                    this.usingLocally = true;
-                }
+                this.usingLocally = !this.configService.isWebOnly();
             });
     }
 

--- a/packages/composer-playground/src/app/login/login.component.spec.ts
+++ b/packages/composer-playground/src/app/login/login.component.spec.ts
@@ -20,6 +20,7 @@ import { ConnectionProfileService } from '../services/connectionprofile.service'
 import { AdminService } from '../services/admin.service';
 import { InitializationService } from '../services/initialization.service';
 import { AlertService } from '../basic-modals/alert.service';
+import { ConfigService } from '../services/config.service';
 
 import { DrawerService } from '../common/drawer';
 import { IdCard } from 'composer-common';
@@ -133,6 +134,7 @@ describe(`LoginComponent`, () => {
     let mockInitializationService;
     let routerStub;
     let mockAlertService;
+    let mockConfigService;
     let mockModal;
     let mockDrawer;
 
@@ -145,6 +147,7 @@ describe(`LoginComponent`, () => {
         mockAdminService = sinon.createStubInstance(AdminService);
         mockInitializationService = sinon.createStubInstance(InitializationService);
         mockAlertService = sinon.createStubInstance(AlertService);
+        mockConfigService = sinon.createStubInstance(ConfigService);
         mockDrawer = sinon.createStubInstance(DrawerService);
         mockModal = sinon.createStubInstance(NgbModal);
 
@@ -173,7 +176,8 @@ describe(`LoginComponent`, () => {
                 {provide: InitializationService, useValue: mockInitializationService},
                 {provide: AlertService, useValue: mockAlertService},
                 {provide: DrawerService, useValue: mockDrawer},
-                {provide: NgbModal, useValue: mockModal}
+                {provide: NgbModal, useValue: mockModal},
+                {provide: ConfigService, useValue: mockConfigService}
             ]
         });
 
@@ -199,13 +203,13 @@ describe(`LoginComponent`, () => {
 
         it('should check if playground is hosted or being used locally', fakeAsync(() => {
             mockInitializationService.initialize.returns(Promise.resolve());
-            mockInitializationService.isWebOnly.returns(true);
+            mockConfigService.isWebOnly.returns(true);
             let loadIdentityCardsStub = sinon.stub(component, 'loadIdentityCards');
             component.ngOnInit();
 
             tick();
 
-            mockInitializationService.isWebOnly.should.have.been.called;
+            mockConfigService.isWebOnly.should.have.been.called;
             component['usingLocally'].should.be.false;
         }));
     });

--- a/packages/composer-playground/src/app/login/login.component.ts
+++ b/packages/composer-playground/src/app/login/login.component.ts
@@ -6,6 +6,7 @@ import { InitializationService } from '../services/initialization.service';
 import { AlertService } from '../basic-modals/alert.service';
 import { DeleteComponent } from '../basic-modals/delete-confirm/delete-confirm.component';
 import { IdentityCardService } from '../services/identity-card.service';
+import { ConfigService } from '../services/config.service';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { DrawerService } from '../common/drawer';
 import { ImportIdentityComponent } from './import-identity';
@@ -41,14 +42,15 @@ export class LoginComponent implements OnInit {
                 private identityCardService: IdentityCardService,
                 private modalService: NgbModal,
                 private drawerService: DrawerService,
-                private alertService: AlertService) {
+                private alertService: AlertService,
+                private configService: ConfigService) {
 
     }
 
     ngOnInit(): Promise<void> {
         return this.initializationService.initialize()
             .then(() => {
-                this.usingLocally = !this.initializationService.isWebOnly();
+                this.usingLocally = !this.configService.isWebOnly();
 
                 return this.loadIdentityCards();
             });

--- a/packages/composer-playground/src/app/services/config.service.spec.ts
+++ b/packages/composer-playground/src/app/services/config.service.spec.ts
@@ -1,0 +1,128 @@
+/* tslint:disable:no-unused-variable */
+/* tslint:disable:no-unused-expression */
+/* tslint:disable:no-var-requires */
+/* tslint:disable:max-classes-per-file */
+import { TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
+import {
+    HttpModule,
+    Response,
+    ResponseOptions,
+    XHRBackend
+} from '@angular/http';
+import { MockBackend } from '@angular/http/testing';
+
+import { ConfigService } from './config.service';
+import { IdCard } from 'composer-common';
+
+import * as sinon from 'sinon';
+import * as chai from 'chai';
+
+let should = chai.should();
+
+describe('ConfigService', () => {
+
+    let mockConfig = {
+        cards: [
+            {
+                metadata: {
+                    name: 'PeerAdmin',
+                    enrollmentId: 'PeerAdmin',
+                    enrollmentSecret: 'NOTUSED',
+                    roles: [
+                        'PeerAdmin',
+                        'ChannelAdmin'
+                    ]
+                },
+                connectionProfile: {
+                    name: 'hlfabric',
+                    description: 'Hyperledger Fabric v1.0',
+                    type: 'hlfv1',
+                    keyValStore: '/home/composer/.composer-credentials',
+                    timeout: 300,
+                    orderers: [
+                        {
+                            url: 'grpc://orderer.example.com:7050'
+                        }
+                    ],
+                    channel: 'composerchannel',
+                    mspID: 'Org1MSP',
+                    ca: {
+                        url: 'http://ca.org1.example.com:7054',
+                        name: 'ca.org1.example.com'
+                    },
+                    peers: [
+                        {
+                            requestURL: 'grpc://peer0.org1.example.com:7051',
+                            eventURL: 'grpc://peer0.org1.example.com:7053'
+                        }
+                    ]
+                },
+                credentials: null
+            }
+        ]
+    };
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [HttpModule],
+            providers: [
+                ConfigService,
+                {provide: XHRBackend, useClass: MockBackend}
+            ]
+        });
+    });
+
+    describe('loadConfig', () => {
+        it('should load config', fakeAsync(inject([ConfigService, XHRBackend], (service: ConfigService, mockBackend) => {
+            // setup a mocked response
+            mockBackend.connections.subscribe((connection) => {
+                connection.mockRespond(new Response(new ResponseOptions({
+                    body: JSON.stringify(mockConfig)
+                })));
+            });
+
+            service.loadConfig().then((config) => {
+                config.should.deep.equal(mockConfig);
+            });
+            tick();
+        })));
+    });
+
+    describe('getConfig', () => {
+        it('should throw if not initialized', fakeAsync(inject([ConfigService], (service: ConfigService) => {
+            (() => {
+                service.getConfig();
+            }).should.throw(/config has not been loaded/);
+        })));
+
+        it('should return the config if initialized', fakeAsync(inject([ConfigService], (service: ConfigService) => {
+            service['configLoaded'] = true;
+            service['config'] = mockConfig;
+            service.getConfig().should.deep.equal(mockConfig);
+        })));
+    });
+
+    describe('isWebOnly', () => {
+        it('should throw if not initialized', fakeAsync(inject([ConfigService], (service: ConfigService) => {
+            (() => {
+                service.getConfig();
+            }).should.throw(/config has not been loaded/);
+        })));
+
+        it('should return false if web only', fakeAsync(inject([ConfigService], (service: ConfigService) => {
+            service['configLoaded'] = true;
+            let result = service.isWebOnly();
+            tick();
+            result.should.equal(false);
+        })));
+
+        it('should return true if not web only', fakeAsync(inject([ConfigService], (service: ConfigService) => {
+            service['configLoaded'] = true;
+            service['config'] = {webonly: true};
+            let result = service.isWebOnly();
+            tick();
+            result.should.equal(true);
+        })));
+    });
+})
+;

--- a/packages/composer-playground/src/app/services/config.service.ts
+++ b/packages/composer-playground/src/app/services/config.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { Http, Response } from '@angular/http';
+
+@Injectable()
+export class ConfigService {
+
+    private configLoaded: boolean = false;
+    private config: any = null;
+
+    constructor(private http: Http) {
+    }
+
+    loadConfig(): Promise<any> {
+        // Load the config data.
+        return this.http.get('/config.json')
+            .map((res: Response) => res.json())
+            .toPromise()
+            .then((config) => {
+                this.configLoaded = true;
+                this.config = config;
+                return config;
+            });
+    }
+
+    getConfig(): any {
+        if (!this.configLoaded) {
+            throw new Error('config has not been loaded');
+        }
+        return this.config;
+    }
+
+    isWebOnly(): boolean {
+        if (!this.configLoaded) {
+            throw new Error('config has not been loaded');
+        } else if (!this.config) {
+            return false;
+        }
+        return this.config.webonly;
+    }
+
+}

--- a/packages/composer-playground/src/app/services/connectionprofilestore.service.spec.ts
+++ b/packages/composer-playground/src/app/services/connectionprofilestore.service.spec.ts
@@ -4,20 +4,38 @@
 /* tslint:disable:max-classes-per-file */
 
 import { TestBed, inject, fakeAsync, tick } from '@angular/core/testing';
+import { ConfigService } from './config.service';
 import { ConnectionProfileStoreService } from './connectionprofilestore.service';
+import { FSConnectionProfileStore } from 'composer-common';
 const ProxyConnectionProfileStore = require('composer-connector-proxy').ProxyConnectionProfileStore;
 import * as sinon from 'sinon';
 import { expect } from 'chai';
 
 describe('ConnectionProfileStoreService', () => {
 
+    let mockConfigService;
+
     beforeEach(() => {
+        mockConfigService = sinon.createStubInstance(ConfigService);
         TestBed.configureTestingModule({
-            providers: [ConnectionProfileStoreService]
+            providers: [
+                ConnectionProfileStoreService,
+                {provide: ConfigService, useValue: mockConfigService}
+            ]
         });
     });
 
     describe('getConnectionProfileStore', () => {
+        it('should create a new file system connection profile store',
+            inject([ConnectionProfileStoreService],
+                (connectionProfileStoreService) => {
+                    connectionProfileStoreService.should.be.ok;
+                    mockConfigService.isWebOnly.returns(true);
+                    const connectionProfileStore = connectionProfileStoreService.getConnectionProfileStore();
+                    connectionProfileStore.should.be.an.instanceOf(FSConnectionProfileStore);
+                }
+            ));
+
         it('should create a new proxy connection profile store',
             inject([ConnectionProfileStoreService],
                 (connectionProfileStoreService) => {
@@ -27,7 +45,7 @@ describe('ConnectionProfileStoreService', () => {
                 }
             ));
 
-        it('should not create more than one proxy connection profile store',
+        it('should not create more than one connection profile store',
             inject([ConnectionProfileStoreService],
                 (connectionProfileStoreService) => {
                     connectionProfileStoreService.should.be.ok;

--- a/packages/composer-playground/src/app/services/connectionprofilestore.service.ts
+++ b/packages/composer-playground/src/app/services/connectionprofilestore.service.ts
@@ -1,15 +1,18 @@
 import { Injectable } from '@angular/core';
 
-import { ConnectionProfileStore } from 'composer-common';
+import { ConfigService } from './config.service';
+
+import { ConnectionProfileStore, FSConnectionProfileStore } from 'composer-common';
 /* tslint:disable:no-var-requires */
 const ProxyConnectionProfileStore = require('composer-connector-proxy').ProxyConnectionProfileStore;
+const fs = require('fs');
 
 @Injectable()
 export class ConnectionProfileStoreService {
 
     private connectionProfileStore: ConnectionProfileStore = null;
 
-    constructor() {
+    constructor(private configService: ConfigService) {
         // The proxy connection manager defaults to http://localhost:15699,
         // but that is not suitable for anything other than development.
         if (ENV && ENV !== 'development') {
@@ -19,7 +22,11 @@ export class ConnectionProfileStoreService {
 
     public getConnectionProfileStore(): ConnectionProfileStore {
         if (!this.connectionProfileStore) {
-            this.connectionProfileStore = new ProxyConnectionProfileStore();
+            if (this.configService.isWebOnly()) {
+                this.connectionProfileStore = new FSConnectionProfileStore(fs);
+            } else {
+                this.connectionProfileStore = new ProxyConnectionProfileStore();
+            }
         }
         return this.connectionProfileStore;
     }

--- a/packages/composer-playground/src/app/services/initialization.service.ts
+++ b/packages/composer-playground/src/app/services/initialization.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
-import { Http, Response } from '@angular/http';
 
 import { ClientService } from './client.service';
 import { AlertService } from '../basic-modals/alert.service';
 import { IdentityService } from './identity.service';
 import { IdentityCardService } from './identity-card.service';
+import { ConfigService } from './config.service';
 import { IdCard } from 'composer-common';
 
 @Injectable()
@@ -19,7 +19,7 @@ export class InitializationService {
                 private alertService: AlertService,
                 private identityService: IdentityService,
                 private identityCardService: IdentityCardService,
-                private http: Http) {
+                private configService: ConfigService) {
     }
 
     initialize(): Promise<any> {
@@ -31,7 +31,7 @@ export class InitializationService {
 
         this.initializingPromise = Promise.resolve()
             .then(() => {
-                return this.loadConfig();
+                return this.configService.loadConfig();
             })
             .then((config) => {
                 let force = !this.identityService.getLoggedIn();
@@ -40,7 +40,7 @@ export class InitializationService {
                     force: force
                 });
                 this.config = config;
-                return this.identityCardService.loadIdentityCards(this.isWebOnly());
+                return this.identityCardService.loadIdentityCards(this.configService.isWebOnly());
             })
             .then(() => {
                 let idCards: IdCard[] = [];
@@ -77,24 +77,10 @@ export class InitializationService {
         return this.initializingPromise;
     }
 
-    loadConfig(): Promise<any> {
-        // Load the config data.
-        return this.http.get('/config.json')
-            .map((res: Response) => res.json())
-            .toPromise();
-    }
-
     deployInitialSample(defaultCardRef) {
         return this.identityCardService.setCurrentIdentityCard(defaultCardRef)
             .then(() => {
                 return this.clientService.deployInitialSample();
             });
-    }
-
-    isWebOnly(): boolean {
-        if (!this.config) {
-            return false;
-        }
-        return this.config.webonly;
     }
 }

--- a/packages/composer-playground/src/app/services/services.module.ts
+++ b/packages/composer-playground/src/app/services/services.module.ts
@@ -12,6 +12,7 @@ import { IdentityCardStorageService } from './identity-card-storage.service';
 import { InitializationService } from './initialization.service';
 import { SampleBusinessNetworkService } from './samplebusinessnetwork.service';
 import { AlertService } from '../basic-modals/alert.service';
+import { ConfigService } from './config.service';
 
 let identityCardStorageServiceConfig = {
     prefix: 'idcard',
@@ -33,6 +34,7 @@ let identityCardStorageServiceConfig = {
         IdentityCardStorageService,
         InitializationService,
         SampleBusinessNetworkService,
+        ConfigService,
         { provide: 'IDENTITY_CARD_STORAGE_SERVICE_CONFIG', useValue: identityCardStorageServiceConfig }
     ],
     exports: []


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?

## Issue/User story
<!--- What issue / user story is this for -->
Using the v0.12.0 playground on safari throws breaking error #1982

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
Web connection profiles contain a `networks` object that stores a mapping of business network names to UUIDs. Those UUIDs are the names of PouchDB databases that live in the web browser and store the actual business network data (the world state) for that business network.

Because the web connection profiles contain browser specific data, they are not suitable for sharing across different browsers or even different machines - so we really shouldn't be writing them to the disk via the connector server!

This fix stops the proxy connection profile store from being used at all in the cloud hosted Playground. We don't know why, but socket.io does not work at all when being served from the cloud hosted Playground on Bluemix - might be socket.io, might be something we're doing, might be Bluemix.

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->