### PR TITLE
close the slider tray upon BN update action

### DIFF
--- a/packages/composer-playground/src/app/editor/editor.component.ts
+++ b/packages/composer-playground/src/app/editor/editor.component.ts
@@ -385,9 +385,6 @@ export class EditorComponent implements OnInit, OnDestroy {
     openImportModal() {
         const importModalRef = this.drawerService.open(UpdateComponent);
         importModalRef.componentInstance.finishedSampleImport.subscribe((result) => {
-
-            importModalRef.close();
-
             if (result.deployed) {
                 this.updatePackageInfo();
                 this.updateFiles();

--- a/packages/composer-playground/src/app/import/update.component.spec.ts
+++ b/packages/composer-playground/src/app/import/update.component.spec.ts
@@ -15,6 +15,7 @@ import { SampleBusinessNetworkService } from '../services/samplebusinessnetwork.
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { AlertService } from '../basic-modals/alert.service';
 import { UpdateComponent } from './update.component';
+import { ActiveDrawer } from '../common/drawer';
 
 import * as sinon from 'sinon';
 import * as chai from 'chai';
@@ -105,7 +106,8 @@ describe('UpdateComponent', () => {
                 {provide: AdminService, useValue: mockAdminService},
                 {provide: ClientService, useValue: mockClientService},
                 {provide: AlertService, useValue: mockAlertService},
-                {provide: NgbModal, useValue: mockNgbModal}
+                {provide: NgbModal, useValue: mockNgbModal},
+                ActiveDrawer
             ],
         });
 
@@ -431,6 +433,26 @@ describe('UpdateComponent', () => {
             component['deployInProgress'].should.equal(false);
             finishedSampleImportSpy.should.have.been.calledWith({deployed: false, error: 'some error'});
             mockAlertService.errorStatus$.next.should.have.been.calledWith('some error');
+        }));
+
+        it('should close the tray', fakeAsync(() => {
+            component['currentBusinessNetwork'] = {network: 'my network'};
+            let traySpy = sinon.spy(component['activeDrawer'], 'close');
+
+            mockNgbModal.open = sinon.stub().returns({
+                componentInstance: {},
+                result: Promise.resolve(false)
+            });
+
+            component.finishedSampleImport.subscribe((result) => {
+                result.should.deep.equal({deployed: false});
+            });
+
+            component.deploy();
+
+            tick();
+
+            traySpy.should.have.been.called;
         }));
     });
 

--- a/packages/composer-playground/src/app/import/update.component.ts
+++ b/packages/composer-playground/src/app/import/update.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
+import { ActiveDrawer } from '../common/drawer';
 import { ClientService } from '../services/client.service';
 import { SampleBusinessNetworkService } from '../services/samplebusinessnetwork.service';
 import { AlertService } from '../basic-modals/alert.service';
@@ -17,7 +18,8 @@ export class UpdateComponent extends ImportComponent {
     constructor(protected clientService: ClientService,
                 protected modalService: NgbModal,
                 protected sampleBusinessNetworkService: SampleBusinessNetworkService,
-                protected alertService: AlertService) {
+                protected alertService: AlertService,
+                protected activeDrawer: ActiveDrawer ) {
         super(clientService, modalService, sampleBusinessNetworkService, alertService);
     }
 
@@ -28,7 +30,8 @@ export class UpdateComponent extends ImportComponent {
 
     deploy() {
         let deployed: boolean = true;
-
+        // close the draw as we no longer need it
+        this.activeDrawer.close();
         const confirmModalRef = this.modalService.open(ReplaceComponent);
         confirmModalRef.componentInstance.mainMessage = 'Your Business Network Definition currently in the Playground will be removed & replaced.';
         confirmModalRef.componentInstance.supplementaryMessage = 'Please ensure that you have exported any current model files in the Playground.';


### PR DESCRIPTION
Nitpick item 16 from #1930 

## Design of the fix
Pass in reference to the active draw and close it during the deploy action

## Validation of the fix
Eyeballed on browsers, new test added

## Automated Tests
test++

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
