### PR TITLE
Keep identity cards a uniform size irrespective of their different

### DIFF
--- a/packages/composer-playground/src/app/login/identity-card/identity-card.component.html
+++ b/packages/composer-playground/src/app/login/identity-card/identity-card.component.html
@@ -10,23 +10,22 @@
     <section class="user-details">
         <div class="image-placeholder">
             <span class="initials">{{getInitials()}}</span>
-            <div class="role-icon" *ngIf="identity.getRoles().length > 0">
+            <div class="role-icon" title="{{getRoles()}}" *ngIf="getRoles()">
                 <svg class="ibm-icon vertical-top">
                     <use xlink:href="#icon-tool"></use>
                 </svg>
             </div>
         </div>
         <div class="user-name">{{identity.getName()}}</div>
-        <span *ngFor="let role of identity.getRoles() last as lastRole">{{role}}{{lastRole ? '': ', '}}</span>
     </section>
     <section *ngIf="!preview" class="actions">
-        <button *ngIf="!indestructible" type="button" class="action circular delete"
+        <button [disabled]="indestructible" type="button" class="action circular delete"
                 (click)="delete()">
             <svg class="ibm-icon vertical-top" aria-hidden="true">
                 <use xlink:href="#icon-trash_32"></use>
             </svg>
         </button>
-        <button *ngIf="'web' !== identity.getConnectionProfile().type" type="button" class="action circular export"
+        <button [disabled]="'web' === identity.getConnectionProfile().type" type="button" class="action circular export"
                 (click)="export()">
             <svg class="ibm-icon vertical-top" aria-hidden="true">
                 <use xlink:href="#icon-download_32"></use>
@@ -37,12 +36,12 @@
         <h3>Connection Profile</h3>
         <p>{{identity.getConnectionProfile().name}}</p>
     </section>
-    <section class="business-network-details" *ngIf="identity.getBusinessNetworkName()">
+    <section class="business-network-details">
         <h3>Business Network</h3>
-        <p title="{{identity.getBusinessNetworkName()}}">{{identity.getBusinessNetworkName()}}</p>
+        <p [class.none]="!identity.getBusinessNetworkName()" title="{{identity.getBusinessNetworkName() || 'none'}}">{{identity.getBusinessNetworkName() || 'none'}}</p>
     </section>
     <footer>
-        <button *ngIf="!preview && identity.getBusinessNetworkName()" type="button" class="action connect"
+        <button *ngIf="!preview" [disabled]="!identity.getBusinessNetworkName()" type="button" class="action connect"
                 (click)="connect()">
             <span>Connect now</span>
             <svg class="ibm-icon" aria-hidden="true">

--- a/packages/composer-playground/src/app/login/identity-card/identity-card.component.scss
+++ b/packages/composer-playground/src/app/login/identity-card/identity-card.component.scss
@@ -53,10 +53,22 @@
                     margin-right: $space-smedium;
                 }
 
-                svg {
+                svg.ibm-icon {
                     // why is the align-self required for Safari?!
                     align-self: center;
                     fill: $second-highlight;
+                }
+
+                &.action[disabled],
+                &.action[disabled]:active,
+                &.action[disabled]:focus {
+                    span {
+                        color: $fifth-highlight;
+                    }
+
+                    svg.ibm-icon {
+                        fill: $fifth-highlight;
+                    }
                 }
             }
         }
@@ -65,7 +77,6 @@
             padding-top: $space-large;
             text-align: center;
             font-size: 0.9em;
-            height: 170px;
 
             .user-name {
                 font-weight: 600;
@@ -137,6 +148,10 @@
             p {
                 text-overflow: ellipsis;
                 overflow: hidden;
+
+                &.none {
+                    color: $fifth-highlight;
+                }
             }
         }
     }

--- a/packages/composer-playground/src/app/login/identity-card/identity-card.component.spec.ts
+++ b/packages/composer-playground/src/app/login/identity-card/identity-card.component.spec.ts
@@ -145,4 +145,42 @@ describe(`IdentityCardComponent`, () => {
             result.should.equal(':)');
         });
     });
+
+    describe('#getRoles', () => {
+        it('should get PeerAdmin role', () => {
+            mockIdCard.getRoles.returns(['PeerAdmin']);
+            component.identity = mockIdCard;
+
+            let result = component.getRoles();
+
+            result.should.deep.equal('PeerAdmin');
+        });
+
+        it('should get ChannelAdmin role', () => {
+            mockIdCard.getRoles.returns(['ChannelAdmin']);
+            component.identity = mockIdCard;
+
+            let result = component.getRoles();
+
+            result.should.deep.equal('ChannelAdmin');
+        });
+
+        it('should not get other roles', () => {
+            mockIdCard.getRoles.returns(['GreenConga']);
+            component.identity = mockIdCard;
+
+            let result = component.getRoles();
+
+            should.not.exist(result);
+        });
+
+        it('should get valid roles as comma separated string', () => {
+            mockIdCard.getRoles.returns(['BlueConga', 'PeerAdmin', 'GreenConga', 'ChannelAdmin', 'PurpleConga']);
+            component.identity = mockIdCard;
+
+            let result = component.getRoles();
+
+            result.should.deep.equal('PeerAdmin, ChannelAdmin');
+        });
+    });
 });

--- a/packages/composer-playground/src/app/login/identity-card/identity-card.component.ts
+++ b/packages/composer-playground/src/app/login/identity-card/identity-card.component.ts
@@ -61,4 +61,12 @@ export class IdentityCardComponent {
 
         return result ? result : ':)';
     }
+
+    getRoles(): string {
+        let adminRoles: string[] = this.identity.getRoles().filter((word) => word === 'PeerAdmin' || word === 'ChannelAdmin');
+
+        if (adminRoles.length > 0) {
+            return adminRoles.join(', ');
+        }
+    }
 }

--- a/packages/composer-playground/src/assets/styles/elements/_button.scss
+++ b/packages/composer-playground/src/assets/styles/elements/_button.scss
@@ -195,12 +195,21 @@
             box-sizing: border-box;
             padding-top: 1px;
             height: 42px;
-        }
 
-        &.action.circular:hover,
-        &.action.circular:focus {
-            background-color: $fourth-highlight;
-            border-bottom: 2px solid transparent;
+            &:hover,
+            &:focus {
+                background-color: $fourth-highlight;
+                border-bottom: 2px solid transparent;
+            }
+
+            &[disabled], &[disabled]:hover, &[disabled]:focus {
+                background-color: transparent;
+                border-bottom: 2px solid transparent;
+
+                svg.ibm-icon {
+                    fill: $fifth-highlight;
+                }
+            }
         }
 
         &.icon {

--- a/packages/composer-playground/src/assets/svg/other/tool.svg
+++ b/packages/composer-playground/src/assets/svg/other/tool.svg
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="10px" height="10px" viewBox="0 0 10 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 46.1 (44463) - http://www.bohemiancoding.com/sketch -->
-    <title>Tool</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">


### PR DESCRIPTION
capabilities.

Instead of completely hiding portions of the identity card, this fix
disables any elements which are not applicable.

Contributes to #1930

Signed-off-by: James Taylor <jamest@uk.ibm.com>