### PR TITLE
Split REST server security option into authentication and multiuser options

### DIFF
--- a/packages/composer-rest-server/cli.js
+++ b/packages/composer-rest-server/cli.js
@@ -38,7 +38,8 @@ const yargs = require('yargs')
     .option('s', { alias: 'enrollSecret', describe: 'The enrollment secret of the user', type: 'string', default: process.env.COMPOSER_ENROLLMENT_SECRET })
     .option('N', { alias: 'namespaces', describe: 'Use namespaces if conflicting types exist', type: 'string', default: process.env.COMPOSER_NAMESPACES || 'always', choices: ['always', 'required', 'never'] })
     .option('P', { alias: 'port', describe: 'The port to serve the REST API on', type: 'number', default: process.env.COMPOSER_PORT || undefined })
-    .option('S', { alias: 'security', describe: 'Enable security for the REST API', type: 'boolean', default: process.env.COMPOSER_SECURITY || false })
+    .option('a', { alias: 'authentication', describe: 'Enable authentication for the REST API using Passport', type: 'boolean', default: process.env.COMPOSER_AUTHENTICATION || false })
+    .option('m', { alias: 'multiuser', describe: 'Enable multiple user and identity management using wallets (implies -a)', type: 'boolean', default: process.env.COMPOSER_MULTIUSER || false })
     .option('w', { alias: 'websockets', describe: 'Enable event publication over WebSockets', type: 'boolean', default: process.env.COMPOSER_WEBSOCKETS || true })
     .option('t', { alias: 'tls', describe: 'Enable TLS security for the REST API', type: 'boolean', default: process.env.COMPOSER_TLS || false })
     .option('c', { alias: 'tlscert', describe: 'File containing the TLS certificate', type: 'string', default: process.env.COMPOSER_TLS_CERTIFICATE || defaultTlsCertificate })
@@ -76,7 +77,8 @@ if (interactive) {
                 participantId: answers.userid,
                 participantPwd: answers.secret,
                 namespaces: answers.namespaces,
-                security: answers.security,
+                authentication: answers.authentication,
+                multiuser: answers.multiuser,
                 websockets: answers.websockets,
                 tls: answers.tls,
                 tlscert: answers.tlscert,
@@ -91,7 +93,8 @@ if (interactive) {
                 '-s': 'participantPwd',
                 '-N': 'namespaces',
                 '-P': 'port',
-                '-S': 'security',
+                '-a': 'authentication',
+                '-m': 'multiuser',
                 '-w': 'websockets',
                 '-t': 'tls',
                 '-c': 'tlscert',
@@ -109,6 +112,12 @@ if (interactive) {
         });
 
 } else {
+
+    // if -m (multiuser) was specified, it implies -a (authentication)
+    if (yargs.m) {
+        yargs.a = true;
+    }
+
     // make sure we have args for all required parms otherwise error
     if (yargs.p === undefined || yargs.n === undefined || yargs.i === undefined || yargs.s === undefined) {
         promise = Promise.reject('Missing parameter. Please run composer-rest-server -h to see usage details');
@@ -120,7 +129,8 @@ if (interactive) {
             participantPwd: yargs.s,
             namespaces: yargs.N,
             port: yargs.P,
-            security: yargs.S,
+            authentication: yargs.a,
+            multiuser: yargs.m,
             websockets: yargs.w,
             tls: yargs.t,
             tlscert: yargs.c,

--- a/packages/composer-rest-server/common/models/wallet.js
+++ b/packages/composer-rest-server/common/models/wallet.js
@@ -17,7 +17,21 @@
 module.exports = function (Wallet) {
 
     // Disable all undesired methods.
-    const whitelist = [ 'create', 'deleteById', 'find', 'findById', 'exists', 'replaceById' ];
+    const whitelist = [
+        'create',
+        'deleteById',
+        'find',
+        'findById',
+        'exists',
+        'replaceById',
+        'prototype.__get__identities',
+        'prototype.__findById__identities',
+        'prototype.__create__identities',
+        'prototype.__updateById__identities',
+        'prototype.__destroyById__identities',
+        'setDefaultWallet',
+        'setDefaultIdentity'
+    ];
     Wallet.sharedClass.methods().forEach((method) => {
         const name = (method.isStatic ? '' : 'prototype.') + method.name;
         if (whitelist.indexOf(name) === -1) {

--- a/packages/composer-rest-server/lib/util.js
+++ b/packages/composer-rest-server/lib/util.js
@@ -94,10 +94,19 @@ class Util {
                 default: 'always'
             },
             {
-                name: 'security',
+                name: 'authentication',
                 type: 'confirm',
-                message: 'Specify if you want the generated REST API to be secured:',
+                message: 'Specify if you want to enable authentication for the REST API using Passport:',
                 default: false
+            },
+            {
+                name: 'multiuser',
+                type: 'confirm',
+                message: 'Specify if you want to enable multiple user and identity management using wallets:',
+                default: false,
+                when: (answers) => {
+                    return answers.authentication;
+                }
             },
             {
                 name: 'websockets',

--- a/packages/composer-rest-server/package.json
+++ b/packages/composer-rest-server/package.json
@@ -70,10 +70,11 @@
     "composer-connector-embedded": "0.12.0",
     "eslint": "^3.17.1",
     "jsdoc": "^3.4.3",
+    "ldapjs": "^1.0.1",
     "license-check": "^1.1.5",
     "mocha": "^3.4.2",
     "nyc": "^11.1.0",
-    "passport-github2": "^0.1.10",
+    "passport-ldapauth": "^2.0.0",
     "proxyquire": "^1.7.11",
     "sinon": "^2.3.8",
     "sleep-promise": "^2.0.0"

--- a/packages/composer-rest-server/server/boot/authentication.js
+++ b/packages/composer-rest-server/server/boot/authentication.js
@@ -16,13 +16,13 @@
 
 module.exports = function (app) {
 
-    // Enable authentication if the security option has been specified.
+    // Enable authentication if the authentication option has been specified.
     const composer = app.get('composer');
     if (!composer) {
         return;
     }
-    const security = !!composer.security;
-    if (security) {
+    const authentication = !!composer.authentication;
+    if (authentication) {
         app.enableAuth();
     }
 

--- a/packages/composer-rest-server/server/boot/composer-discovery.js
+++ b/packages/composer-rest-server/server/boot/composer-discovery.js
@@ -80,6 +80,7 @@ function createDataSource(app, composer) {
         participantId: composer.participantId,
         participantPwd: composer.participantPwd,
         namespaces: composer.namespaces,
+        multiuser: composer.multiuser,
         fs: composer.fs,
         wallet: composer.wallet
     };

--- a/packages/composer-rest-server/server/boot/composer-runtime.js
+++ b/packages/composer-rest-server/server/boot/composer-runtime.js
@@ -24,9 +24,9 @@ module.exports = function (app) {
         return;
     }
 
-    // We only need to enable thhis code if security has been enabled.
-    const security = !!composer.security;
-    if (!security) {
+    // We only need to enable this code if the multiple user option has been specified.
+    const multiuser = !!composer.multiuser;
+    if (!multiuser) {
         return;
     }
 

--- a/packages/composer-rest-server/server/composer.json
+++ b/packages/composer-rest-server/server/composer.json
@@ -5,5 +5,10 @@
     "participantPwd": "adminpw",
     "namespaces": "always",
     "port": 3000,
-    "security": true
+    "authentication": false,
+    "multiuser": false,
+    "websockets": true,
+    "tls": false,
+    "tlscert": "/path/to/cert.pem",
+    "tlskey": "/path/to/key.pem"
 }

--- a/packages/composer-rest-server/server/server.js
+++ b/packages/composer-rest-server/server/server.js
@@ -41,10 +41,10 @@ module.exports = function (composer) {
         app.set('composer', composer);
 
         // Load the model-config.json file; we want to make the visibility of the wallet
-        // model dependent on whether or not security is enabled.
+        // model dependent on whether or not the multiple user option has been specified.
         const models = require('./model-config.json');
-        const security = !!composer.security;
-        models.Wallet.public = security;
+        const multiuser = !!composer.multiuser;
+        models.Wallet.public = multiuser;
 
         // Allow environment variable overrides for the datasources.json file.
         let dataSources = require('./datasources.json');
@@ -92,9 +92,9 @@ module.exports = function (composer) {
             extended: true,
         }));
 
-        // The following configuration is only required if security is enabled.
-        const security = !!composer.security;
-        if (security) {
+        // The following configuration is only required if the authentication option has been specified.
+        const authentication = !!composer.authentication;
+        if (authentication) {
 
             // Enable the use of access tokens to identify users.
             app.middleware('auth', loopback.token({

--- a/packages/composer-rest-server/test/authentication.js
+++ b/packages/composer-rest-server/test/authentication.js
@@ -1,0 +1,206 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const AdminConnection = require('composer-admin').AdminConnection;
+const BrowserFS = require('browserfs/dist/node/index');
+const BusinessNetworkDefinition = require('composer-common').BusinessNetworkDefinition;
+require('loopback-component-passport');
+const ldapserver = require('./ldapserver');
+const server = require('../server/server');
+
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-http'));
+
+const bfs_fs = BrowserFS.BFSRequire('fs');
+
+describe('Authentication REST API unit tests', () => {
+
+    let app;
+
+    before(() => {
+        BrowserFS.initialize(new BrowserFS.FileSystem.InMemory());
+        const adminConnection = new AdminConnection({ fs: bfs_fs });
+        return adminConnection.createProfile('defaultProfile', {
+            type : 'embedded'
+        })
+        .then(() => {
+            return adminConnection.connect('defaultProfile', 'admin', 'Xurw3yU9zI0l');
+        })
+        .then(() => {
+            return BusinessNetworkDefinition.fromDirectory('./test/data/bond-network');
+        })
+        .then((businessNetworkDefinition) => {
+            return adminConnection.deploy(businessNetworkDefinition);
+        })
+        .then(() => {
+            return ldapserver.start();
+        })
+        .then((ldapport) => {
+            process.env.COMPOSER_PROVIDERS = JSON.stringify({
+                ldap: {
+                    provider: 'ldap',
+                    module: 'passport-ldapauth',
+                    authPath: '/auth/ldap',
+                    callbackURL: '/auth/ldap/callback',
+                    successRedirect: '/?success=true',
+                    failureRedirect: '/?failure=true',
+                    authScheme: 'ldap',
+                    server: {
+                        url: `ldap://localhost:${ldapport}`,
+                        bindDN: 'cn=root,dc=example,dc=org',
+                        bindCredentials: 'secret',
+                        searchBase: 'dc=example,dc=org',
+                        searchFilter: '(uid={{username}})'
+                    }
+                }
+            });
+            return server({
+                connectionProfileName: 'defaultProfile',
+                businessNetworkIdentifier: 'bond-network',
+                participantId: 'admin',
+                participantPwd: 'adminpw',
+                fs: bfs_fs,
+                namespaces: 'never',
+                authentication: true
+            });
+        })
+        .then((result) => {
+            app = result.app;
+        });
+    });
+
+    after(() => {
+        ldapserver.close();
+        delete process.env.COMPOSER_PROVIDERS;
+    });
+
+    describe('POST /auth/ldap', () => {
+
+        it('should authenticate to the endpoint with invalid credentials and not get an access token', () => {
+            const agent = chai.request.agent(app);
+            return agent
+                .post('/auth/ldap')
+                .send({ username: 'alice', password: 'invalid' })
+                .then((res) => {
+                    res.redirects.should.have.lengthOf(1);
+                    res.redirects[0].should.match(/\/?failure=true$/);
+                    res.req.should.not.have.cookie('access_token');
+                });
+        });
+
+        it('should authenticate to the endpoint with valid credentials and get an access token', () => {
+            const agent = chai.request.agent(app);
+            return agent
+                .post('/auth/ldap')
+                .send({ username: 'alice', password: 'secret' })
+                .then((res) => {
+                    res.redirects.should.have.lengthOf(1);
+                    res.redirects[0].should.match(/\/?success=true$/);
+                    res.req.should.have.cookie('access_token');
+                });
+        });
+
+    });
+
+    describe('GET /api/system/ping', () => {
+
+        it('should return 401 Unauthorized if not authenticated', () => {
+            return chai.request(app)
+                .get('/api/system/ping')
+                .then(() => {
+                    throw new Error('should not get here');
+                })
+                .catch((err) => {
+                    err.response.should.have.status(401);
+                });
+        });
+
+        it('should return 200 OK if authenticated', () => {
+            const agent = chai.request.agent(app);
+            return agent
+                .post('/auth/ldap')
+                .send({ username: 'alice', password: 'secret' })
+                .then((res) => {
+                    return agent.get('/api/system/ping');
+                })
+                .then((res) => {
+                    res.should.have.status(200);
+                    res.should.be.json;
+                });
+        });
+
+    });
+
+    describe('GET /api/BondAsset', () => {
+
+        it('should return 401 Unauthorized if not authenticated', () => {
+            return chai.request(app)
+                .get('/api/BondAsset')
+                .then(() => {
+                    throw new Error('should not get here');
+                })
+                .catch((err) => {
+                    err.response.should.have.status(401);
+                });
+        });
+
+        it('should return 200 OK if authenticated', () => {
+            const agent = chai.request.agent(app);
+            return agent
+                .post('/auth/ldap')
+                .send({ username: 'alice', password: 'secret' })
+                .then((res) => {
+                    return agent.get('/api/BondAsset');
+                })
+                .then((res) => {
+                    res.should.have.status(200);
+                    res.should.be.json;
+                });
+        });
+
+    });
+
+    describe('GET /api/Member', () => {
+
+        it('should return 401 Unauthorized if not authenticated', () => {
+            return chai.request(app)
+                .get('/api/Member')
+                .then(() => {
+                    throw new Error('should not get here');
+                })
+                .catch((err) => {
+                    err.response.should.have.status(401);
+                });
+        });
+
+        it('should return 200 OK if authenticated', () => {
+            const agent = chai.request.agent(app);
+            return agent
+                .post('/auth/ldap')
+                .send({ username: 'alice', password: 'secret' })
+                .then((res) => {
+                    return agent.get('/api/Member');
+                })
+                .then((res) => {
+                    res.should.have.status(200);
+                    res.should.be.json;
+                });
+        });
+
+    });
+
+});

--- a/packages/composer-rest-server/test/cli.js
+++ b/packages/composer-rest-server/test/cli.js
@@ -36,7 +36,7 @@ describe('composer-rest-server CLI unit tests', () => {
             userid: 'admin',
             secret: 'adminpw',
             namespaces: 'always',
-            security: false,
+            authentication: false,
             websockets: true,
             tls: false
         });
@@ -93,7 +93,8 @@ describe('composer-rest-server CLI unit tests', () => {
                 namespaces: 'always',
                 participantId: 'admin',
                 participantPwd: 'adminpw',
-                security: false,
+                authentication: false,
+                multiuser: undefined,
                 websockets: true,
                 tls: false,
                 tlscert: undefined,
@@ -132,7 +133,7 @@ describe('composer-rest-server CLI unit tests', () => {
         });
     });
 
-    it('should use the argumemts from yargs and start the server', () => {
+    it('should use the arguments from yargs and start the server', () => {
         let listen = sinon.stub();
         let get = sinon.stub();
         get.withArgs('port').returns(3000);
@@ -167,7 +168,108 @@ describe('composer-rest-server CLI unit tests', () => {
                 participantId: 'admin',
                 participantPwd: 'adminpw',
                 port: undefined,
-                security: false,
+                authentication: false,
+                multiuser: false,
+                websockets: true,
+                tls: false,
+                tlscert: defaultTlsCertificate,
+                tlskey: defaultTlsKey
+            };
+            sinon.assert.calledWith(server, settings);
+            sinon.assert.calledOnce(listen);
+            listen.args[0][0].should.equal(3000);
+            listen.args[0][1].should.be.a('function');
+        });
+    });
+
+    it('should not enable multiuser if authentication specified', () => {
+        let listen = sinon.stub();
+        let get = sinon.stub();
+        get.withArgs('port').returns(3000);
+        process.argv = [
+            process.argv0, 'cli.js',
+            '-p', 'defaultProfile',
+            '-n', 'org-acme-biznet',
+            '-i', 'admin',
+            '-s', 'adminpw',
+            '-a'
+        ];
+        delete require.cache[require.resolve('yargs')];
+        const server = sinon.stub().resolves({
+            app: {
+                get
+            },
+            server: {
+                listen
+            }
+        });
+        return proxyquire('../cli', {
+            clear: () => { },
+            chalk: {
+                yellow: () => { return ''; }
+            },
+            './server/server': server
+        }).then(() => {
+            sinon.assert.notCalled(Util.getConnectionSettings);
+            const settings = {
+                businessNetworkIdentifier: 'org-acme-biznet',
+                connectionProfileName: 'defaultProfile',
+                namespaces: 'always',
+                participantId: 'admin',
+                participantPwd: 'adminpw',
+                port: undefined,
+                authentication: true,
+                multiuser: false,
+                websockets: true,
+                tls: false,
+                tlscert: defaultTlsCertificate,
+                tlskey: defaultTlsKey
+            };
+            sinon.assert.calledWith(server, settings);
+            sinon.assert.calledOnce(listen);
+            listen.args[0][0].should.equal(3000);
+            listen.args[0][1].should.be.a('function');
+        });
+    });
+
+    it('should automatically enable authentication if multiuser specified', () => {
+        let listen = sinon.stub();
+        let get = sinon.stub();
+        get.withArgs('port').returns(3000);
+        process.argv = [
+            process.argv0, 'cli.js',
+            '-p', 'defaultProfile',
+            '-n', 'org-acme-biznet',
+            '-i', 'admin',
+            '-s', 'adminpw',
+            '-m'
+        ];
+        delete require.cache[require.resolve('yargs')];
+        const server = sinon.stub().resolves({
+            app: {
+                get
+            },
+            server: {
+                listen
+            }
+        });
+        return proxyquire('../cli', {
+            clear: () => { },
+            chalk: {
+                yellow: () => { return ''; }
+            },
+            './server/server': server
+        }).then(() => {
+            sinon.assert.notCalled(Util.getConnectionSettings);
+            const settings = {
+                businessNetworkIdentifier: 'org-acme-biznet',
+                connectionProfileName: 'defaultProfile',
+                namespaces: 'always',
+                participantId: 'admin',
+                participantPwd: 'adminpw',
+                port: undefined,
+                authentication: true,
+                multiuser: true,
                 websockets: true,
                 tls: false,
                 tlscert: defaultTlsCertificate,

--- a/packages/composer-rest-server/test/data/bond-network/permissions.acl
+++ b/packages/composer-rest-server/test/data/bond-network/permissions.acl
@@ -6,7 +6,7 @@ rule Issuer {
     participant(i): "org.acme.bond.Issuer"
     operation: ALL
     resource(a): "org.acme.bond.BondAsset"
-    condition: (a.bond.issuer.memberId === i.memberId) 
+    condition: (a.bond.issuer.memberId === i.memberId)
     action: ALLOW
 }
 
@@ -15,5 +15,13 @@ rule Default {
     participant: "org.acme.bond.*"
     operation: ALL
     resource: "org.acme.bond.*"
+    action: ALLOW
+}
+
+rule SystemACL {
+    description: "Allow read access"
+    participant: "org.acme.bond.*"
+    operation: ALL
+    resource: "org.hyperledger.composer.system.*"
     action: ALLOW
 }

--- a/packages/composer-rest-server/test/ldapserver.js
+++ b/packages/composer-rest-server/test/ldapserver.js
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const ldap = require('ldapjs');
+
+const authorize = function (req, res, next) {
+    return next();
+};
+
+const SUFFIX = 'dc=example, dc=org';
+let server = null;
+
+const db = {
+    alice: {
+        dn: 'cn=alice, dc=example, dc=org',
+        attributes:  {
+            uid: 'alice',
+            name: 'Alice',
+            mail: 'alice@example.org'
+        }
+    }
+};
+
+exports.start = function () {
+    if (server) {
+        return Promise.resolve();
+    }
+
+    server = ldap.createServer();
+
+    server.bind('cn=root, dc=example, dc=org', function(req, res, next) {
+        if (req.dn.toString() !== 'cn=root, dc=example, dc=org' || req.credentials !== 'secret') {
+            return next(new ldap.InvalidCredentialsError());
+        }
+        res.end();
+        return next();
+    });
+
+    server.bind(SUFFIX, authorize, function(req, res, next) {
+        let dn = req.dn.toString();
+        if (dn !== 'cn=alice, dc=example, dc=org' || req.credentials !== 'secret') {
+            return next(new ldap.InvalidCredentialsError());
+        }
+        res.end();
+        return next();
+    });
+
+    server.search(SUFFIX, authorize, function(req, res, next) {
+        if (req.filter.attribute === 'uid' && req.filter.value === 'alice') {
+            res.send(db.alice);
+        }
+        res.end();
+        return next();
+    });
+
+    return new Promise((resolve, reject) => {
+        server.listen(0, (error) => {
+            if (error) {
+                return reject(error);
+            }
+            resolve(server.address().port);
+        });
+    });
+};
+
+exports.close = function () {
+    if (server) {
+        server.close();
+        server = null;
+    }
+};

--- a/packages/composer-rest-server/test/lib/util.js
+++ b/packages/composer-rest-server/test/lib/util.js
@@ -44,7 +44,7 @@ describe('Util', () => {
                     const names = questions.map((question) => {
                         return question.name;
                     });
-                    names.should.deep.equal(['profilename', 'businessNetworkId', 'userid', 'secret', 'namespaces', 'security', 'websockets', 'tls', 'tlscert', 'tlskey']);
+                    names.should.deep.equal(['profilename', 'businessNetworkId', 'userid', 'secret', 'namespaces', 'authentication', 'multiuser', 'websockets', 'tls', 'tlscert', 'tlskey']);
                 });
         });
 
@@ -97,6 +97,19 @@ describe('Util', () => {
                     });
                     question.validate('').should.match(/Please enter/);
                     question.validate('adminpw').should.be.true;
+                });
+        });
+
+        it('should only enable the multiuser question if TLS enabled', () => {
+            return Util.getConnectionSettings()
+                .then(() => {
+                    sinon.assert.calledOnce(inquirer.prompt);
+                    const questions = inquirer.prompt.args[0][0]; // First call, first argument.
+                    const question = questions.find((question) => {
+                        return question.name === 'multiuser';
+                    });
+                    question.when({ authentication: false }).should.be.false;
+                    question.when({ authentication: true }).should.be.true;
                 });
         });
 

--- a/packages/composer-rest-server/test/multiuser.js
+++ b/packages/composer-rest-server/test/multiuser.js
@@ -1,0 +1,269 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const AdminConnection = require('composer-admin').AdminConnection;
+const BrowserFS = require('browserfs/dist/node/index');
+const BusinessNetworkConnection = require('composer-client').BusinessNetworkConnection;
+const BusinessNetworkDefinition = require('composer-common').BusinessNetworkDefinition;
+require('loopback-component-passport');
+const ldapserver = require('./ldapserver');
+const server = require('../server/server');
+
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-http'));
+
+const bfs_fs = BrowserFS.BFSRequire('fs');
+
+describe('Multiple user REST API unit tests', () => {
+
+    const participantData = [{
+        $class: 'org.acme.bond.Member',
+        memberId: 'MEMBER_1',
+        name: 'Alice'
+    }, {
+        $class: 'org.acme.bond.Member',
+        memberId: 'MEMBER_2',
+        name: 'Bob'
+    }, {
+        $class: 'org.acme.bond.Issuer',
+        memberId: 'ISSUER_1',
+        name: 'Charlie'
+    }, {
+        $class: 'org.acme.bond.Issuer',
+        memberId: 'ISSUER_2',
+        name: 'Dave'
+    }];
+
+    let app;
+    let businessNetworkConnection;
+    let participantRegistry;
+    let serializer;
+    let aliceIdentity;
+    let bobIdentity;
+
+    before(() => {
+        BrowserFS.initialize(new BrowserFS.FileSystem.InMemory());
+        const adminConnection = new AdminConnection({ fs: bfs_fs });
+        return adminConnection.createProfile('defaultProfile', {
+            type : 'embedded'
+        })
+        .then(() => {
+            return adminConnection.connect('defaultProfile', 'admin', 'Xurw3yU9zI0l');
+        })
+        .then(() => {
+            return BusinessNetworkDefinition.fromDirectory('./test/data/bond-network');
+        })
+        .then((businessNetworkDefinition) => {
+            serializer = businessNetworkDefinition.getSerializer();
+            return adminConnection.deploy(businessNetworkDefinition);
+        })
+        .then(() => {
+            return ldapserver.start();
+        })
+        .then((ldapport) => {
+            process.env.COMPOSER_PROVIDERS = JSON.stringify({
+                ldap: {
+                    provider: 'ldap',
+                    module: 'passport-ldapauth',
+                    authPath: '/auth/ldap',
+                    callbackURL: '/auth/ldap/callback',
+                    successRedirect: '/?success=true',
+                    failureRedirect: '/?failure=true',
+                    authScheme: 'ldap',
+                    server: {
+                        url: `ldap://localhost:${ldapport}`,
+                        bindDN: 'cn=root,dc=example,dc=org',
+                        bindCredentials: 'secret',
+                        searchBase: 'dc=example,dc=org',
+                        searchFilter: '(uid={{username}})'
+                    }
+                }
+            });
+            return server({
+                connectionProfileName: 'defaultProfile',
+                businessNetworkIdentifier: 'bond-network',
+                participantId: 'admin',
+                participantPwd: 'adminpw',
+                fs: bfs_fs,
+                namespaces: 'never',
+                authentication: true,
+                multiuser: true
+            });
+        })
+        .then((result) => {
+            app = result.app;
+            businessNetworkConnection = new BusinessNetworkConnection({ fs: bfs_fs });
+            return businessNetworkConnection.connect('defaultProfile', 'bond-network', 'admin', 'Xurw3yU9zI0l');
+        })
+        .then(() => {
+            return businessNetworkConnection.getParticipantRegistry('org.acme.bond.Member');
+        })
+        .then((participantRegistry_) => {
+            participantRegistry = participantRegistry_;
+            return participantRegistry.addAll([
+                serializer.fromJSON(participantData[0]),
+                serializer.fromJSON(participantData[1])
+            ]);
+        })
+        .then(() => {
+            return businessNetworkConnection.getParticipantRegistry('org.acme.bond.Issuer');
+        })
+        .then((participantRegistry_) => {
+            participantRegistry = participantRegistry_;
+            return participantRegistry.addAll([
+                serializer.fromJSON(participantData[2]),
+                serializer.fromJSON(participantData[3])
+            ]);
+        })
+        .then(() => {
+            return businessNetworkConnection.issueIdentity('org.acme.bond.Member#MEMBER_1', 'alice1', { issuer: true });
+        })
+        .then((aliceIdentity_) => {
+            aliceIdentity = aliceIdentity_;
+            return businessNetworkConnection.issueIdentity('org.acme.bond.Member#MEMBER_2', 'bob1', { issuer: true });
+        })
+        .then((bobIdentity_) => {
+            bobIdentity = bobIdentity_;
+        });
+    });
+
+    after(() => {
+        ldapserver.close();
+        delete process.env.COMPOSER_PROVIDERS;
+    });
+
+    describe('GET /api/system/ping', () => {
+
+        it('should return 401 Unauthorized if not authenticated', () => {
+            return chai.request(app)
+                .get('/api/system/ping')
+                .then(() => {
+                    throw new Error('should not get here');
+                })
+                .catch((err) => {
+                    err.response.should.have.status(401);
+                });
+        });
+
+        it('should return 400 Bad Request if authenticated but no identities in wallet', () => {
+            const agent = chai.request.agent(app);
+            return agent
+                .post('/auth/ldap')
+                .send({ username: 'alice', password: 'secret' })
+                .then((res) => {
+                    return agent.get('/api/system/ping');
+                })
+                .then(() => {
+                    throw new Error('should not get here');
+                })
+                .catch((err) => {
+                    err.response.should.have.status(500);
+                });
+        });
+
+        it('should return 400 Bad Request if authenticated but identity in wallet but no default', () => {
+            const agent = chai.request.agent(app);
+            return agent
+                .post('/auth/ldap')
+                .send({ username: 'alice', password: 'secret' })
+                .then((res) => {
+                    return agent
+                        .post('/api/wallets/1/identities')
+                        .send({ enrollmentID: aliceIdentity.userID, enrollmentSecret: aliceIdentity.userSecret });
+                })
+                .then(() => {
+                    return agent.get('/api/system/ping');
+                })
+                .then(() => {
+                    throw new Error('should not get here');
+                })
+                .catch((err) => {
+                    err.response.should.have.status(500);
+                });
+        });
+
+        it('should return 200 OK if authenticated and default identity in wallet', () => {
+            const agent = chai.request.agent(app);
+            return agent
+                .post('/auth/ldap')
+                .send({ username: 'alice', password: 'secret' })
+                .then((res) => {
+                    return agent
+                        .post('/api/wallets/1/identities')
+                        .send({ enrollmentID: aliceIdentity.userID, enrollmentSecret: aliceIdentity.userSecret });
+                })
+                .then((res) => {
+                    return agent
+                        .post(`/api/wallets/1/identities/${res.body.id}/setDefault`)
+                        .send();
+                })
+                .then(() => {
+                    return agent.get('/api/system/ping');
+                })
+                .then((res) => {
+                    res.should.have.status(200);
+                    res.should.be.json;
+                    res.body.participant.should.equal('org.acme.bond.Member#MEMBER_1');
+                });
+        });
+
+        it('should return 200 OK if authenticated and default identity is subsequently changed', () => {
+            const agent = chai.request.agent(app);
+            return agent
+                .post('/auth/ldap')
+                .send({ username: 'alice', password: 'secret' })
+                .then((res) => {
+                    return agent
+                        .post('/api/wallets/1/identities')
+                        .send({ enrollmentID: aliceIdentity.userID, enrollmentSecret: aliceIdentity.userSecret });
+                })
+                .then((res) => {
+                    return agent
+                        .post(`/api/wallets/1/identities/${res.body.id}/setDefault`)
+                        .send();
+                })
+                .then(() => {
+                    return agent.get('/api/system/ping');
+                })
+                .then((res) => {
+                    res.should.have.status(200);
+                    res.should.be.json;
+                    res.body.participant.should.equal('org.acme.bond.Member#MEMBER_1');
+                })
+                .then((res) => {
+                    return agent
+                        .post('/api/wallets/1/identities')
+                        .send({ enrollmentID: bobIdentity.userID, enrollmentSecret: bobIdentity.userSecret });
+                })
+                .then((res) => {
+                    return agent
+                        .post(`/api/wallets/1/identities/${res.body.id}/setDefault`)
+                        .send();
+                })
+                .then(() => {
+                    return agent.get('/api/system/ping');
+                })
+                .then((res) => {
+                    res.should.have.status(200);
+                    res.should.be.json;
+                    res.body.participant.should.equal('org.acme.bond.Member#MEMBER_2');
+                });
+        });
+
+    });
+
+});

--- a/packages/composer-rest-server/test/server/boot/authentication.js
+++ b/packages/composer-rest-server/test/server/boot/authentication.js
@@ -41,17 +41,17 @@ describe('authentication boot script', () => {
         authentication(app);
     });
 
-    it('should do nothing if composer security is not enabled', () => {
+    it('should do nothing if composer authentication is not enabled', () => {
         composerConfig = {
-            security: false
+            authentication: false
         };
         authentication(app);
         sinon.assert.notCalled(app.enableAuth);
     });
 
-    it('should enable authentication if composer security is enabled', () => {
+    it('should enable authentication if composer authentication is enabled', () => {
         composerConfig = {
-            security: true
+            authentication: true
         };
         authentication(app);
         sinon.assert.calledOnce(app.enableAuth);

--- a/packages/composer-rest-server/test/server/boot/composer-runtime.js
+++ b/packages/composer-rest-server/test/server/boot/composer-runtime.js
@@ -88,9 +88,9 @@ describe('composer-runtime boot script', () => {
         sinon.assert.notCalled(useSpy);
     });
 
-    it('should do nothing if composer security is not enabled', () => {
+    it('should do nothing if composer multiuser is not enabled', () => {
         composerConfig = {
-            security: false
+            multiuser: false
         };
         composerRuntime(app);
         sinon.assert.notCalled(useSpy);
@@ -98,7 +98,7 @@ describe('composer-runtime boot script', () => {
 
     it('should ignore requests without any options', () => {
         composerConfig = {
-            security: true
+            multiuser: true
         };
         composerRuntime(app);
         const fn = useSpy.args[0][0]; // First call, first argument.
@@ -114,7 +114,7 @@ describe('composer-runtime boot script', () => {
 
     it('should ignore requests without an access token', () => {
         composerConfig = {
-            security: true
+            multiuser: true
         };
         composerRuntime(app);
         const fn = useSpy.args[0][0]; // First call, first argument.
@@ -132,7 +132,7 @@ describe('composer-runtime boot script', () => {
 
     it('should ignore requests with an access token for a user that does not exist', () => {
         composerConfig = {
-            security: true
+            multiuser: true
         };
         composerRuntime(app);
         const fn = useSpy.args[0][0]; // First call, first argument.
@@ -154,7 +154,7 @@ describe('composer-runtime boot script', () => {
 
     it('should ignore requests with an access token for a user that does not have a default wallet', () => {
         composerConfig = {
-            security: true
+            multiuser: true
         };
         composerRuntime(app);
         const fn = useSpy.args[0][0]; // First call, first argument.
@@ -176,7 +176,7 @@ describe('composer-runtime boot script', () => {
 
     it('should ignore requests with an access token for a user that has a default wallet that does not exist', () => {
         composerConfig = {
-            security: true
+            multiuser: true
         };
         composerRuntime(app);
         const fn = useSpy.args[0][0]; // First call, first argument.
@@ -201,7 +201,7 @@ describe('composer-runtime boot script', () => {
 
     it('should ignore requests with an access token for a wallet that does not have a default identity', () => {
         composerConfig = {
-            security: true
+            multiuser: true
         };
         composerRuntime(app);
         const fn = useSpy.args[0][0]; // First call, first argument.
@@ -229,7 +229,7 @@ describe('composer-runtime boot script', () => {
 
     it('should ignore requests with an access token for a wallet that has a default identity that does not exist', () => {
         composerConfig = {
-            security: true
+            multiuser: true
         };
         composerRuntime(app);
         const fn = useSpy.args[0][0]; // First call, first argument.
@@ -257,7 +257,7 @@ describe('composer-runtime boot script', () => {
 
     it('should configure the options with the default wallet and default identity', () => {
         composerConfig = {
-            security: true
+            multiuser: true
         };
         composerRuntime(app);
         const fn = useSpy.args[0][0]; // First call, first argument.
@@ -296,7 +296,7 @@ describe('composer-runtime boot script', () => {
 
     it('should handle any errors', () => {
         composerConfig = {
-            security: true
+            multiuser: true
         };
         composerRuntime(app);
         const fn = useSpy.args[0][0]; // First call, first argument.

--- a/packages/composer-rest-server/test/server/server.js
+++ b/packages/composer-rest-server/test/server/server.js
@@ -148,8 +148,8 @@ describe('server', () => {
             });
     });
 
-    it('should enable security if specified', () => {
-        composerConfig.security = true;
+    it('should enable authentication if specified', () => {
+        composerConfig.authentication = true;
         return server(composerConfig)
             .then((result) => {
                 result.app.should.exist;
@@ -176,26 +176,26 @@ describe('server', () => {
             });
     });
 
-    it('should enable security if specified with providers loaded from the environment', () => {
+    it('should enable authentication if specified with providers loaded from the environment', () => {
         process.env.COMPOSER_PROVIDERS = JSON.stringify({
-            'github-login': {
-                provider: 'github',
-                module: 'passport-github2',
-                clientID: '69e33e2302c923ebe3c5',
-                clientSecret: '2b8e4449a07b5e2dfbdc70a8e836388eb48c9e54',
-                callbackURL: '/auth/github/callback',
-                authPath: '/auth/github',
-                callbackPath: '/auth/github/callback',
-                successRedirect: '/auth/account',
-                failureRedirect: '/login',
-                scope: [
-                    'email'
-                ],
-                failureFlash: true,
-                display: 'GitHub'
+            ldap: {
+                provider: 'ldap',
+                module: 'passport-ldapauth',
+                authPath: '/auth/ldap',
+                callbackURL: '/auth/ldap/callback',
+                successRedirect: '/',
+                failureRedirect: '/',
+                authScheme: 'ldap',
+                server: {
+                    url: 'ldap://localhost:389',
+                    bindDN: 'cn=admin,dc=example,dc=org',
+                    bindCredentials: 'admin',
+                    searchBase: 'dc=example,dc=org',
+                    searchFilter: '(uid={{username}})'
+                }
             }
         });
-        composerConfig.security = true;
+        composerConfig.authentication = true;
         return server(composerConfig)
             .then((result) => {
                 result.app.should.exist;
@@ -205,7 +205,7 @@ describe('server', () => {
                 }).map((r) => {
                     return r.route.path;
                 });
-                routes.should.deep.equal(['/auth/github', '/auth/github/callback', '/auth/logout']);
+                routes.should.deep.equal(['/auth/ldap', '/auth/ldap/callback', '/auth/logout']);
             });
     });
 

--- a/packages/composer-website/jekylldocs/integrating/call-out.md
+++ b/packages/composer-website/jekylldocs/integrating/call-out.md
@@ -4,7 +4,7 @@ title: "Calling external REST services"
 category: start
 section: integrating
 status: experimental
-index-order: 607
+index-order: 608
 sidebar: sidebars/accordion-toc0.md
 excerpt: "[**Transaction processor functions can be used to call external REST services**](./call-out.html). This allows you to move complex computation off the blockchain."
 ---

--- a/packages/composer-website/jekylldocs/integrating/deploying-the-rest-server.md
+++ b/packages/composer-website/jekylldocs/integrating/deploying-the-rest-server.md
@@ -3,7 +3,7 @@ layout: default
 title: Deploying the REST server for a business network
 category: start
 section: integrating
-index-order: 605
+index-order: 606
 sidebar: sidebars/accordion-toc0.md
 excerpt: By deploying a REST server for a business network, you can [**integrate existing systems and data with your Hyperledger Composer business network**](./deploying-the-rest-server.html), allowing you to create, update, or delete assets and participants, as well as get and submit transactions.
 ---
@@ -105,17 +105,27 @@ The REST server can be configured using environment variables, instead of supply
 
         COMPOSER_NAMESPACES=never
 
-7. `COMPOSER_SECURITY`
+7. `COMPOSER_AUTHENTICATION`
 
-    You can use the `COMPOSER_SECURITY` environment variable to specify if the REST server should enable REST API authentication or not. Valid values are `true` and `false`.
+    You can use the `COMPOSER_AUTHENTICATION` environment variable to specify if the REST server should enable REST API authentication or not. Valid values are `true` and `false`.
 
     For example:
 
-        COMPOSER_SECURITY=true
+        COMPOSER_AUTHENTICATION=true
 
-    For more information, see [Enabling REST API authentication for a business network](./enabling-rest-authentication.html).
+    For more information, see [Enabling authentication for the REST server](./enabling-rest-authentication.html).
 
-8. `COMPOSER_DATASOURCES`
+8. `COMPOSER_MULTIUSER`
+
+    You can use the `COMPOSER_MULTIUSER` environment variable to specify if the REST server should enable multiple user mode or not. Valid values are `true` and `false`.
+
+    For example:
+
+        COMPOSER_MULTIUSER=true
+
+    For more information, see [Enabling multiple user mode for the REST server](./enabling-multiuser.html).
+
+9. `COMPOSER_DATASOURCES`
 
     You can use the `COMPOSER_DATASOURCES` environment variable to specify the LoopBack data sources and the connection information required by the selected LoopBack connector.
 
@@ -129,7 +139,7 @@ The REST server can be configured using environment variables, instead of supply
           }
         }'
 
-9. `COMPOSER_PROVIDERS`
+10. `COMPOSER_PROVIDERS`
 
     You can use the `COMPOSER_PROVIDERS` environment variable to specify the Passport strategies that the REST server should use to authenticate clients of the REST API.
 
@@ -148,7 +158,7 @@ The REST server can be configured using environment variables, instead of supply
           }
         }'
 
-10. `COMPOSER_TLS`
+11. `COMPOSER_TLS`
 
     You can use the `COMPOSER_TLS` environment variable to specify if the REST server should enable HTTPS and TLS. Valid values are `true` and `false`.
 
@@ -158,7 +168,7 @@ The REST server can be configured using environment variables, instead of supply
 
     For more information, see [Securing the REST server using HTTPS and TLS](./securing-the-rest-server.html).
 
-11. `COMPOSER_TLS_CERTIFICATE`
+12. `COMPOSER_TLS_CERTIFICATE`
 
     You can use the `COMPOSER_TLS_CERTIFICATE` environment variable to specify the certificate file that the REST server should use when HTTPS and TLS are enabled.
 
@@ -166,7 +176,7 @@ The REST server can be configured using environment variables, instead of supply
 
         COMPOSER_TLS_CERTIFICATE=/tmp/cert.pem
 
-12. `COMPOSER_TLS_KEY`
+13. `COMPOSER_TLS_KEY`
 
     You can use the `COMPOSER_TLS_KEY` environment variable to specify the private key file that the REST server should use when HTTPS and TLS are enabled.
 
@@ -219,7 +229,8 @@ The examples are based on the business network that is deployed to Hyperledger F
         COMPOSER_ENROLLMENT_ID=admin
         COMPOSER_ENROLLMENT_SECRET=adminpw
         COMPOSER_NAMESPACES=never
-        COMPOSER_SECURITY=true
+        COMPOSER_AUTHENTICATION=true
+        COMPOSER_MULTIUSER=true
         COMPOSER_CONFIG='{
           "connectionProfiles": {
             "hlfv1": {
@@ -281,7 +292,8 @@ The examples are based on the business network that is deployed to Hyperledger F
             -e COMPOSER_ENROLLMENT_ID=${COMPOSER_ENROLLMENT_ID} \
             -e COMPOSER_ENROLLMENT_SECRET=${COMPOSER_ENROLLMENT_SECRET} \
             -e COMPOSER_NAMESPACES=${COMPOSER_NAMESPACES} \
-            -e COMPOSER_SECURITY=${COMPOSER_SECURITY} \
+            -e COMPOSER_AUTHENTICATION=${COMPOSER_AUTHENTICATION} \
+            -e COMPOSER_MULTIUSER=${COMPOSER_MULTIUSER} \
             -e COMPOSER_CONFIG="${COMPOSER_CONFIG}" \
             -e COMPOSER_DATASOURCES="${COMPOSER_DATASOURCES}" \
             -e COMPOSER_PROVIDERS="${COMPOSER_PROVIDERS}" \
@@ -299,7 +311,7 @@ These steps will run the REST server in a Docker Container with no security, and
 
 1. Pull the Docker Image for the REST Server:
 
-        docker pull hyperledger/composer-rest-server 
+        docker pull hyperledger/composer-rest-server
 
 2. Create a new file named `envvars.txt`, with the following contents:
 (The values used below will typically work with a Test Fabric created from examples in this documentation, but the value of the `COMPOSER_BUSINESS_NETWORK` will need to be set correctly.)
@@ -309,7 +321,8 @@ These steps will run the REST server in a Docker Container with no security, and
         COMPOSER_ENROLLMENT_ID=admin
         COMPOSER_ENROLLMENT_SECRET=adminpw
         COMPOSER_NAMESPACES=never
-        COMPOSER_SECURITY=false
+        COMPOSER_AUTHENTICATION=false
+        COMPOSER_MULTIUSER=false
         COMPOSER_CONFIG='{
           "connectionProfiles": {
             "hlfv1": {
@@ -352,7 +365,8 @@ These steps will run the REST server in a Docker Container with no security, and
             -e COMPOSER_ENROLLMENT_ID=${COMPOSER_ENROLLMENT_ID} \
             -e COMPOSER_ENROLLMENT_SECRET=${COMPOSER_ENROLLMENT_SECRET} \
             -e COMPOSER_NAMESPACES=${COMPOSER_NAMESPACES} \
-            -e COMPOSER_SECURITY=${COMPOSER_SECURITY} \
+            -e COMPOSER_AUTHENTICATION=${COMPOSER_AUTHENTICATION} \
+            -e COMPOSER_MULTIUSER=${COMPOSER_MULTIUSER} \
             -e COMPOSER_CONFIG="${COMPOSER_CONFIG}" \
             -e COMPOSER_DATASOURCES="${COMPOSER_DATASOURCES}" \
             -e COMPOSER_PROVIDERS="${COMPOSER_PROVIDERS}" \

--- a/packages/composer-website/jekylldocs/integrating/enabling-multiuser.md
+++ b/packages/composer-website/jekylldocs/integrating/enabling-multiuser.md
@@ -1,0 +1,115 @@
+---
+layout: default
+title: Enabling multiple user mode for the REST server
+category: start
+section: integrating
+index-order: 604
+sidebar: sidebars/accordion-toc0.md
+excerpt: By default, the Hyperledger Composer REST server services all requests by using the Blockchain identity specified on the command line at startup. By [**enabling authentication, the identity of the client can be used to digitally sign all transactions made by that client.**](./securing-the-rest-server.html)
+---
+
+# Enabling multiple user mode for the REST server
+
+---
+
+By default, the {{site.data.conrefs.composer_full}} REST server services all requests by using the Blockchain identity specified on the command line at startup. For example, when using the following command, all requests made to the REST server will be serviced by using the Blockchain identity **alice1** to digitally sign all transactions:
+
+    composer-rest-server -p hlfv1 -n my-network -i alice1 -s suchs3cret
+
+This means that the business network cannot distinguish between different clients of the REST server. This may be acceptable in certain use cases, for example if the Blockchain identity only has read-only access and the REST server is secured using an API management gateway.
+
+The REST server can be configured to multiple user mode. Multiple user mode permits clients of the REST server to provide their own Blockchain identities for digitally signing transactions. This enables the business network to differentiate between different clients of the REST server.
+
+Multiple user mode requires that REST API authentication is enabled, and will automatically enable REST API authentication if it is not explicitly specified. You must select and configure a Passport strategy for authenticating users. REST API authentication is required so that clients can be identified.
+
+Once a client has authenticated to the REST API, that client can add Blockchain identities to a wallet. The wallet is private to that client, and is not accessible to other clients. When a client makes a request to the REST server, a Blockchain identity in the clients wallet is used to digitally sign all transactions made by that client.
+
+Please note that this feature requires that clients trust the REST server. This trust is required because this feature requires that the REST server stores the clients Blockchain identities, including the private keys. Therefore, it is strongly recommended that clients only use REST servers that are managed by a trusted party, such as an administrator within their organization.
+
+## Starting the REST server with multiple user mode enabled
+
+You must configure the environment variable `COMPOSER_PROVIDERS` before continuing. For instructions on how to perform this task, read the following topic before continuing: [Enabling authentication for the REST server](./enabling-rest-authentication.md)
+
+You can use the `-m true` argument to start the REST server with multiple user mode enabled. Once multiple user mode is enabled, clients will have to authenticate before they can make any requests to the business network.
+
+For example, here is the command for the business network that is deployed as part of the Developer Tutorial, however you may need to modify the command for your business network:
+
+    composer-rest-server -p hlfv1 -n my-network -i admin -s adminpw -m true
+
+The `-m true` argument automatically enables REST API authentication. You can alternatively supply both arguments, `-a true -m true`, if you wish to be explicit. Before continuing, you must authenticate to the REST API using the configured authentication mechanism.
+
+Now, navigate to the REST API explorer at [http://localhost:3000/explorer/](http://localhost:3000/explorer/). If multiple user mode has been successfully enabled, any attempts to call one of the business network REST API operations using the REST API explorer should be rejected with an `No enrollment ID or enrollment secret has been provided` error message.
+
+If you see a `HTTP 401 Authorization Required` error message, you have not authenticated correctly to the REST API.
+
+## Adding a Blockchain identity to the default wallet
+
+First, you must issue a Blockchain identity to a participant in the business network. This example will assume that you have issued the Blockchain identity `alice1` to the participant `org.acme.mynetwork.Trader#alice@email.com`, and the secret is `suchs3cret`.
+
+Follow these steps to add a Blockchain identity to the default wallet:
+
+1. Navigate to the REST API explorer at http://localhost:3000/explorer/.
+2. List all of the authenticated clients wallets by expanding the **Wallet** category and calling the `GET /wallets` operation.
+    The response from the operation should be similiar to the following:
+
+    ```json
+    [
+      {
+        "description": "Default wallet",
+        "id": 1
+      }
+    ]
+    ```
+
+    Each wallet has a unique ID that will be used in subsequent REST API calls for interacting with the wallet. Note down the value of the `id` property for the wallet with the description `Default wallet`, in this example `1`.
+3. List the Blockchain identities in the default wallet by calling the `GET /wallets/{id}/identities` operation with the `id` parameter set to the unique wallet ID noted from step 2.
+    The response from the operation should be:
+
+    ```json
+    []
+    ```
+
+    This means that there are no Blockchain identities in the default wallet.
+4. Add the Blockchain identity to the default wallet by calling the `POST /wallets/{id}/identities` operation with the `id` parameter set to the unique wallet ID noted from step 2, and the `data` parameter set to the following JSON payload (do not include the `id` property in the JSON payload):
+
+    ```json
+    {
+      "enrollmentID": "alice1",
+      "enrollmentSecret": "suchs3cret"
+    }
+    ```
+
+    The response from the operation should be similiar to the following:
+
+    ```json
+    {
+      "enrollmentID": "alice1",
+      "enrollmentSecret": "suchs3cret",
+      "id": 2
+    }
+    ```
+
+    The Blockchain identity for `alice1` has now been added to the default wallet. Each Blockchain identity has a unique ID that will be used in subsequent REST API calls for interacting with the Blockchain identity. Note down the value of the `id` property for the Blockchain identity, in this example `2`.
+5. Set the Blockchain identity as the default Blockchain identity for the default wallet by calling the `POST /wallets/{id}/identities/{fk}/setDefault` operation with the `id` parameter set to the unique wallet ID noted from step 2, and the `fk` parameter set to the unique Blockchain identity ID noted from step 4.
+    The response from the operation should be:
+
+    ```
+    no content
+    ```
+
+    The Blockchain identity has now been set as the default Blockchain identity for the default wallet.
+
+Now, navigate to the REST API explorer at http://localhost:3000/explorer/. Attempt to call one of the business network REST API operations again using the REST API explorer. This time, the calls should succeed.
+
+You can test that the Blockchain identity is being used by calling the `GET /system/ping` operation. This operation returns the fully qualified identifier for the participant that the Blockchain identity was issued to:
+
+    {
+      "version": "0.8.0",
+      "participant": "org.acme.mynetwork.Trader#alice@email.com"
+    }
+
+## Final notes
+
+When the REST server is started with multiple user mode enabled, all REST API requests made by clients use a Blockchain identity stored in the clients wallet. The Blockchain identity specified on the command line at startup is not used to service any requests; it is only used to initially connect to the business network and download the business network definition, which is required to generate the REST API. Therefore, the Blockchain identity specified on the command line only requires minimal permissions - the ability to connect, and the ability to download the business network definition - it does not need permission for any assets, participants, or transactions.
+
+All user information is persisted in a LoopBack data source by using a LoopBack connector. By default, the REST server uses the LoopBack "memory" connector to persist user information, which is lost when the REST server is terminated. The REST server should be configured with a LoopBack connector that stores data in a highly available data source, for example a database. For more information, see [Deploying the REST server](./deploying-the-rest-server.md).

--- a/packages/composer-website/jekylldocs/integrating/enabling-rest-authentication.md
+++ b/packages/composer-website/jekylldocs/integrating/enabling-rest-authentication.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Enabling REST API authentication for a business network
+title: Enabling authentication for the REST server
 category: start
 section: integrating
 index-order: 603
@@ -8,19 +8,11 @@ sidebar: sidebars/accordion-toc0.md
 excerpt: By default, the Hyperledger Composer REST server services all requests by using the Blockchain identity specified on the command line at startup. By [**enabling authentication, the identity of the client can be used to digitally sign all transactions made by that client.**](./securing-the-rest-server.html)
 ---
 
-# Enabling REST API authentication for a business network
+# Enabling authentication for the REST server
 
 ---
 
-By default, the {{site.data.conrefs.composer_full}} REST server services all requests by using the Blockchain identity specified on the command line at startup. For example, when using the following command, all requests made to the REST server will be serviced by using the Blockchain identity **alice1** to digitally sign all transactions:
-
-    composer-rest-server -p hlfv1 -n my-network -i alice1 -s suchs3cret
-
-This means that the business network cannot distinguish between different clients of the REST server. This may be acceptable in certain use cases, for example if the Blockchain identity only has read-only access and the REST server is secured using an API management gateway.
-
-The REST server can be optionally configured to authenticate clients. Once authenticated, a client can add Blockchain identities to a wallet. The wallet is private to that client, and is not accessible to other clients. When a client makes a request to the REST server, a Blockchain identity in the clients wallet is used to digitally sign all transactions made by that client.
-
-Please note that this feature requires that clients trust the REST server. This trust is required because this feature requires that the REST server stores the clients Blockchain identities, including the private keys. Therefore, it is strongly recommended that clients only use REST servers that are managed by a trusted party, such as an administrator within their organization.
+The REST server can be configured to authenticate clients. When this option is enabled, clients must authenticate to the REST server before they are permitted to call the REST API.
 
 ## Selecting an authentication strategy
 
@@ -65,15 +57,15 @@ The configuration for the REST server should be specified using the environment 
 
 ## Starting the REST server with REST API authentication enabled
 
-Once the environment variable `COMPOSER_PROVIDERS` has been set, you can use the `-S true` argument to start the REST server with security enabled. Once security is enabled, clients will have to authenticate before they can make any requests to the business network.
+Once the environment variable `COMPOSER_PROVIDERS` has been set, you can use the `-a true` argument to start the REST server with authentication enabled. Once authentication is enabled, clients will have to authenticate before they can make any requests to the business network.
 
 For example, here is the command for the business network that is deployed as part of the Developer Tutorial, however you may need to modify the command for your business network:
 
-    composer-rest-server -p hlfv1 -n my-network -i admin -s adminpw -S true
+    composer-rest-server -p hlfv1 -n my-network -i admin -s adminpw -a true
 
-Now, navigate to the REST API explorer at [http://localhost:3000/explorer/](http://localhost:3000/explorer/). If security has been successfully enabled, any attempts to call one of the business network REST API operations using the REST API explorer should be rejected with an `HTTP 401 Authorization Required` message.
+Now, navigate to the REST API explorer at [http://localhost:3000/explorer/](http://localhost:3000/explorer/). If authentication has been successfully enabled, any attempts to call one of the business network REST API operations using the REST API explorer should be rejected with an `HTTP 401 Authorization Required` message.
 
-## Authenticating to the REST server
+## Authenticating to the REST server using a web browser
 
 This step is dependent on the configuration and behaviour of the Passport strategies being used by the REST server.
 
@@ -81,76 +73,4 @@ This step is dependent on the configuration and behaviour of the Passport strate
 2. The REST server will redirect you to GitHub to perform the OAuth web server authentication flow. GitHub will ask you if you want to authorize the Composer application to access your account. Click the **Authorize** button.
 3. If successful, GitHub will redirect you back to the REST server.
 
-Now, navigate to the REST API explorer at http://localhost:3000/explorer/. Attempt to call one of the business network REST API operations again using the REST API explorer. This time, the calls should be rejected with an `No enrollment ID or enrollment secret has been provided` error message.
-
-## Adding a Blockchain identity to the default wallet
-
-First, you must issue a Blockchain identity to a participant in the business network. This example will assume that you have issued the Blockchain identity `alice1` to the participant `org.acme.mynetwork.Trader#alice@email.com`, and the secret is `suchs3cret`.
-
-Follow these steps to add a Blockchain identity to the default wallet:
-
-1. Navigate to the REST API explorer at http://localhost:3000/explorer/.
-2. List all of the authenticated clients wallets by expanding the **Wallet** category and calling the `GET /wallets` operation.
-    The response from the operation should be similiar to the following:
-
-    ```json
-    [
-      {
-        "description": "Default wallet",
-        "id": 1
-      }
-    ]
-    ```
-
-    Each wallet has a unique ID that will be used in subsequent REST API calls for interacting with the wallet. Note down the value of the `id` property for the wallet with the description `Default wallet`, in this example `1`.
-3. List the Blockchain identities in the default wallet by calling the `GET /wallets/{id}/identities` operation with the `id` parameter set to the unique wallet ID noted from step 2.
-    The response from the operation should be:
-
-    ```json
-    []
-    ```
-
-    This means that there are no Blockchain identities in the default wallet.
-4. Add the Blockchain identity to the default wallet by calling the `POST /wallets/{id}/identities` operation with the `id` parameter set to the unique wallet ID noted from step 2, and the `data` parameter set to the following JSON payload (do not include the `id` property in the JSON payload):
-
-    ```json
-    {
-      "enrollmentID": "alice1",
-      "enrollmentSecret": "suchs3cret"
-    }
-    ```
-
-    The response from the operation should be similiar to the following:
-
-    ```json
-    {
-      "enrollmentID": "alice1",
-      "enrollmentSecret": "suchs3cret",
-      "id": 2
-    }
-    ```
-
-    The Blockchain identity for `alice1` has now been added to the default wallet. Each Blockchain identity has a unique ID that will be used in subsequent REST API calls for interacting with the Blockchain identity. Note down the value of the `id` property for the Blockchain identity, in this example `2`.
-5. Set the Blockchain identity as the default Blockchain identity for the default wallet by calling the `POST /wallets/{id}/identities/{fk}/setDefault` operation with the `id` parameter set to the unique wallet ID noted from step 2, and the `fk` parameter set to the unique Blockchain identity ID noted from step 4.
-    The response from the operation should be:
-
-    ```
-    no content
-    ```
-
-    The Blockchain identity has now been set as the default Blockchain identity for the default wallet.
-
 Now, navigate to the REST API explorer at http://localhost:3000/explorer/. Attempt to call one of the business network REST API operations again using the REST API explorer. This time, the calls should succeed.
-
-You can test that the Blockchain identity is being used by calling the `GET /system/ping` operation. This operation returns the fully qualified identifier for the participant that the Blockchain identity was issued to:
-
-    {
-      "version": "0.8.0",
-      "participant": "org.acme.mynetwork.Trader#alice@email.com"
-    }
-
-## Final notes
-
-When the REST server is started with REST API authentication enabled, all REST API requests made by clients use a Blockchain identity stored in the clients wallet. The Blockchain identity specified on the command line at startup is not used to service any requests; it is only used to initially connect to the business network and download the business network definition, which is required to generate the REST API. Therefore, the Blockchain identity specified on the command line only requires minimal permissions - the ability to connect, and the ability to download the business network definition - it does not need permission for any assets, participants, or transactions.
-
-All user information is persisted in a LoopBack data source by using a LoopBack connector. By default, the REST server uses the LoopBack "memory" connector to persist user information, which is lost when the REST server is terminated. The REST server should be configured with a LoopBack connector that stores data in a highly available data source, for example a database. For more information, see [Deploying the REST server](./deploying-the-rest-server.md).

--- a/packages/composer-website/jekylldocs/integrating/node-red.md
+++ b/packages/composer-website/jekylldocs/integrating/node-red.md
@@ -3,7 +3,7 @@ layout: default
 title: Integrating with Node-RED
 category: integrating
 section: integrating
-index-order: 606
+index-order: 607
 sidebar: sidebars/accordion-toc0.md
 excerpt: "[Node-RED](http://nodered.org) includes a number of [**Hyperledger Composer _nodes_ allowing you to submit transactions, read, update and delete assets and participants, and subscribe to events.**](./node-red.html)"
 ---

--- a/packages/composer-website/jekylldocs/integrating/securing-the-rest-server.md
+++ b/packages/composer-website/jekylldocs/integrating/securing-the-rest-server.md
@@ -3,7 +3,7 @@ layout: default
 title: Securing the REST server using HTTPS and TLS
 category: start
 section: integrating
-index-order: 604
+index-order: 605
 sidebar: sidebars/accordion-toc0.md
 excerpt: By default, the Hyperledger Composer REST server services all requests by using the Blockchain identity specified on the command line at startup. By [**enabling authentication, the identity of the client can be used to digitally sign all transactions made by that client.**](./enabling-rest-authentication.html)
 ---

--- a/packages/loopback-connector-composer/lib/businessnetworkconnector.js
+++ b/packages/loopback-connector-composer/lib/businessnetworkconnector.js
@@ -55,6 +55,7 @@ class BusinessNetworkConnector extends Connector {
         // Assign defaults for any optional properties.
         this.settings = settings;
         this.settings.namespaces = this.settings.namespaces || 'always';
+        this.settings.multiuser = !!this.settings.multiuser;
 
         // Create a new visitor for generating LoopBack models.
         this.visitor = new LoopbackVisitor(this.settings.namespaces === 'always');
@@ -84,8 +85,9 @@ class BusinessNetworkConnector extends Connector {
      */
     getConnectionWrapper(options) {
 
-        // If an accessToken has been specified, we are in "multi-user" mode.
-        if (options && options.accessToken) {
+        // If multiple user mode has been specified, and an accessToken has been specified,
+        // then handle the request by using a user specific connection.
+        if (this.settings.multiuser && options && options.accessToken) {
 
             // Check that the LoopBack application has supplied the required information.
             if (!options.enrollmentID || !options.enrollmentSecret) {

--- a/packages/loopback-connector-composer/test/assets.js
+++ b/packages/loopback-connector-composer/test/assets.js
@@ -174,7 +174,6 @@ const bfs_fs = BrowserFS.BFSRequire('fs');
                 console.log('Generating schemas for all types in business network definition ...');
                 return modelDefinitions.reduce((promise, modelDefinition) => {
                     return promise.then((schemas) => {
-
                         return new Promise((resolve, reject) => {
                             dataSource.discoverSchemas(modelDefinition.name, { visited: {}, associations: true }, (error, modelSchema) => {
                                 if (error) {
@@ -197,29 +196,22 @@ const bfs_fs = BrowserFS.BFSRequire('fs');
                         public: true
                     });
                 });
-                console.log('Creating BNC');
                 businessNetworkConnection = new BusinessNetworkConnection({ fs: bfs_fs });
-
                 return businessNetworkConnection.connect('defaultProfile', 'bond-network', 'admin', 'Xurw3yU9zI0l');
             })
             .then(() => {
-                console.log('Getting asset registry');
                 return businessNetworkConnection.getAssetRegistry('org.acme.bond.BondAsset');
             })
             .then((assetRegistry_) => {
-                console.log('Adding asset data' + assetRegistry_);
                 assetRegistry = assetRegistry_;
                 return assetRegistry.addAll([
                     serializer.fromJSON(assetData[0]),
                     serializer.fromJSON(assetData[1])
                 ]);
-            }).then(()=>{
-                console.log('Done adding asset data');
             });
         });
 
         beforeEach(() => {
-            console.log('before each');
             return Util.invokeChainCode(businessNetworkConnection.securityContext, 'resetBusinessNetwork', [])
                 .then(() => {
                     return businessNetworkConnection.getAssetRegistry('org.acme.bond.BondAsset');

--- a/packages/loopback-connector-composer/test/businessnetworkconnector.js
+++ b/packages/loopback-connector-composer/test/businessnetworkconnector.js
@@ -80,7 +80,8 @@ describe('BusinessNetworkConnector', () => {
             connectionProfileName : 'MockProfileName',
             businessNetworkIdentifier : 'MockBusinessNetId',
             participantId : 'MockEnrollmentId',
-            participantPwd : 'MockEnrollmentPwd'
+            participantPwd : 'MockEnrollmentPwd',
+            multiuser: true
         };
 
         // create real instances
@@ -200,6 +201,13 @@ describe('BusinessNetworkConnector', () => {
     });
 
     describe('#getConnectionWrapper', () => {
+
+        it('should return the default connection wrapper if multiuser not specified', () => {
+            delete settings.multiuser;
+            testConnector = new BusinessNetworkConnector(settings);
+            testConnector.defaultConnectionWrapper = mockBusinessNetworkConnectionWrapper;
+            testConnector.getConnectionWrapper().should.equal(mockBusinessNetworkConnectionWrapper);
+        });
 
         it('should return the default connection wrapper if no options specified', () => {
             testConnector.getConnectionWrapper().should.equal(mockBusinessNetworkConnectionWrapper);


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?

## Issue/User story
<!--- What issue / user story is this for -->
As a user, I can authenticate users of the REST API without requiring multi-user mode #2016

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.

## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
These changes split the "security" or `-S` option into two separate options, "authentication" or `-a` and "multiuser" or `-m`. Use of the "multiuser" option automatically implies "authentication".

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->