### PR TITLE
add drawer closure on cancel

### DIFF
--- a/packages/composer-playground/src/app/editor/editor.component.spec.ts
+++ b/packages/composer-playground/src/app/editor/editor.component.spec.ts
@@ -1099,12 +1099,13 @@ describe('EditorComponent', () => {
 
             let finishedImport = new BehaviorSubject<any>(true);
 
-            mockDrawer.open = sinon.stub().returns({
+            let drawerItem = {
                 componentInstance: {
                     finishedSampleImport: finishedImport
                 },
                 close: sinon.stub()
-            });
+            };
+            mockDrawer.open = sinon.stub().returns(drawerItem);
 
             component.openImportModal();
 
@@ -1114,7 +1115,7 @@ describe('EditorComponent', () => {
 
             mockUpdatePackage.should.not.have.been.called;
             mockUpdateFiles.should.not.have.been.called;
-
+            drawerItem.close.should.have.been.called;
             mockAlertService.errorStatus$.next.should.have.been.calledWith('some error');
         }));
 
@@ -1124,12 +1125,13 @@ describe('EditorComponent', () => {
 
             let finishedImport = new BehaviorSubject<any>(true);
 
-            mockDrawer.open = sinon.stub().returns({
+            let drawerItem = {
                 componentInstance: {
                     finishedSampleImport: finishedImport
                 },
                 close: sinon.stub()
-            });
+            };
+            mockDrawer.open = sinon.stub().returns(drawerItem);
 
             component.openImportModal();
 
@@ -1139,7 +1141,7 @@ describe('EditorComponent', () => {
 
             mockUpdatePackage.should.not.have.been.called;
             mockUpdateFiles.should.not.have.been.called;
-
+            drawerItem.close.should.have.been.called;
             mockAlertService.errorStatus$.next.should.not.have.been.called;
         }));
     });

--- a/packages/composer-playground/src/app/editor/editor.component.ts
+++ b/packages/composer-playground/src/app/editor/editor.component.ts
@@ -398,11 +398,12 @@ export class EditorComponent implements OnInit, OnDestroy {
                     this.setCurrentFile(currentFile);
                     this.alertService.successStatus$.next({
                         title: 'Deploy Successful',
-                        text: 'Business network imported deployed successfully',
+                        text: 'Business network deployed successfully',
                         icon: '#icon-deploy_24'
                     });
                 }
             } else {
+                importModalRef.close();
                 if (result.error) {
                     this.alertService.errorStatus$.next(result.error);
                 }


### PR DESCRIPTION
Part of #1930 

The update (import business network when editing bus-net) was not closing the modal on close option.

## Design of the fix
add modalref.close() to else case

## Validation of the fix
browser check and tests added

## Automated Tests
2 tests extended for cancel and error case

