### PR TITLE
Fix of issue#1968

### DIFF
--- a/packages/composer-common/lib/modelmanager.js
+++ b/packages/composer-common/lib/modelmanager.js
@@ -138,14 +138,14 @@ class ModelManager {
         }
 
         if(m.isSystemModelFile()) {
-            throw new Error('Cannot add a model file with the reserved system namspace: ' + m.getNamespace() );
+            throw new Error('modelmanager.js : addModelFile() : Cannot add a model file with the reserved system namespace: ' + m.getNamespace() );
         }
 
         if (!this.modelFiles[m.getNamespace()]) {
             m.validate();
             this.modelFiles[m.getNamespace()] = m;
         } else {
-            throw new Error('namespace already exists');
+            throw new Error('modelmanager.js : addModelFile() : namespace already exists '+m.getNamespace());
         }
 
         return m;
@@ -168,9 +168,9 @@ class ModelManager {
             let m = new ModelFile(this, modelFile, fileName);
             let existing = this.modelFiles[m.getNamespace()];
             if (!existing) {
-                throw new Error('model file does not exist');
+                throw new Error('modelmanager.js : updateModelFile() : model file does not exist');
             } else if (existing.isSystemModelFile()) {
-                throw new Error('System namespace can not be updated');
+                throw new Error('modelmanager.js : updateModelFile() : System namespace can not be updated');
             }
             m.validate();
             this.modelFiles[m.getNamespace()] = m;
@@ -178,9 +178,9 @@ class ModelManager {
         } else {
             let existing = this.modelFiles[modelFile.getNamespace()];
             if (!existing) {
-                throw new Error('model file does not exist');
+                throw new Error('modelmanager.js : updateModelFile() : model file does not exist');
             } else if (existing.isSystemModelFile()) {
-                throw new Error('System namespace can not be updated');
+                throw new Error('modelmanager.js : updateModelFile() : System namespace can not be updated');
             }
             modelFile.validate();
             this.modelFiles[modelFile.getNamespace()] = modelFile;
@@ -195,9 +195,9 @@ class ModelManager {
      */
     deleteModelFile(namespace) {
         if (!this.modelFiles[namespace]) {
-            throw new Error('model file does not exist');
+            throw new Error('modelmanager.js : deleteModelFile() : model file does not exist for namespace '+namespace);
         } else if (namespace === ModelUtil.getSystemNamespace()) {
-            throw new Error('Cannot delete system namespace');
+            throw new Error('modelmanager.js : deleteModelFile() : Cannot delete system namespace '+namespace);
 
         }
         delete this.modelFiles[namespace];
@@ -231,25 +231,25 @@ class ModelManager {
                 if (typeof modelFile === 'string') {
                     let m = new ModelFile(this, modelFile, fileName);
                     if (m.isSystemModelFile()){
-                        throw new Error('System namespace can not be updated');
+                        throw new Error('modelmanager.js : addModelFiles() : System namespace can not be updated');
                     }
                     if (!this.modelFiles[m.getNamespace()]) {
                         this.modelFiles[m.getNamespace()] = m;
                         newModelFiles.push(m);
                     }
                     else {
-                        throw new Error('namespace already exists');
+                        throw new Error('modelmanager.js : addModelFiles() : namespace '+m.getNamespace()+' already exists');
                     }
                 } else {
                     if (modelFile.isSystemModelFile()){
-                        throw new Error('System namespace can not be updated');
+                        throw new Error('modelmanager.js : addModelFiles() : System namespace can not be updated');
                     }
                     if (!this.modelFiles[modelFile.getNamespace()]) {
                         this.modelFiles[modelFile.getNamespace()] = modelFile;
                         newModelFiles.push(modelFile);
                     }
                     else {
-                        throw new Error('namespace already exists');
+                        throw new Error('modelmanager.js : addModelFiles() : namespace '+modelFile.getNamespace()+' already exists');
                     }
                 }
             }

--- a/packages/composer-common/test/modelmanager.js
+++ b/packages/composer-common/test/modelmanager.js
@@ -239,7 +239,7 @@ describe('ModelManager', () => {
         it('should return an error for duplicate namespace from strings', () => {
             (() => {
                 modelManager.addModelFiles([concertoModel, modelBase, farm2fork, modelBase]);
-            }).should.throw(/namespace already exists/);
+            }).should.throw('modelmanager.js : addModelFiles() : namespace org.acme.base already exists');
         });
 
         it('should return an error for duplicate namespace from objects', () => {
@@ -250,7 +250,7 @@ describe('ModelManager', () => {
             modelManager.addModelFiles([mf1,mf2]);
             (() => {
                 modelManager.addModelFiles([mf1]);
-            }).should.throw(/namespace already exists/);
+            }).should.throw('modelmanager.js : addModelFiles() : namespace org.doge already exists');
         });
 
     });


### PR DESCRIPTION
Error messages don't include information about what was wrong and from where error was for thrown.

## Checklist
 - [y]  A link to the issue/user story that the pull request relates to
 - [y]  How to recreate the problem without the fix
 - [y]  Design of the fix
 - [y]  How to prove that the fix works
 - [y]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
Error messages don't include information about what was wrong and from where error was for thrown for example, in case of addition of model files, if same file is added twice, the error message is not informative enough.

https://github.com/hyperledger/composer/issues/1968       

## Steps to Reproduce
1. add a model file and then try to add the same file again, the error will be thrown
2. try to delete a non existent model file

## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
All the error message will be now preceded by file name and function name (the line numbers are thrown in js errors itself). The text has also been changed at few places to make it more informative.

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
The automated tests has been changes to match the modified error strings e.g. in addModelFiles testcases.

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
