### PR TITLE
Formalize the list of maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,8 @@
+# Maintainers for Hyperledger Composer
+
+This file is the official list of maintainers for the Hyperledger Composer project.
+Changes to this list should be submitted by submitting a pull request that changes this file, and requesting reviews on that pull request from all of the current maintainers.
+The maintainers are listed in alphabetical order.
+
+- Daniel Selman ([dselman](https://github.com/dselman))
+- Simon Stone ([sstone1](https://github.com/sstone1))


### PR DESCRIPTION
As requested by Hyperledger a while ago, formalize the list of maintainers by adding a file `MAINTAINERS.md` to the root of the project that lists all of the maintainers along with their GitHub IDs.