### PR TITLE
#2144 - Fixed new line character issue with certs

### DIFF
--- a/packages/composer-playground/src/app/login/edit-card-credentials/edit-card-credentials.component.spec.ts
+++ b/packages/composer-playground/src/app/login/edit-card-credentials/edit-card-credentials.component.spec.ts
@@ -189,6 +189,27 @@ describe('EditCardCredentialsComponent', () => {
         }));
     });
 
+    describe('#formatCert', () => {
+
+        it('should remove all instances of \n from a given certificate', () => {
+            let testCert = 'this is the\\n\\ntest cert';
+            let result = component.formatCert(testCert);
+            result.should.equal('this is the\n\ntest cert');
+        });
+
+        it('should remove all instances of \r\n from a given certificate', () => {
+            let testCert = 'this is the\\r\\ntest cert';
+            let result = component.formatCert(testCert);
+            result.should.equal('this is the\ntest cert');
+        });
+
+        it('should remove all instances of \n\r from a given certificate', () => {
+            let testCert = 'this is the\\n\\rtest cert';
+            let result = component.formatCert(testCert);
+            result.should.equal('this is the\ntest cert');
+        });
+    });
+
     describe('#validContents', () => {
 
         it('should not enable validation if trying to set certificates', () => {

--- a/packages/composer-playground/src/app/login/edit-card-credentials/edit-card-credentials.component.ts
+++ b/packages/composer-playground/src/app/login/edit-card-credentials/edit-card-credentials.component.ts
@@ -20,6 +20,8 @@ export class EditCardCredentialsComponent {
     private useCerts: boolean = true;
     private addedPublicCertificate: string;
     private addedPrivateCertificate: string;
+    private formattedCert: string;
+    private formattedPrivateKey: string;
     private useParticipantCard: boolean = true;
     private peerAdmin: boolean = false;
     private channelAdmin: boolean = false;
@@ -90,9 +92,14 @@ export class EditCardCredentialsComponent {
             text: 'Adding ID card'
         });
 
+        if (this.useCerts) {
+            this.formattedCert = this.formatCert(this.addedPublicCertificate);
+            this.formattedPrivateKey = this.formatCert(this.addedPrivateCertificate);
+        }
+
         let credentials = this.useCerts ? {
-            certificate: this.addedPublicCertificate,
-            privateKey: this.addedPrivateCertificate
+            certificate: this.formattedCert,
+            privateKey: this.formattedPrivateKey
         } : null;
 
         let roles = [];
@@ -123,4 +130,9 @@ export class EditCardCredentialsComponent {
                 this.idCardAdded.emit(false);
             });
     }
+
+    formatCert(unformatted: string) {
+        return  unformatted.replace(/\\r\\n|\\n\\r|\\n/g, '\n');
+    }
+
 }


### PR DESCRIPTION
As stated in issue #2144, previously when trying to create an ID card using certificates, if those certificates contained \n they did not work correctly. This issue has been fixed and the creation can now deal with \n within the certificate string.