### PR TITLE
Ensure exported identity cards include certificates and private

### DIFF
--- a/packages/composer-playground/src/app/import/deploy.component.spec.ts
+++ b/packages/composer-playground/src/app/import/deploy.component.spec.ts
@@ -14,7 +14,6 @@ import { ClientService } from '../services/client.service';
 import { SampleBusinessNetworkService } from '../services/samplebusinessnetwork.service';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { AlertService } from '../basic-modals/alert.service';
-import { IdentityCardService } from '../services/identity-card.service';
 import { DeployComponent } from './deploy.component';
 
 import * as sinon from 'sinon';
@@ -82,7 +81,6 @@ describe('DeployComponent', () => {
     let mockAlertService;
     let mockClientService;
     let mockNgbModal;
-    let mockIdentityCardService;
 
     beforeEach(() => {
         mockBusinessNetworkService = sinon.createStubInstance(SampleBusinessNetworkService);
@@ -90,7 +88,6 @@ describe('DeployComponent', () => {
         mockAlertService = sinon.createStubInstance(AlertService);
         mockClientService = sinon.createStubInstance(ClientService);
         mockNgbModal = sinon.createStubInstance(NgbModal);
-        mockIdentityCardService = sinon.createStubInstance(IdentityCardService);
 
         mockAlertService.errorStatus$ = {
             next: sinon.stub()
@@ -108,8 +105,7 @@ describe('DeployComponent', () => {
                 {provide: AdminService, useValue: mockAdminService},
                 {provide: ClientService, useValue: mockClientService},
                 {provide: AlertService, useValue: mockAlertService},
-                {provide: NgbModal, useValue: mockNgbModal},
-                {provide: IdentityCardService, useValue: mockIdentityCardService}],
+                {provide: NgbModal, useValue: mockNgbModal}],
         });
 
         sandbox = sinon.sandbox.create();
@@ -131,7 +127,6 @@ describe('DeployComponent', () => {
         let onShowMock;
 
         beforeEach(() => {
-            mockIdentityCardService.getCurrentConnectionProfile.returns({name: 'myNetwork'});
             mockAdminService.connectWithoutNetwork.returns(Promise.resolve());
             onShowMock = sinon.stub(component, 'onShow');
         });

--- a/packages/composer-playground/src/app/import/update.component.spec.ts
+++ b/packages/composer-playground/src/app/import/update.component.spec.ts
@@ -14,7 +14,6 @@ import { ClientService } from '../services/client.service';
 import { SampleBusinessNetworkService } from '../services/samplebusinessnetwork.service';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { AlertService } from '../basic-modals/alert.service';
-import { IdentityCardService } from '../services/identity-card.service';
 import { UpdateComponent } from './update.component';
 
 import * as sinon from 'sinon';
@@ -82,7 +81,6 @@ describe('UpdateComponent', () => {
     let mockAlertService;
     let mockClientService;
     let mockNgbModal;
-    let mockIdentityCardService;
 
     beforeEach(() => {
         mockBusinessNetworkService = sinon.createStubInstance(SampleBusinessNetworkService);
@@ -90,7 +88,6 @@ describe('UpdateComponent', () => {
         mockAlertService = sinon.createStubInstance(AlertService);
         mockClientService = sinon.createStubInstance(ClientService);
         mockNgbModal = sinon.createStubInstance(NgbModal);
-        mockIdentityCardService = sinon.createStubInstance(IdentityCardService);
 
         mockAlertService.errorStatus$ = {
             next: sinon.stub()
@@ -108,8 +105,7 @@ describe('UpdateComponent', () => {
                 {provide: AdminService, useValue: mockAdminService},
                 {provide: ClientService, useValue: mockClientService},
                 {provide: AlertService, useValue: mockAlertService},
-                {provide: NgbModal, useValue: mockNgbModal},
-                {provide: IdentityCardService, useValue: mockIdentityCardService}
+                {provide: NgbModal, useValue: mockNgbModal}
             ],
         });
 
@@ -132,7 +128,6 @@ describe('UpdateComponent', () => {
         let onShowMock;
 
         beforeEach(() => {
-            mockIdentityCardService.getCurrentConnectionProfile.returns({name: 'myNetwork'});
             mockAdminService.connectWithoutNetwork.returns(Promise.resolve());
             onShowMock = sinon.stub(component, 'onShow');
         });

--- a/packages/composer-playground/src/app/login/login.component.spec.ts
+++ b/packages/composer-playground/src/app/login/login.component.spec.ts
@@ -552,15 +552,12 @@ describe(`LoginComponent`, () => {
     describe('exportIdentity', () => {
         let sandbox = sinon.sandbox.create();
         let mockIdCard;
-        let mockIdCards: Map<string, IdCard>;
         let saveAsStub;
 
         beforeEach(() => {
             saveAsStub = sandbox.stub(fileSaver, 'saveAs');
             mockIdCard = sinon.createStubInstance(IdCard);
             mockIdCard.getName.returns('myCard');
-            mockIdCards = new Map<string, IdCard>();
-            mockIdCards.set('myCardRef', mockIdCard);
         });
 
         afterEach(() => {
@@ -568,8 +565,8 @@ describe(`LoginComponent`, () => {
         });
 
         it('should export an identity card', fakeAsync(() => {
+            mockIdentityCardService.getIdentityCardForExport.returns(Promise.resolve(mockIdCard));
             mockIdCard.toArchive.returns(Promise.resolve('card data'));
-            component['idCards'] = mockIdCards;
 
             component.exportIdentity('myCardRef');
             tick();
@@ -579,8 +576,8 @@ describe(`LoginComponent`, () => {
         }));
 
         it('should handle errors', fakeAsync(() => {
+            mockIdentityCardService.getIdentityCardForExport.returns(Promise.resolve(mockIdCard));
             mockIdCard.toArchive.returns(Promise.reject('some error'));
-            component['idCards'] = mockIdCards;
 
             component.exportIdentity('myCardRef');
             tick();

--- a/packages/composer-playground/src/app/login/login.component.ts
+++ b/packages/composer-playground/src/app/login/login.component.ts
@@ -197,15 +197,21 @@ export class LoginComponent implements OnInit {
     }
 
     exportIdentity(cardRef): Promise<any> {
-        let card = this.idCards.get(cardRef);
+        let fileName;
 
-        return card.toArchive().then((exportedData) => {
-            let file = new Blob([exportedData],
-                {type: 'application/octet-stream'});
-            saveAs(file, card.getName() + '.card');
-        }).catch((reason) => {
-            this.alertService.errorStatus$.next(reason);
-        });
+        return this.identityCardService.getIdentityCardForExport(cardRef)
+            .then((card) => {
+                fileName = card.getName() + '.card';
+                return card.toArchive();
+            })
+            .then((archiveData) => {
+                let file = new Blob([archiveData],
+                    {type: 'application/octet-stream'});
+                saveAs(file, fileName);
+            })
+            .catch((reason) => {
+                this.alertService.errorStatus$.next(reason);
+            });
     }
 
     removeIdentity(cardRef): void {

--- a/packages/composer-playground/src/app/services/admin.service.spec.ts
+++ b/packages/composer-playground/src/app/services/admin.service.spec.ts
@@ -13,7 +13,7 @@ let should = chai.should();
 
 import { AlertService } from '../basic-modals/alert.service';
 import { BusinessNetworkDefinition, ConnectionProfileStore } from 'composer-common';
-import { IdentityCardService } from './identity-card.service';
+import { IdentityService } from './identity.service';
 import { AdminConnection } from 'composer-admin';
 import { ConnectionProfileStoreService } from './connectionprofilestore.service';
 
@@ -23,7 +23,7 @@ describe('AdminService', () => {
 
     let alertMock;
     let businessNetworkDefMock;
-    let identityCardMock;
+    let identityMock;
 
     let adminConnectionMock;
 
@@ -35,10 +35,10 @@ describe('AdminService', () => {
 
         alertMock = sinon.createStubInstance(AlertService);
         businessNetworkDefMock = sinon.createStubInstance(BusinessNetworkDefinition);
-        identityCardMock = sinon.createStubInstance(IdentityCardService);
-        identityCardMock.getCurrentConnectionProfile.returns({name: 'myProfile'});
-        identityCardMock.getQualifiedProfileName.returns('xxx-myProfile');
-        identityCardMock.getCurrentEnrollmentCredentials.returns({id: 'myId', secret: 'mySecret'});
+        identityMock = sinon.createStubInstance(IdentityService);
+        identityMock.getCurrentConnectionProfile.returns({name: 'myProfile'});
+        identityMock.getCurrentQualifiedProfileName.returns('qpn-myProfile');
+        identityMock.getCurrentEnrollmentCredentials.returns({id: 'myId', secret: 'mySecret'});
         adminConnectionMock = sinon.createStubInstance(AdminConnection);
 
         alertMock.busyStatus$ = {
@@ -56,7 +56,7 @@ describe('AdminService', () => {
         TestBed.configureTestingModule({
             providers: [AdminService,
                 {provide: AlertService, useValue: alertMock},
-                {provide: IdentityCardService, useValue: identityCardMock},
+                {provide: IdentityService, useValue: identityMock},
                 {provide: ConnectionProfileStoreService, useValue: connectionProfileStoreServiceMock}]
         });
     });
@@ -88,29 +88,32 @@ describe('AdminService', () => {
 
             service.connect('myNetwork');
 
-            identityCardMock.getCurrentConnectionProfile.should.not.have.been.called;
+            tick();
+
+            identityMock.getCurrentConnectionProfile.should.not.have.been.called;
         })));
 
-        it('should return if connecting', inject([AdminService], (service: AdminService) => {
+        it('should return if connecting', fakeAsync(inject([AdminService], (service: AdminService) => {
             service['connectingPromise'] = Promise.resolve();
-
-            service.connect('myNetwork');
-
-            identityCardMock.getCurrentConnectionProfile.should.not.have.been.called;
-        }));
-
-        it('should connect', fakeAsync(inject([AdminService], (service: AdminService) => {
-            adminConnectionMock.connect.returns(Promise.resolve());
-            let mockGetAdminConnection = sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
-
-            identityCardMock.activateCurrentIdentityCard.returns(Promise.resolve());
 
             service.connect('myNetwork');
 
             tick();
 
-            identityCardMock.getCurrentConnectionProfile.should.have.been.called;
-            identityCardMock.getCurrentEnrollmentCredentials.should.have.been.called;
+            identityMock.getCurrentConnectionProfile.should.not.have.been.called;
+        })));
+
+        it('should connect', fakeAsync(inject([AdminService], (service: AdminService) => {
+            adminConnectionMock.connect.returns(Promise.resolve());
+            let mockGetAdminConnection = sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
+
+            service.connect('myNetwork');
+
+            tick();
+
+            identityMock.getCurrentConnectionProfile.should.have.been.called;
+            identityMock.getCurrentQualifiedProfileName.should.have.been.called;
+            identityMock.getCurrentEnrollmentCredentials.should.have.been.called;
 
             alertMock.busyStatus$.next.should.have.been.calledWith({
                 title: 'Connecting to Business Network myNetwork',
@@ -119,9 +122,7 @@ describe('AdminService', () => {
 
             mockGetAdminConnection.should.have.been.called;
 
-            identityCardMock.activateCurrentIdentityCard.should.have.been.called;
-
-            adminConnectionMock.connect.should.have.been.calledWith('xxx-myProfile', 'myId', 'mySecret', 'myNetwork');
+            adminConnectionMock.connect.should.have.been.calledWith('qpn-myProfile', 'myId', 'mySecret', 'myNetwork');
 
             service['isConnected'].should.equal(true);
             should.not.exist(service['isConnectingPromise']);
@@ -132,16 +133,15 @@ describe('AdminService', () => {
             adminConnectionMock.connect.returns(Promise.resolve());
             let mockGetAdminConnection = sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
 
-            identityCardMock.activateCurrentIdentityCard.returns(Promise.resolve());
-
             service['isConnected'] = true;
 
             service.connect('myNetwork', true);
 
             tick();
 
-            identityCardMock.getCurrentConnectionProfile.should.have.been.called;
-            identityCardMock.getCurrentEnrollmentCredentials.should.have.been.called;
+            identityMock.getCurrentConnectionProfile.should.have.been.called;
+            identityMock.getCurrentQualifiedProfileName.should.have.been.called;
+            identityMock.getCurrentEnrollmentCredentials.should.have.been.called;
 
             alertMock.busyStatus$.next.should.have.been.calledWith({
                 title: 'Connecting to Business Network myNetwork',
@@ -150,41 +150,7 @@ describe('AdminService', () => {
 
             mockGetAdminConnection.should.have.been.called;
 
-            identityCardMock.activateCurrentIdentityCard.should.have.been.called;
-
-            adminConnectionMock.connect.should.have.been.calledWith('xxx-myProfile', 'myId', 'mySecret', 'myNetwork');
-
-            service['isConnected'].should.equal(true);
-            should.not.exist(service['isConnectingPromise']);
-            alertMock.busyStatus$.next.should.have.been.calledWith(null);
-        })));
-
-        it('should connect and import the certificates', fakeAsync(inject([AdminService], (service: AdminService) => {
-            adminConnectionMock.connect.returns(Promise.resolve());
-            let mockGetAdminConnection = sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
-
-            identityCardMock.activateCurrentIdentityCard.returns(Promise.resolve('myCardRef'));
-
-            let importStub = sinon.stub(service, 'importCertificates');
-
-            service.connect('myNetwork');
-
-            tick();
-
-            identityCardMock.getCurrentConnectionProfile.should.have.been.called;
-            identityCardMock.getCurrentEnrollmentCredentials.should.have.been.called;
-
-            alertMock.busyStatus$.next.should.have.been.calledWith({
-                title: 'Connecting to Business Network myNetwork',
-                text: 'using connection profile myProfile'
-            });
-
-            mockGetAdminConnection.should.have.been.called;
-
-            identityCardMock.activateCurrentIdentityCard.should.have.been.called;
-            importStub.should.have.been.called;
-
-            adminConnectionMock.connect.should.have.been.calledWith('xxx-myProfile', 'myId', 'mySecret', 'myNetwork');
+            adminConnectionMock.connect.should.have.been.calledWith('qpn-myProfile', 'myId', 'mySecret', 'myNetwork');
 
             service['isConnected'].should.equal(true);
             should.not.exist(service['isConnectingPromise']);
@@ -194,8 +160,6 @@ describe('AdminService', () => {
         it('should handle error', fakeAsync(inject([AdminService], (service: AdminService) => {
             adminConnectionMock.connect.returns(Promise.reject('some error'));
             let mockGetAdminConnection = sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
-
-            identityCardMock.activateCurrentIdentityCard.returns(Promise.resolve());
 
             service.connect('myNetwork')
                 .then(() => {
@@ -207,19 +171,18 @@ describe('AdminService', () => {
 
             tick();
 
-            identityCardMock.getCurrentConnectionProfile.should.have.been.called;
-            identityCardMock.getCurrentEnrollmentCredentials.should.have.been.called;
+            identityMock.getCurrentConnectionProfile.should.have.been.called;
+            identityMock.getCurrentQualifiedProfileName.should.have.been.called;
+            identityMock.getCurrentEnrollmentCredentials.should.have.been.called;
 
             alertMock.busyStatus$.next.should.have.been.calledWith({
                 title: 'Connecting to Business Network myNetwork',
                 text: 'using connection profile myProfile'
             });
 
-            identityCardMock.activateCurrentIdentityCard.should.have.been.called;
-
             mockGetAdminConnection.should.have.been.called;
 
-            adminConnectionMock.connect.should.have.been.calledWith('xxx-myProfile', 'myId', 'mySecret', 'myNetwork');
+            adminConnectionMock.connect.should.have.been.calledWith('qpn-myProfile', 'myId', 'mySecret', 'myNetwork');
 
             service['isConnected'].should.equal(false);
             should.not.exist(service['isConnectingPromise']);
@@ -233,85 +196,41 @@ describe('AdminService', () => {
 
             service.connectWithoutNetwork();
 
-            identityCardMock.getCurrentConnectionProfile.should.not.have.been.called;
+            tick();
+
+            identityMock.getCurrentConnectionProfile.should.not.have.been.called;
         })));
 
-        it('should return if connecting', inject([AdminService], (service: AdminService) => {
+        it('should return if connecting', fakeAsync(inject([AdminService], (service: AdminService) => {
             service['connectingPromise'] = Promise.resolve();
 
             service.connectWithoutNetwork();
 
-            identityCardMock.getCurrentConnectionProfile.should.not.have.been.called;
-        }));
+            tick();
+
+            identityMock.getCurrentConnectionProfile.should.not.have.been.called;
+        })));
 
         it('should connect without an id', fakeAsync(inject([AdminService], (service: AdminService) => {
             let mockGetAdminConnection = sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
-
-            identityCardMock.activateCurrentIdentityCard.returns(Promise.resolve());
-
             adminConnectionMock.connect.returns(Promise.resolve());
-            adminConnectionMock.list.returns(Promise.resolve([]));
-
-            let mockGenerateBusinessNetwork = sinon.stub(service, 'generateDefaultBusinessNetwork').returns({name: 'myNetwork'});
-
-            adminConnectionMock.deploy.returns(Promise.resolve());
 
             service.connectWithoutNetwork();
 
             tick();
 
-            identityCardMock.getCurrentConnectionProfile.should.have.been.called;
-            identityCardMock.getCurrentEnrollmentCredentials.should.have.been.called;
+            identityMock.getCurrentConnectionProfile.should.have.been.called;
+            identityMock.getCurrentQualifiedProfileName.should.have.been.called;
+            identityMock.getCurrentEnrollmentCredentials.should.have.been.called;
 
             alertMock.busyStatus$.next.should.have.been.calledWith({
                 title: 'Connecting without a business network',
                 text: 'using connection profile myProfile'
             });
 
-            identityCardMock.activateCurrentIdentityCard.should.have.been.called;
-
             mockGetAdminConnection.should.have.been.called;
 
-            adminConnectionMock.connect.should.have.been.calledWith('xxx-myProfile', 'myId', 'mySecret');
-
-            service['isConnected'].should.equal(true);
-            should.not.exist(service['isConnectingPromise']);
-            alertMock.busyStatus$.next.should.have.been.calledWith(null);
-        })));
-
-        it('should connect without an id and import certificate', fakeAsync(inject([AdminService], (service: AdminService) => {
-            let mockGetAdminConnection = sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
-
-            let importMock = sinon.stub(service, 'importCertificates');
-
-            identityCardMock.activateCurrentIdentityCard.returns(Promise.resolve('cardRef'));
-
-            adminConnectionMock.connect.returns(Promise.resolve());
-            adminConnectionMock.list.returns(Promise.resolve([]));
-
-            let mockGenerateBusinessNetwork = sinon.stub(service, 'generateDefaultBusinessNetwork').returns({name: 'myNetwork'});
-
-            adminConnectionMock.deploy.returns(Promise.resolve());
-
-            service.connectWithoutNetwork();
-
-            tick();
-
-            identityCardMock.getCurrentConnectionProfile.should.have.been.called;
-            identityCardMock.getCurrentEnrollmentCredentials.should.have.been.called;
-
-            alertMock.busyStatus$.next.should.have.been.calledWith({
-                title: 'Connecting without a business network',
-                text: 'using connection profile myProfile'
-            });
-
-            identityCardMock.activateCurrentIdentityCard.should.have.been.called;
-
-            importMock.should.have.been.called;
-
-            mockGetAdminConnection.should.have.been.called;
-
-            adminConnectionMock.connect.should.have.been.calledWith('xxx-myProfile', 'myId', 'mySecret');
+            adminConnectionMock.connect.should.have.been.calledWith('qpn-myProfile', 'myId', 'mySecret');
 
             service['isConnected'].should.equal(true);
             should.not.exist(service['isConnectingPromise']);
@@ -320,15 +239,7 @@ describe('AdminService', () => {
 
         it('should connect if forced', fakeAsync(inject([AdminService], (service: AdminService) => {
             let mockGetAdminConnection = sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
-
-            identityCardMock.activateCurrentIdentityCard.returns(Promise.resolve());
-
             adminConnectionMock.connect.returns(Promise.resolve());
-            adminConnectionMock.list.returns(Promise.resolve([]));
-
-            let mockGenerateBusinessNetwork = sinon.stub(service, 'generateDefaultBusinessNetwork').returns({name: 'myNetwork'});
-
-            adminConnectionMock.deploy.returns(Promise.resolve());
 
             service['isConnected'] = true;
 
@@ -336,19 +247,18 @@ describe('AdminService', () => {
 
             tick();
 
-            identityCardMock.getCurrentConnectionProfile.should.have.been.called;
-            identityCardMock.getCurrentEnrollmentCredentials.should.have.been.called;
+            identityMock.getCurrentConnectionProfile.should.have.been.called;
+            identityMock.getCurrentQualifiedProfileName.should.have.been.called;
+            identityMock.getCurrentEnrollmentCredentials.should.have.been.called;
 
             alertMock.busyStatus$.next.should.have.been.calledWith({
                 title: 'Connecting without a business network',
                 text: 'using connection profile myProfile'
             });
 
-            identityCardMock.activateCurrentIdentityCard.should.have.been.called;
-
             mockGetAdminConnection.should.have.been.called;
 
-            adminConnectionMock.connect.should.have.been.calledWith('xxx-myProfile', 'myId', 'mySecret');
+            adminConnectionMock.connect.should.have.been.calledWith('qpn-myProfile', 'myId', 'mySecret');
 
             service['isConnected'].should.equal(true);
             should.not.exist(service['isConnectingPromise']);
@@ -357,37 +267,33 @@ describe('AdminService', () => {
 
         it('should handle error', fakeAsync(inject([AdminService], (service: AdminService) => {
             let mockGetAdminConnection = sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
-
-            identityCardMock.activateCurrentIdentityCard.returns(Promise.resolve());
-
             adminConnectionMock.connect.returns(Promise.reject('some error'));
-            adminConnectionMock.list.returns(Promise.resolve([]));
 
-            let mockGenerateBusinessNetwork = sinon.stub(service, 'generateDefaultBusinessNetwork').returns({name: 'myNetwork'});
-
-            adminConnectionMock.deploy.returns(Promise.resolve());
-
-            service.connectWithoutNetwork();
+            service.connectWithoutNetwork()
+                .then(() => {
+                    throw new Error('should not get here');
+                })
+                .catch((error) => {
+                    error.should.equal('some error');
+                });
 
             tick();
 
-            identityCardMock.getCurrentConnectionProfile.should.have.been.called;
-            identityCardMock.getCurrentEnrollmentCredentials.should.have.been.called;
+            identityMock.getCurrentConnectionProfile.should.have.been.called;
+            identityMock.getCurrentQualifiedProfileName.should.have.been.called;
+            identityMock.getCurrentEnrollmentCredentials.should.have.been.called;
 
             alertMock.busyStatus$.next.should.have.been.calledWith({
                 title: 'Connecting without a business network',
                 text: 'using connection profile myProfile'
             });
 
-            identityCardMock.activateCurrentIdentityCard.should.have.been.called;
-
             mockGetAdminConnection.should.have.been.called;
 
-            adminConnectionMock.connect.should.have.been.calledWith('xxx-myProfile', 'myId', 'mySecret');
+            adminConnectionMock.connect.should.have.been.calledWith('qpn-myProfile', 'myId', 'mySecret');
 
             service['isConnected'].should.equal(false);
             should.not.exist(service['isConnectingPromise']);
-            alertMock.errorStatus$.next.should.have.been.calledWith('some error');
             alertMock.busyStatus$.next.should.have.been.calledWith(null);
         })));
     });
@@ -401,7 +307,7 @@ describe('AdminService', () => {
             adminConnectionMock.disconnect.returns(Promise.resolve());
             adminConnectionMock.deploy.returns(Promise.resolve());
 
-            identityCardMock.getCurrentConnectionProfile.returns({name: 'myProfile'});
+            identityMock.getCurrentConnectionProfile.returns({name: 'myProfile'});
 
             let stubGenerateBusinessNetwork = sinon.stub(service, 'generateDefaultBusinessNetwork').returns({name: 'myNetwork'});
 
@@ -425,10 +331,11 @@ describe('AdminService', () => {
                 force: true
             });
 
-            identityCardMock.getCurrentConnectionProfile.should.have.been.called;
-            identityCardMock.getCurrentEnrollmentCredentials.should.have.been.called;
+            identityMock.getCurrentConnectionProfile.should.have.been.called;
+            identityMock.getCurrentQualifiedProfileName.should.have.been.called;
+            identityMock.getCurrentEnrollmentCredentials.should.have.been.called;
 
-            adminConnectionMock.connect.should.have.been.calledWith('xxx-myProfile', 'myId', 'mySecret');
+            adminConnectionMock.connect.should.have.been.calledWith('qpn-myProfile', 'myId', 'mySecret');
 
             stubGenerateBusinessNetwork.should.have.been.calledWith('myNetwork', 'myDescription');
 
@@ -436,7 +343,7 @@ describe('AdminService', () => {
 
             adminConnectionMock.disconnect.should.have.been.called;
 
-            adminConnectionMock.connect.should.have.been.calledWith('xxx-myProfile', 'myId', 'mySecret', 'myNetwork');
+            adminConnectionMock.connect.should.have.been.calledWith('qpn-myProfile', 'myId', 'mySecret', 'myNetwork');
 
             alertMock.busyStatus$.next.thirdCall.should.have.been.calledWith({
                 title: 'Connecting to Business Network myNetwork',
@@ -560,6 +467,30 @@ describe('AdminService', () => {
         })));
     });
 
+    describe('importIdentity', () => {
+        it('should start a business network', fakeAsync(inject([AdminService], (service: AdminService) => {
+            sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
+
+            service.importIdentity('qpn-myProfile', 'myId', 'myCertificate', 'myPrivateKey');
+
+            tick();
+
+            adminConnectionMock.importIdentity.should.have.been.calledWith('qpn-myProfile', 'myId', 'myCertificate', 'myPrivateKey');
+        })));
+    });
+
+    describe('exportIdentity', () => {
+        it('should start a business network', fakeAsync(inject([AdminService], (service: AdminService) => {
+            sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
+
+            service.exportIdentity('qpn-myProfile', 'myId');
+
+            tick();
+
+            adminConnectionMock.exportIdentity.should.have.been.calledWith('qpn-myProfile', 'myId');
+        })));
+    });
+
     describe('update', () => {
         it('should update a business network', fakeAsync(inject([AdminService], (service: AdminService) => {
             service['adminConnection'] = adminConnectionMock;
@@ -576,8 +507,6 @@ describe('AdminService', () => {
         it('should list the business networks', fakeAsync(inject([AdminService], (service: AdminService) => {
             let mockGetAdminConnection = sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
 
-            identityCardMock.activateCurrentIdentityCard.returns(Promise.resolve());
-
             adminConnectionMock.connect.returns(Promise.resolve());
             adminConnectionMock.list.returns(Promise.resolve(['myNetwork']));
 
@@ -589,41 +518,11 @@ describe('AdminService', () => {
 
             tick();
 
-            identityCardMock.getCurrentConnectionProfile.should.have.been.called;
-            identityCardMock.getCurrentEnrollmentCredentials.should.have.been.called;
+            identityMock.getCurrentConnectionProfile.should.have.been.called;
+            identityMock.getCurrentQualifiedProfileName.should.have.been.called;
+            identityMock.getCurrentEnrollmentCredentials.should.have.been.called;
 
-            identityCardMock.activateCurrentIdentityCard.should.have.been.called;
-
-            adminConnectionMock.connect.should.have.been.calledWith('xxx-myProfile', 'myId', 'mySecret');
-            adminConnectionMock.list.should.have.been.called;
-
-            disconnectStub.should.have.been.called;
-        })));
-
-        it('should list the business networks and import certificates', fakeAsync(inject([AdminService], (service: AdminService) => {
-            let mockGetAdminConnection = sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
-
-            identityCardMock.activateCurrentIdentityCard.returns(Promise.resolve('cardRef'));
-            let importStub = sinon.stub(service, 'importCertificates').returns(Promise.resolve());
-
-            adminConnectionMock.connect.returns(Promise.resolve());
-            adminConnectionMock.list.returns(Promise.resolve(['myNetwork']));
-
-            let disconnectStub = sinon.stub(service, 'disconnect');
-
-            service.list().then((networks) => {
-                networks.should.deep.equal(['myNetwork']);
-            });
-
-            tick();
-
-            identityCardMock.getCurrentConnectionProfile.should.have.been.called;
-            identityCardMock.getCurrentEnrollmentCredentials.should.have.been.called;
-
-            identityCardMock.activateCurrentIdentityCard.should.have.been.called;
-            importStub.should.have.been.called;
-
-            adminConnectionMock.connect.should.have.been.calledWith('xxx-myProfile', 'myId', 'mySecret');
+            adminConnectionMock.connect.should.have.been.calledWith('qpn-myProfile', 'myId', 'mySecret');
             adminConnectionMock.list.should.have.been.called;
 
             disconnectStub.should.have.been.called;
@@ -643,127 +542,6 @@ describe('AdminService', () => {
 
             service['isConnected'].should.equal(false);
             adminConnectionMock.disconnect.should.have.been.called;
-        })));
-    });
-
-    describe('importCertificates', () => {
-        let mockConnectionProfile;
-        let mockIdCard;
-
-        beforeEach(() => {
-            mockConnectionProfile = {name: 'myProfile'};
-            mockIdCard = sinon.createStubInstance(IdCard);
-            mockIdCard.getBusinessNetworkName.returns('myNetwork');
-            mockIdCard.getConnectionProfile.returns(mockConnectionProfile);
-            mockIdCard.getEnrollmentCredentials.returns({id: 'myId'});
-            mockIdCard.getCredentials.returns({certificate: 'certificate', privateKey: 'privateKey'});
-        });
-
-        it('should import the certificates', fakeAsync(inject([AdminService], (service: AdminService) => {
-            adminConnectionMock.importIdentity.returns(Promise.resolve());
-
-            sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
-
-            identityCardMock.getCurrentIdentityCard.returns(mockIdCard);
-            identityCardMock.getQualifiedProfileName.returns('qpn');
-
-            service.importCertificates();
-
-            identityCardMock.getCurrentIdentityCard.should.have.been.called;
-            identityCardMock.getQualifiedProfileName.should.have.been.calledWith(mockConnectionProfile);
-            mockIdCard.getEnrollmentCredentials.should.have.been.called;
-            mockIdCard.getCredentials.should.have.been.called;
-
-            adminConnectionMock.importIdentity.should.have.been.calledWith('qpn', 'myId', 'certificate', 'privateKey');
-        })));
-
-        it('should do nothing if no certs but is a secret', fakeAsync(inject([AdminService], (service: AdminService) => {
-            adminConnectionMock.importIdentity.returns(Promise.resolve());
-
-            mockIdCard.getEnrollmentCredentials.returns({id: 'myId', secret: 'mySecret'});
-            mockIdCard.getCredentials.returns(null);
-
-            sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
-
-            identityCardMock.getCurrentIdentityCard.returns(mockIdCard);
-            identityCardMock.getQualifiedProfileName.returns('qpn');
-
-            service.importCertificates().catch(() => {
-                throw new Error('should not have got here');
-            });
-
-            identityCardMock.getCurrentIdentityCard.should.have.been.called;
-            identityCardMock.getQualifiedProfileName.should.have.been.calledWith(mockConnectionProfile);
-            mockIdCard.getEnrollmentCredentials.should.have.been.called;
-            mockIdCard.getCredentials.should.have.been.called;
-
-            adminConnectionMock.importIdentity.should.not.have.been.called;
-        })));
-
-        it('should give an error if no private key and no secret', fakeAsync(inject([AdminService], (service: AdminService) => {
-            mockIdCard.getCredentials.returns({certificate: 'certificate'});
-
-            adminConnectionMock.importIdentity.returns(Promise.resolve());
-
-            sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
-
-            identityCardMock.getCurrentIdentityCard.returns(mockIdCard);
-            identityCardMock.getQualifiedProfileName.returns('qpn');
-
-            service.importCertificates().catch((error) => {
-                error.message.should.equal('No certificates or user secret was specified. An identity card must contain either public and private certificates or an enrollment secret');
-            });
-
-            identityCardMock.getCurrentIdentityCard.should.have.been.called;
-            identityCardMock.getQualifiedProfileName.should.have.been.calledWith(mockConnectionProfile);
-            mockIdCard.getEnrollmentCredentials.should.have.been.called;
-            mockIdCard.getCredentials.should.have.been.called;
-
-            adminConnectionMock.importIdentity.should.not.have.been.called;
-        })));
-
-        it('should give an error if no public key and no secret', fakeAsync(inject([AdminService], (service: AdminService) => {
-            mockIdCard.getCredentials.returns({privateKey: 'privateKey'});
-
-            adminConnectionMock.importIdentity.returns(Promise.resolve());
-
-            sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
-
-            identityCardMock.getCurrentIdentityCard.returns(mockIdCard);
-            identityCardMock.getQualifiedProfileName.returns('qpn');
-
-            service.importCertificates().catch((error) => {
-                error.message.should.equal('No certificates or user secret was specified. An identity card must contain either public and private certificates or an enrollment secret');
-            });
-
-            identityCardMock.getCurrentIdentityCard.should.have.been.called;
-            identityCardMock.getQualifiedProfileName.should.have.been.calledWith(mockConnectionProfile);
-            mockIdCard.getEnrollmentCredentials.should.have.been.called;
-            mockIdCard.getCredentials.should.have.been.called;
-
-            adminConnectionMock.importIdentity.should.not.have.been.called;
-        })));
-
-        it('should give an error if no credentials and no secret', fakeAsync(inject([AdminService], (service: AdminService) => {
-            mockIdCard.getCredentials.returns(null);
-
-            adminConnectionMock.importIdentity.returns(Promise.resolve());
-
-            sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
-
-            identityCardMock.getCurrentIdentityCard.returns(mockIdCard);
-            identityCardMock.getQualifiedProfileName.returns('qpn');
-
-            service.importCertificates().catch((error) => {
-                error.message.should.equal('No certificates or user secret was specified. An identity card must contain either public and private certificates or an enrollment secret');
-            });
-
-            identityCardMock.getCurrentIdentityCard.should.have.been.called;
-            identityCardMock.getQualifiedProfileName.should.have.been.calledWith(mockConnectionProfile);
-            mockIdCard.getEnrollmentCredentials.should.have.been.called;
-            mockIdCard.getCredentials.should.have.been.called;
-
-            adminConnectionMock.importIdentity.should.not.have.been.called;
         })));
     });
 });

--- a/packages/composer-playground/src/app/services/client.service.spec.ts
+++ b/packages/composer-playground/src/app/services/client.service.spec.ts
@@ -15,6 +15,7 @@ import { AdminService } from './admin.service';
 import { AlertService } from '../basic-modals/alert.service';
 import { BusinessNetworkDefinition, ModelFile, Script, AclFile, QueryFile, ConnectionProfileStore } from 'composer-common';
 import { BusinessNetworkConnection } from 'composer-client';
+import { IdentityService } from './identity.service';
 import { IdentityCardService } from './identity-card.service';
 import { LocalStorageService } from 'angular-2-local-storage';
 import { ConnectionProfileStoreService } from './connectionprofilestore.service';
@@ -26,6 +27,7 @@ describe('ClientService', () => {
     let adminMock;
     let alertMock;
     let businessNetworkDefMock;
+    let identityServiceMock;
     let identityCardServiceMock;
     let businessNetworkConMock;
     let modelFileMock;
@@ -42,6 +44,7 @@ describe('ClientService', () => {
         businessNetworkDefMock = sinon.createStubInstance(BusinessNetworkDefinition);
         adminMock = sinon.createStubInstance(AdminService);
         alertMock = sinon.createStubInstance(AlertService);
+        identityServiceMock = sinon.createStubInstance(IdentityService);
         identityCardServiceMock = sinon.createStubInstance(IdentityCardService);
         businessNetworkConMock = sinon.createStubInstance(BusinessNetworkConnection);
         modelFileMock = sinon.createStubInstance(ModelFile);
@@ -61,6 +64,7 @@ describe('ClientService', () => {
             providers: [ClientService,
                 {provide: AdminService, useValue: adminMock},
                 {provide: AlertService, useValue: alertMock},
+                {provide: IdentityService, useValue: identityServiceMock},
                 {provide: IdentityCardService, useValue: identityCardServiceMock},
                 {provide: LocalStorageService, useValue: mockLocalStorage},
                 {provide: ConnectionProfileStoreService, useValue: connectionProfileStoreServiceMock}]
@@ -799,8 +803,8 @@ describe('ClientService', () => {
 
     describe('ensureConnected', () => {
         beforeEach(() => {
-            identityCardServiceMock.getCurrentConnectionProfile.returns({name: 'myProfile'});
-            identityCardServiceMock.getCurrentEnrollmentCredentials.returns({id: 'myId'});
+            identityServiceMock.getCurrentConnectionProfile.returns({name: 'myProfile'});
+            identityServiceMock.getCurrentEnrollmentCredentials.returns({id: 'myId'});
         });
 
         it('should return if connected when not forced', fakeAsync(inject([ClientService], (service: ClientService) => {
@@ -808,7 +812,7 @@ describe('ClientService', () => {
 
             service.ensureConnected();
 
-            identityCardServiceMock.getCurrentEnrollmentCredentials.should.not.have.been.called;
+            identityServiceMock.getCurrentEnrollmentCredentials.should.not.have.been.called;
         })));
 
         it('should return if connecting', fakeAsync(inject([ClientService], (service: ClientService) => {
@@ -816,7 +820,7 @@ describe('ClientService', () => {
 
             service.ensureConnected();
 
-            identityCardServiceMock.getCurrentEnrollmentCredentials.should.not.have.been.called;
+            identityServiceMock.getCurrentEnrollmentCredentials.should.not.have.been.called;
         })));
 
         it('should connect if not connected', fakeAsync(inject([ClientService], (service: ClientService) => {
@@ -829,7 +833,7 @@ describe('ClientService', () => {
 
             tick();
 
-            identityCardServiceMock.getCurrentEnrollmentCredentials.should.have.been.called;
+            identityServiceMock.getCurrentEnrollmentCredentials.should.have.been.called;
 
             alertMock.busyStatus$.next.should.have.been.calledTwice;
             alertMock.busyStatus$.next.firstCall.should.have.been.calledWith({
@@ -860,7 +864,7 @@ describe('ClientService', () => {
 
             tick();
 
-            identityCardServiceMock.getCurrentEnrollmentCredentials.should.have.been.called;
+            identityServiceMock.getCurrentEnrollmentCredentials.should.have.been.called;
 
             alertMock.busyStatus$.next.should.have.been.calledTwice;
             alertMock.busyStatus$.next.firstCall.should.have.been.calledWith({
@@ -895,7 +899,7 @@ describe('ClientService', () => {
 
             tick();
 
-            identityCardServiceMock.getCurrentEnrollmentCredentials.should.have.been.called;
+            identityServiceMock.getCurrentEnrollmentCredentials.should.have.been.called;
 
             alertMock.busyStatus$.next.should.have.been.calledTwice;
             alertMock.busyStatus$.next.firstCall.should.have.been.calledWith({
@@ -952,9 +956,9 @@ describe('ClientService', () => {
 
     describe('refresh', () => {
         beforeEach(() => {
-            identityCardServiceMock.getCurrentConnectionProfile.returns({name: 'myProfile'});
-            identityCardServiceMock.getQualifiedProfileName.returns('xxx-myProfile');
-            identityCardServiceMock.getCurrentEnrollmentCredentials.returns({id: 'myUser', secret: 'mySecret'});
+            identityServiceMock.getCurrentConnectionProfile.returns({name: 'myProfile'});
+            identityServiceMock.getCurrentQualifiedProfileName.returns('xxx-myProfile');
+            identityServiceMock.getCurrentEnrollmentCredentials.returns({id: 'myUser', secret: 'mySecret'});
         });
 
         it('should diconnect and reconnect the business network connection', fakeAsync(inject([ClientService], (service: ClientService) => {
@@ -993,9 +997,9 @@ describe('ClientService', () => {
 
     describe('it should deployInitial sample', () => {
         beforeEach(() => {
-            identityCardServiceMock.getCurrentConnectionProfile.returns({name: '$default', type: 'web'});
-            identityCardServiceMock.getQualifiedProfileName.returns('web-$default');
-            identityCardServiceMock.getCurrentEnrollmentCredentials.returns({id: 'admin', secret: 'adminpw'});
+            identityServiceMock.getCurrentConnectionProfile.returns({name: '$default', type: 'web'});
+            identityServiceMock.getCurrentQualifiedProfileName.returns('web-$default');
+            identityServiceMock.getCurrentEnrollmentCredentials.returns({id: 'admin', secret: 'adminpw'});
         });
 
         it('should deploy the initial sample', fakeAsync(inject([ClientService], (service: ClientService) => {
@@ -1042,8 +1046,8 @@ describe('ClientService', () => {
         })));
 
         it('should deploy the initial sample and create id card', fakeAsync(inject([ClientService], (service: ClientService) => {
-            identityCardServiceMock.getCurrentConnectionProfile.returns({name: 'hlfv1', type: 'hlfv1'});
-            identityCardServiceMock.getQualifiedProfileName.returns('qpn');
+            identityServiceMock.getCurrentConnectionProfile.returns({name: 'hlfv1', type: 'hlfv1'});
+            identityServiceMock.getCurrentQualifiedProfileName.returns('qpn');
 
             identityCardServiceMock.createIdentityCard.returns(Promise.resolve());
 
@@ -1151,7 +1155,7 @@ describe('ClientService', () => {
     describe('issueIdentity', () => {
 
         it('should generate and return an identity using internally held state information', fakeAsync(inject([ClientService], (service: ClientService) => {
-            identityCardServiceMock.getCurrentConnectionProfile.returns({name: 'myProfile'});
+            identityServiceMock.getCurrentConnectionProfile.returns({name: 'myProfile'});
             businessNetworkConMock.issueIdentity.returns(Promise.resolve({
                 participant: 'uniqueName',
                 userID: 'userId',
@@ -1174,7 +1178,7 @@ describe('ClientService', () => {
         })));
 
         it('should generate and return an identity, detecting blockchain.ibm.com URLs', fakeAsync(inject([ClientService], (service: ClientService) => {
-            identityCardServiceMock.getCurrentConnectionProfile.returns({
+            identityServiceMock.getCurrentConnectionProfile.returns({
                 name: 'myProfile',
                 membershipServicesURL: 'memberURL\.blockchain\.ibm\.com',
                 peerURL: 'peerURL\.blockchain\.ibm\.com',

--- a/packages/composer-playground/src/app/services/identity-card.service.spec.ts
+++ b/packages/composer-playground/src/app/services/identity-card.service.spec.ts
@@ -5,6 +5,7 @@
 import { TestBed, inject, fakeAsync, tick } from '@angular/core/testing';
 
 import { IdCard } from 'composer-common';
+import { AdminService } from './admin.service';
 import { IdentityCardStorageService } from './identity-card-storage.service';
 import { ConnectionProfileService } from './connectionprofile.service';
 import { IdentityService } from './identity.service';
@@ -20,17 +21,20 @@ import { IdentityCardService } from './identity-card.service';
 
 describe('IdentityCardService', () => {
 
+    let mockAdminService;
     let mockIdentityCardStorageService;
     let mockConnectionProfileService;
     let mockIdentityService;
 
     beforeEach(() => {
+        mockAdminService = sinon.createStubInstance(AdminService);
         mockIdentityCardStorageService = sinon.createStubInstance(IdentityCardStorageService);
         mockConnectionProfileService = sinon.createStubInstance(ConnectionProfileService);
         mockIdentityService = sinon.createStubInstance(IdentityService);
 
         TestBed.configureTestingModule({
             providers: [IdentityCardService,
+                {provide: AdminService, useValue: mockAdminService},
                 {provide: ConnectionProfileService, useValue: mockConnectionProfileService},
                 {provide: IdentityService, useValue: mockIdentityService},
                 {provide: IdentityCardStorageService, useValue: mockIdentityCardStorageService}
@@ -71,39 +75,68 @@ describe('IdentityCardService', () => {
         })));
     });
 
-    describe('#getCurrentConnectionProfile', () => {
-        it('should get the connection profile of the current identity card', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
-            let mockIdCard = sinon.createStubInstance(IdCard);
-            mockIdCard.getConnectionProfile.returns({name: '$default'});
-            let getCurrentIdentityCardStub = sinon.stub(service, 'getCurrentIdentityCard');
-            getCurrentIdentityCardStub.returns(mockIdCard);
+    describe('#getIdentityCardForExport', () => {
+        let mockIdCard1;
+        let mockIdCard2;
+        let mockCardMap;
 
-            service.getCurrentConnectionProfile().name.should.equal('$default');
+        beforeEach(() => {
+            mockAdminService.exportIdentity.returns(Promise.resolve({certificate: 'CERTIFICATE', privateKey: 'PRIVATE_KEY'}));
+
+            mockIdCard1 = sinon.createStubInstance(IdCard);
+            mockIdCard1.getName.returns('card1');
+            mockIdCard1.getBusinessNetworkName.returns('assassin-network');
+            mockIdCard1.getEnrollmentCredentials.returns({id: 'admin', secret: 'adminpw'});
+            mockIdCard1.getConnectionProfile.returns({name: 'hlfv1'});
+
+            mockIdCard2 = sinon.createStubInstance(IdCard);
+            mockIdCard2.getName.returns('card2');
+            mockIdCard2.getBusinessNetworkName.returns('assassin-network');
+            mockIdCard2.getEnrollmentCredentials.returns({id: 'admin', secret: 'adminpw'});
+            mockIdCard2.getConnectionProfile.returns({name: 'hlfv1'});
+
+            mockCardMap = new Map<string, IdCard>();
+            mockCardMap.set('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', mockIdCard1);
+            mockCardMap.set('uuid2xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', mockIdCard2);
+        });
+
+        it('should get an unused identity card without credentials', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
+            mockIdentityCardStorageService.get.withArgs('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd').returns({
+                unused: true
+            });
+            service['idCards'] = mockCardMap;
+
+            let result;
+            service.getIdentityCardForExport('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx').then((card) => {
+                result = card;
+            });
+
+            tick();
+
+            mockAdminService.exportIdentity.should.not.have.been.called;
+            result.getName().should.equal('card1');
+            result.getBusinessNetworkName().should.equal('assassin-network');
+            result.getEnrollmentCredentials().should.deep.equal({id: 'admin', secret: 'adminpw'});
+            result.getConnectionProfile().should.deep.equal({name: 'hlfv1'});
+            result.getCredentials().should.deep.equal({});
         })));
 
-        it('should not get a connection profile if there is no current identity card', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
-            let getCurrentIdentityCardStub = sinon.stub(service, 'getCurrentIdentityCard');
-            getCurrentIdentityCardStub.returns(undefined);
+        it('should get a used identity card with credentials', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
+            service['idCards'] = mockCardMap;
 
-            should.not.exist(service.getCurrentConnectionProfile());
-        })));
-    });
+            let result;
+            service.getIdentityCardForExport('uuid2xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx').then((card) => {
+                result = card;
+            });
 
-    describe('#getCurrentEnrollmentCredentials', () => {
-        it('should get the enrollment credentials of the current identity card', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
-            let mockIdCard = sinon.createStubInstance(IdCard);
-            mockIdCard.getEnrollmentCredentials.returns({id: 'alice'});
-            let getCurrentIdentityCardStub = sinon.stub(service, 'getCurrentIdentityCard');
-            getCurrentIdentityCardStub.returns(mockIdCard);
+            tick();
 
-            service.getCurrentEnrollmentCredentials().id.should.equal('alice');
-        })));
-
-        it('should not get enrollment credentials if there is no current identity card', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
-            let getCurrentIdentityCardStub = sinon.stub(service, 'getCurrentIdentityCard');
-            getCurrentIdentityCardStub.returns(undefined);
-
-            should.not.exist(service.getCurrentEnrollmentCredentials());
+            mockAdminService.exportIdentity.should.have.been.called;
+            result.getName().should.equal('card2');
+            result.getBusinessNetworkName().should.equal('assassin-network');
+            result.getEnrollmentCredentials().should.deep.equal({id: 'admin', secret: 'adminpw'});
+            result.getConnectionProfile().should.deep.equal({name: 'hlfv1'});
+            result.getCredentials().should.deep.equal({certificate: 'CERTIFICATE', privateKey: 'PRIVATE_KEY'});
         })));
     });
 
@@ -116,6 +149,9 @@ describe('IdentityCardService', () => {
         });
 
         it('should load cards from local storage', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
+            let setCurrentIdentityCardStub = sinon.stub(service, 'setCurrentIdentityCard');
+            setCurrentIdentityCardStub.returns(Promise.resolve());
+
             let result: number;
             service['currentCard'] = 'someCardRef';
             service.loadIdentityCards(false).then((cardsLoaded) => {
@@ -127,6 +163,7 @@ describe('IdentityCardService', () => {
             result.should.equal(3);
             service['idCards'].size.should.equal(3);
             should.not.exist(service['currentCard']);
+            setCurrentIdentityCardStub.should.not.have.been.called;
         })));
 
         it('should only load cards with web connection profiles from local storage', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
@@ -174,6 +211,9 @@ describe('IdentityCardService', () => {
         })));
 
         it('should set the current identity card', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
+            let setCurrentIdentityCardStub = sinon.stub(service, 'setCurrentIdentityCard');
+            setCurrentIdentityCardStub.returns(Promise.resolve());
+
             mockIdentityCardStorageService.get.withArgs('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx').returns(JSON.parse('{"metadata":{"name":"NetworkAdmin","businessNetwork":"basic-sample-network"},"connectionProfile":{"name":"$default","type":"web"},"credentials":null}'));
             mockIdentityCardStorageService.get.withArgs('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd').returns(JSON.parse('{"current":true}'));
 
@@ -182,18 +222,7 @@ describe('IdentityCardService', () => {
             tick();
 
             service['currentCard'].should.equal('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
-            mockIdentityService.setCurrentIdentity.should.not.have.been.called;
-        })));
-
-        it('should set the current identity card and current identity', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
-            mockIdentityCardStorageService.get.withArgs('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd').returns(JSON.parse('{"current":true}'));
-
-            service.loadIdentityCards(false);
-
-            tick();
-
-            service['currentCard'].should.equal('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
-            mockIdentityService.setCurrentIdentity.should.have.been.calledWith('admin');
+            setCurrentIdentityCardStub.should.have.been.called;
         })));
     });
 
@@ -292,7 +321,8 @@ describe('IdentityCardService', () => {
     });
 
     describe('#addIdentityCard', () => {
-        it('should add an identity card', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
+        it('should add an identity card without credentials', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
+            let activateIdentityCardStub = sinon.stub(service, 'activateIdentityCard');
             let mockIdCard = sinon.createStubInstance(IdCard);
             mockIdCard.getName.returns('bcc');
 
@@ -307,6 +337,28 @@ describe('IdentityCardService', () => {
             mockIdentityCardStorageService.set.should.have.been.calledTwice;
             mockIdentityCardStorageService.set.should.have.been.calledWith(result);
             mockIdentityCardStorageService.set.should.have.been.calledWith(result + '-pd', {unused: true});
+            activateIdentityCardStub.should.not.have.been.called;
+        })));
+
+        it('should add and activate an identity card with credentials', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
+            let activateIdentityCardStub = sinon.stub(service, 'activateIdentityCard');
+            activateIdentityCardStub.returns(Promise.resolve());
+            let mockIdCard = sinon.createStubInstance(IdCard);
+            mockIdCard.getName.returns('bcc');
+            mockIdCard.getCredentials.returns({certificate: 'CERTIFICATE', privateKey: 'PRIVATE_KEY'});
+
+            let result;
+            service.addIdentityCard(mockIdCard).then((cardRef) => {
+                result = cardRef;
+            });
+
+            tick();
+
+            service['idCards'].size.should.equal(1);
+            mockIdentityCardStorageService.set.should.have.been.calledTwice;
+            mockIdentityCardStorageService.set.should.have.been.calledWith(result);
+            mockIdentityCardStorageService.set.should.have.been.calledWith(result + '-pd', {unused: true});
+            activateIdentityCardStub.should.have.been.called;
         })));
     });
 
@@ -464,6 +516,10 @@ describe('IdentityCardService', () => {
         });
 
         it('should set the current identity card', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
+            let activateIdentityCardStub = sinon.stub(service, 'activateIdentityCard');
+            let getQualifiedProfileNameStub = sinon.stub(service, 'getQualifiedProfileName');
+            getQualifiedProfileNameStub.returns('fqn');
+            activateIdentityCardStub.returns(Promise.resolve());
             service['idCards'] = mockCardMap;
 
             service.setCurrentIdentityCard('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
@@ -472,10 +528,14 @@ describe('IdentityCardService', () => {
 
             mockConnectionProfileService.createProfile.should.not.have.been.called;
             mockIdentityCardStorageService.set.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd', {current: true});
-            mockIdentityService.setCurrentIdentity.should.have.been.calledWith('admin');
+            mockIdentityService.setCurrentIdentity.should.have.been.calledWith('fqn', mockIdCard1);
         })));
 
         it('should change the current identity card', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
+            let activateIdentityCardStub = sinon.stub(service, 'activateIdentityCard');
+            let getQualifiedProfileNameStub = sinon.stub(service, 'getQualifiedProfileName');
+            getQualifiedProfileNameStub.returns('fqn');
+            activateIdentityCardStub.returns(Promise.resolve());
             mockIdentityCardStorageService.get.withArgs('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd').returns({
                 current: true
             });
@@ -491,7 +551,7 @@ describe('IdentityCardService', () => {
             mockIdentityCardStorageService.set.should.have.been.calledTwice;
             mockIdentityCardStorageService.set.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd', {});
             mockIdentityCardStorageService.set.should.have.been.calledWith('uuid2xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd', {current: true});
-            mockIdentityService.setCurrentIdentity.should.have.been.calledWith('admin');
+            mockIdentityService.setCurrentIdentity.should.have.been.calledWith('fqn', mockIdCard2);
         })));
 
         it('should not set the current identity card to one that does not exist', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
@@ -506,29 +566,12 @@ describe('IdentityCardService', () => {
 
             result.message.should.equal('Identity card does not exist');
         })));
-
-        it('should give an error if no enrollment id', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
-            mockIdCard1.getEnrollmentCredentials.returns(null);
-            mockCardMap.set('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', mockIdCard1);
-
-            service['idCards'] = mockCardMap;
-
-            service.setCurrentIdentityCard('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx').catch((error) => {
-                error.message.should.equal('Identity card does not contain an enrollment id');
-            });
-
-            tick();
-
-            mockConnectionProfileService.createProfile.should.not.have.been.called;
-            mockIdentityCardStorageService.set.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd', {current: true});
-            mockIdentityService.setCurrentIdentity.should.not.have.been.called;
-        })));
     });
 
-    describe('activateCurrentIdentityCard', () => {
+    describe('activateIdentityCard', () => {
         let mockIdCard1;
         let mockIdCard2;
-        let mockConnectionProfile2;
+        let mockIdCard3;
         let mockCardMap;
 
         beforeEach(() => {
@@ -538,69 +581,90 @@ describe('IdentityCardService', () => {
             mockIdCard1.getEnrollmentCredentials.returns({id: 'admin', secret: 'adminpw'});
             mockIdCard1.getConnectionProfile.returns({name: '$default', type: 'web'});
 
-            mockConnectionProfile2 = {name: 'hlfv1'};
             mockIdCard2 = sinon.createStubInstance(IdCard);
             mockIdCard2.getEnrollmentCredentials.returns({id: 'admin'});
-            mockIdCard2.getConnectionProfile.returns(mockConnectionProfile2);
+            mockIdCard2.getCredentials.returns({certificate: 'CERTIFICATE', privateKey: 'PRIVATE_KEY'});
+            mockIdCard2.getConnectionProfile.returns({name: 'hlfv1'});
+
+            mockIdCard3 = sinon.createStubInstance(IdCard);
+            mockIdCard3.getEnrollmentCredentials.returns({id: 'admin'});
+            mockIdCard3.getCredentials.returns({});
+            mockIdCard3.getConnectionProfile.returns({name: 'hlfv1'});
 
             mockCardMap = new Map<string, IdCard>();
             mockCardMap.set('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', mockIdCard1);
             mockCardMap.set('uuid2xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', mockIdCard2);
+            mockCardMap.set('uuid3xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', mockIdCard3);
         });
 
-        it('should activate an unused current identity card', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
-            service['currentCard'] = 'uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+        it('should activate an unused identity card with no credentials', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
+            // service['currentCard'] = 'uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
             mockIdentityCardStorageService.get.withArgs('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd').returns({
                 unused: true
             });
             service['idCards'] = mockCardMap;
 
-            service.activateCurrentIdentityCard().then((result: string) => {
+            service['activateIdentityCard']('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx').then((result: string) => {
                 result.should.equal('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
             });
 
             tick();
 
+            mockAdminService.importIdentity.should.not.have.been.called;
             mockConnectionProfileService.createProfile.should.have.been.calledWith('web-$default');
             mockIdentityCardStorageService.set.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd', {});
         })));
 
-        it('should activate an unused current identity card (updating a connection profile)', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
-            service['currentCard'] = 'uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
-            mockIdentityCardStorageService.get.withArgs('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd').returns({
+        it('should activate an unused identity card with credentials', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
+            // service['currentCard'] = 'uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+            mockIdentityCardStorageService.get.withArgs('uuid2xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd').returns({
                 unused: true
             });
-
-            mockIdCard1.getEnrollmentCredentials.returns({id: 'admin'});
-            mockCardMap.set('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', mockIdCard1);
-
             service['idCards'] = mockCardMap;
 
-            service.activateCurrentIdentityCard().then((result: string) => {
-                result.should.equal('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
+            service['activateIdentityCard']('uuid2xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx').then((result: string) => {
+                result.should.equal('uuid2xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
             });
 
             tick();
 
-            mockConnectionProfileService.createProfile.should.have.been.calledWith('web-$default');
-            mockIdentityCardStorageService.set.should.have.been.calledWith('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd', {});
+            mockAdminService.importIdentity.should.have.been.called;
+            mockConnectionProfileService.createProfile.should.have.been.calledWith(sinon.match(/^.{40}-hlfv1$/));
+            mockIdentityCardStorageService.set.should.have.been.calledWith('uuid2xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd', {});
         })));
 
-        it('should activate a used current identity card', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
-            service['currentCard'] = 'uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+        it('should not activate a used identity card', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
             mockIdentityCardStorageService.get.withArgs('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd').returns();
             service['idCards'] = mockCardMap;
 
-            service.activateCurrentIdentityCard().then((result) => {
+            service['activateIdentityCard']('uuid1xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx').then((result) => {
                 should.not.exist(result);
             });
 
             tick();
 
+            mockAdminService.importIdentity.should.not.have.been.called;
             mockConnectionProfileService.createProfile.should.not.have.been.called;
             mockIdentityCardStorageService.set.should.not.have.been.called;
         })));
 
+        it('should give an error when activating an identity card with no enrollment secret and no credentials', fakeAsync(inject([IdentityCardService], (service: IdentityCardService) => {
+            mockIdentityCardStorageService.get.withArgs('uuid3xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-pd').returns({
+                unused: true
+            });
+            service['idCards'] = mockCardMap;
+
+            service['activateIdentityCard']('uuid3xxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx').then((result) => {
+                should.not.exist(result);
+            }).catch((reason) => {
+                reason.message.should.equal('No credentials or enrollment secret available. An identity card must contain either a certificate and private key, or an enrollment secret');
+            });
+
+            tick();
+
+            mockAdminService.importIdentity.should.not.have.been.called;
+            mockConnectionProfileService.createProfile.should.not.have.been.called;
+        })));
     });
 
     describe('getIdentityCardRefsWithProfileAndRole', () => {

--- a/packages/composer-playground/src/app/services/identity-card.service.ts
+++ b/packages/composer-playground/src/app/services/identity-card.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 
+import { AdminService } from './admin.service';
 import { ConnectionProfileService } from './connectionprofile.service';
 import { IdentityService } from './identity.service';
 import { IdentityCardStorageService } from './identity-card-storage.service';
@@ -34,7 +35,8 @@ export class IdentityCardService {
 
     private idCards: Map<string, IdCard> = new Map<string, IdCard>();
 
-    constructor(private connectionProfileService: ConnectionProfileService,
+    constructor(private adminService: AdminService,
+                private connectionProfileService: ConnectionProfileService,
                 private identityService: IdentityService,
                 private identityCardStorageService: IdentityCardStorageService) {
         Logger.setFunctionalLogger({
@@ -52,22 +54,6 @@ export class IdentityCardService {
         return this.getIdentityCard(this.currentCard);
     }
 
-    getCurrentConnectionProfile(): any {
-        let card = this.getCurrentIdentityCard();
-
-        if (card) {
-            return card.getConnectionProfile();
-        }
-    }
-
-    getCurrentEnrollmentCredentials(): any {
-        let card = this.getCurrentIdentityCard();
-
-        if (card) {
-            return card.getEnrollmentCredentials();
-        }
-    }
-
     getIdentityCardRefsWithProfileAndRole(qualifiedProfileName: string, role: string): string[] {
         let cardRefs: string[] = [];
         this.idCards.forEach((card, key) => {
@@ -78,6 +64,38 @@ export class IdentityCardService {
         });
 
         return cardRefs;
+    }
+
+    getIdentityCardForExport(cardRef: string): Promise<IdCard> {
+        let card = this.idCards.get(cardRef);
+
+        return Promise.resolve()
+            .then(() => {
+                let data: any = this.identityCardStorageService.get(this.dataRef(cardRef)) || {};
+
+                if (!data.unused) {
+                    let connectionProfile = card.getConnectionProfile();
+                    let connectionProfileRef = this.getQualifiedProfileName(connectionProfile);
+                    let enrollmentCredentials = card.getEnrollmentCredentials();
+
+                    return this.adminService.exportIdentity(connectionProfileRef, enrollmentCredentials.id);
+                }
+            })
+            .then((exportedCredentials) => {
+                let metadata = {
+                    name: card.getName(),
+                    businessNetwork: card.getBusinessNetworkName(),
+                    enrollmentId: card.getEnrollmentCredentials().id,
+                    enrollmentSecret: card.getEnrollmentCredentials().secret
+                };
+
+                let exportCard: IdCard = new IdCard(metadata, card.getConnectionProfile());
+                if (exportedCredentials) {
+                    exportCard.setCredentials(exportedCredentials);
+                }
+
+                return exportCard;
+            });
     }
 
     loadIdentityCards(webOnly: boolean): Promise<number> {
@@ -113,12 +131,7 @@ export class IdentityCardService {
                 }, new Map<string, IdCard>());
 
             if (this.currentCard) {
-                let card: IdCard = this.getCurrentIdentityCard();
-                let enrollmentCredentials = card.getEnrollmentCredentials();
-
-                if (enrollmentCredentials && enrollmentCredentials.id) {
-                    this.identityService.setCurrentIdentity(enrollmentCredentials.id);
-                }
+                this.setCurrentIdentityCard(this.currentCard);
             }
 
             resolve(this.idCards.size);
@@ -166,11 +179,20 @@ export class IdentityCardService {
     addIdentityCard(card: IdCard): Promise<string> {
         let cardRef: string = uuid.v4();
 
-        this.identityCardStorageService.set(cardRef, card);
-        this.identityCardStorageService.set(this.dataRef(cardRef), {unused: true});
-        this.idCards.set(cardRef, card);
+        return Promise.resolve()
+            .then(() => {
+                this.identityCardStorageService.set(cardRef, card);
+                this.identityCardStorageService.set(this.dataRef(cardRef), {unused: true});
+                this.idCards.set(cardRef, card);
 
-        return Promise.resolve(cardRef);
+                let credentials = card.getCredentials();
+                if (credentials && credentials.certificate && credentials.privateKey) {
+                    return this.activateIdentityCard(cardRef);
+                }
+            })
+            .then(() => {
+                return cardRef;
+            });
     }
 
     deleteIdentityCard(cardRef: string): Promise<void> {
@@ -197,13 +219,12 @@ export class IdentityCardService {
     }
 
     setCurrentIdentityCard(cardRef): Promise<IdCard> {
-        return Promise.resolve()
+        if (!this.idCards.has(cardRef)) {
+            return Promise.reject(new Error('Identity card does not exist'));
+        }
+
+        return this.activateIdentityCard(cardRef)
             .then(() => {
-                if (!
-                        this.idCards.has(cardRef)
-                ) {
-                    return Promise.reject(new Error('Identity card does not exist'));
-                }
                 let card: IdCard = this.idCards.get(cardRef);
 
                 let oldData: any = this.identityCardStorageService.get(this.dataRef(this.currentCard));
@@ -217,15 +238,9 @@ export class IdentityCardService {
                 newData.current = true;
                 this.identityCardStorageService.set(this.dataRef(cardRef), newData);
 
-                // Hmmm, suspicious... is the enrollement ID really the identity?!
-                let enrollmentCredentials = card.getEnrollmentCredentials();
-                if (!enrollmentCredentials) {
-                    return Promise.reject(new Error('Identity card does not contain an enrollment id'));
-                }
-
-                let enrollmentId = enrollmentCredentials.id;
-
-                this.identityService.setCurrentIdentity(enrollmentId);
+                let profile = card.getConnectionProfile();
+                let qpn = this.getQualifiedProfileName(profile);
+                this.identityService.setCurrentIdentity(qpn, card);
 
                 return Promise.resolve(card);
             });
@@ -277,24 +292,40 @@ export class IdentityCardService {
         return wantedCards;
     }
 
-    activateCurrentIdentityCard(): Promise<string | void> {
-        let data: any = this.identityCardStorageService.get(this.dataRef(this.currentCard));
+    private activateIdentityCard(cardRef): Promise<string | void> {
+        let data: any = this.identityCardStorageService.get(this.dataRef(cardRef));
 
         if (data && data.unused) {
             delete data['unused'];
-            this.identityCardStorageService.set(this.dataRef(this.currentCard), data);
+            this.identityCardStorageService.set(this.dataRef(cardRef), data);
 
-            let card = this.idCards.get(this.currentCard);
+            let hasCredentials = false;
+            let card = this.idCards.get(cardRef);
             let connectionProfile = card.getConnectionProfile();
-            let connectionProfileName = this.getQualifiedProfileName(connectionProfile);
-
-            // Hmmm, suspicious... is the enrollement ID really the identity?!
+            let connectionProfileRef = this.getQualifiedProfileName(connectionProfile);
             let enrollmentCredentials = card.getEnrollmentCredentials();
+            let credentials = card.getCredentials();
 
-            // Is this enough activation? What about the identity import thing?
-            return this.connectionProfileService.createProfile(connectionProfileName, connectionProfile).then(() => {
-                return this.currentCard;
-            });
+            if (credentials && credentials.certificate && credentials.privateKey) {
+                hasCredentials = true;
+
+                // don't want to keep credentials around after the card has been activated
+                card.setCredentials({});
+                this.identityCardStorageService.set(cardRef, card);
+                this.idCards.set(cardRef, card);
+            } else if (!enrollmentCredentials || !enrollmentCredentials.secret) {
+                return Promise.reject(new Error('No credentials or enrollment secret available. An identity card must contain either a certificate and private key, or an enrollment secret'));
+            }
+
+            return this.connectionProfileService.createProfile(connectionProfileRef, connectionProfile)
+                .then(() => {
+                    if (hasCredentials) {
+                        return this.adminService.importIdentity(connectionProfileRef, enrollmentCredentials.id, credentials.certificate, credentials.privateKey);
+                    }
+                })
+                .then(() => {
+                    return cardRef;
+                });
         }
 
         return Promise.resolve();

--- a/packages/composer-playground/src/app/services/identity.service.spec.ts
+++ b/packages/composer-playground/src/app/services/identity.service.spec.ts
@@ -7,6 +7,8 @@ import { IdentityService } from './identity.service';
 import { LocalStorageService } from 'angular-2-local-storage';
 import * as sinon from 'sinon';
 
+import { IdCard } from 'composer-common';
+
 describe('IdentityService', () => {
 
     let mockLocalStorageService;
@@ -22,13 +24,50 @@ describe('IdentityService', () => {
 
     describe('setCurrentIdentity', () => {
         it('should set current identity', fakeAsync(inject([IdentityService], (service: IdentityService) => {
+            let idCardMock = sinon.createStubInstance(IdCard);
+            idCardMock.getConnectionProfile.returns({name: 'hlfv1'});
+            idCardMock.getEnrollmentCredentials.returns({id: 'admin', secret: 'adminpw'});
             let nextCurrentIdentitySpy = sinon.stub(service['_currentIdentity'], 'next');
-            service.setCurrentIdentity('identity1');
+
+            service.setCurrentIdentity('qpn-hlfv1', idCardMock);
 
             tick();
 
             nextCurrentIdentitySpy.should.have.been.called;
+            service['currentQualifiedProfileName'].should.equal('qpn-hlfv1');
+            service['currentConnectionProfile'].should.deep.equal({name: 'hlfv1'});
+            service['currentEnrollmentCredentials'].should.deep.equal({id: 'admin', secret: 'adminpw'});
         })));
+    });
+
+    describe('getCurrentConnectionProfile', () => {
+        it('should get the current connection profile', inject([IdentityService], (service: IdentityService) => {
+            service['currentConnectionProfile'] = {name: 'hlfv1'};
+
+            let result = service.getCurrentConnectionProfile();
+
+            result.should.deep.equal({name: 'hlfv1'});
+        }));
+    });
+
+    describe('getCurrentQualifiedProfileName', () => {
+        it('should get the current qualified profile name', inject([IdentityService], (service: IdentityService) => {
+            service['currentQualifiedProfileName'] = 'qpn-hlfv1';
+
+            let result = service.getCurrentQualifiedProfileName();
+
+            result.should.equal('qpn-hlfv1');
+        }));
+    });
+
+    describe('getCurrentEnrollmentCredentials', () => {
+        it('should get the current qualified profile name', inject([IdentityService], (service: IdentityService) => {
+            service['currentEnrollmentCredentials'] = {id: 'admin', secret: 'adminpw'};
+
+            let result = service.getCurrentEnrollmentCredentials();
+
+            result.should.deep.equal({id: 'admin', secret: 'adminpw'});
+        }));
     });
 
     describe('getLoggedIn', () => {

--- a/packages/composer-playground/src/app/services/identity.service.ts
+++ b/packages/composer-playground/src/app/services/identity.service.ts
@@ -2,13 +2,16 @@ import { Injectable } from '@angular/core';
 import { LocalStorageService } from 'angular-2-local-storage';
 import { BehaviorSubject, Observable } from 'rxjs/Rx';
 
-import { Logger } from 'composer-common';
+import { IdCard, Logger } from 'composer-common';
 import { IdentityCardService } from './identity-card.service';
 
 @Injectable()
 export class IdentityService {
 
     private _currentIdentity: BehaviorSubject<string> = new BehaviorSubject(null);
+    private currentQualifiedProfileName: string;
+    private currentConnectionProfile: any;
+    private currentEnrollmentCredentials: { id, secret };
 
     // tslint:disable-next-line:member-ordering
     public readonly currentIdentity: Observable<string> = this._currentIdentity.asObservable();
@@ -22,8 +25,24 @@ export class IdentityService {
         });
     }
 
-    setCurrentIdentity(identity: string) {
-        this._currentIdentity.next(identity);
+    setCurrentIdentity(qualifiedProfileName: string, card: IdCard) {
+        this.currentQualifiedProfileName = qualifiedProfileName;
+        this.currentConnectionProfile = card.getConnectionProfile();
+        this.currentEnrollmentCredentials = card.getEnrollmentCredentials();
+
+        this._currentIdentity.next(this.currentEnrollmentCredentials.id);
+    }
+
+    getCurrentConnectionProfile(): any {
+        return this.currentConnectionProfile;
+    }
+
+    getCurrentQualifiedProfileName(): string {
+        return this.currentQualifiedProfileName;
+    }
+
+    getCurrentEnrollmentCredentials(): { id, secret } {
+        return this.currentEnrollmentCredentials;
     }
 
     setLoggedIn(loggedIn: boolean) {

--- a/packages/composer-website/jekylldocs/managing/id-cards-playground.md
+++ b/packages/composer-website/jekylldocs/managing/id-cards-playground.md
@@ -65,7 +65,7 @@ ID cards are composite files containing up to three elements:
 
 - A connection profile. (`.json`)
 - A metadata file containing the data for the identity to use to connect to the business network. (`metadata.json`)
-- An optional credentials directory containing a public and private key.
+- An optional credentials directory containing a certificate and private key.
 
 _Please note_: If there is no credentials directory, the metadata file must contain the _User Secret_ property with the property name _enrollmentSecret_. If an _enrollmentSecret_ is specified, a credentials directory with certificates will be created and populated if the ID card is exported.
 
@@ -87,7 +87,7 @@ The metadata file should take the following format:
 
 The _businessNetworkName_, _image_, _enrollmentSecret_, and _roles_ properties are optional. The available _roles_ are `PeerAdmin` and `ChannelAdmin`.
 
-To create the ID card file, compress the connection profile, metadata file, and optionally a credentials file, then modify the file type to `.card`.
+To create the ID card file, compress the connection profile, metadata file, and optionally a credentials directory, then modify the file type to `.card`.
 
 This ID card can now be imported using the {{site.data.conrefs.composer_full}} Playground.
 
@@ -103,6 +103,9 @@ Importing and exporting ID cards is the simplest way to grant access to other us
 
 2. On the **My Wallet** page, click the **Export** icon on the ID card you wish to export. The ID card should download as a `.card` file.
 
+_Please note_: If you export an ID card that has never been used, for example to send to a new participant, it will contain the enrollment ID and enrollment secret required to obtain the certificate and public key which are then used to identify participants. Alternatively, if you export an ID card that has been used before, it will already contain the certificate and public key.
+
+**Important**: Exported identity cards should be handled with care since they contain unprotected credentials. For example, you should never send identity cards via email or other unencrypted means of communication.
 
 ### Importing ID Cards
 


### PR DESCRIPTION
Ensure exported identity cards include certificates and private
keys when they are available.

Also includes some refactoring to simplify how cards are activated
and minimise the time that credentials are kept in the browser.

Completes #1427

Signed-off-by: James Taylor <jamest@uk.ibm.com>