### PR TITLE
tx id as per fabrics

### DIFF
--- a/packages/composer-client/lib/businessnetworkconnection.js
+++ b/packages/composer-client/lib/businessnetworkconnection.js
@@ -540,18 +540,17 @@ class BusinessNetworkConnection extends EventEmitter {
         if (!(classDeclaration instanceof TransactionDeclaration)) {
             throw new Error(classDeclaration.getFullyQualifiedName() + ' is not a transaction');
         }
-        let id = transaction.getIdentifier();
-        if (id === null || id === undefined) {
-            id = uuid.v4();
-            transaction.setIdentifier(id);
-        }
-        let timestamp = transaction.timestamp;
-        if (timestamp === null || timestamp === undefined) {
-            timestamp = transaction.timestamp = new Date();
-        }
 
-        let data = this.getBusinessNetwork().getSerializer().toJSON(transaction);
-        return Util.invokeChainCode(this.securityContext, 'submitTransaction', [JSON.stringify(data)]);
+        return Util.createTransactionId(this.securityContext)
+        .then ((id)=>{
+            transaction.setIdentifier(id);
+            let timestamp = transaction.timestamp;
+            if (timestamp === null || timestamp === undefined) {
+                timestamp = transaction.timestamp = new Date();
+            }
+            let data = this.getBusinessNetwork().getSerializer().toJSON(transaction);
+            return Util.invokeChainCode(this.securityContext, 'submitTransaction', [JSON.stringify(data)]);
+        });
 
     }
 

--- a/packages/composer-client/test/businessnetworkconnection.js
+++ b/packages/composer-client/test/businessnetworkconnection.js
@@ -793,6 +793,7 @@ describe('BusinessNetworkConnection', () => {
 
             // Set up the responses from the chain-code.
             sandbox.stub(Util, 'invokeChainCode').resolves();
+            sandbox.stub(Util, 'createTransactionId').resolves('c89291eb-969f-4b04-b653-82deb5ee0ba1');
 
             // Invoke the submitTransaction function.
             return businessNetworkConnection
@@ -826,7 +827,7 @@ describe('BusinessNetworkConnection', () => {
 
             // Set up the responses from the chain-code.
             sandbox.stub(Util, 'invokeChainCode').resolves();
-
+            sandbox.stub(Util, 'createTransactionId').resolves('c89291eb-969f-4b04-b653-82deb5ee0ba1');
             // Invoke the add function.
             return businessNetworkConnection
                 .submitTransaction(tx)
@@ -859,7 +860,7 @@ describe('BusinessNetworkConnection', () => {
 
             // Set up the responses from the chain-code.
             sandbox.stub(Util, 'invokeChainCode').resolves();
-
+            sandbox.stub(Util, 'createTransactionId').resolves('c89291eb-969f-4b04-b653-82deb5ee0ba1');
             // Invoke the add function.
             return businessNetworkConnection
                 .submitTransaction(tx)
@@ -892,7 +893,7 @@ describe('BusinessNetworkConnection', () => {
 
             // Set up the responses from the chain-code.
             sandbox.stub(Util, 'invokeChainCode').rejects(new Error('such error'));
-
+            sandbox.stub(Util, 'createTransactionId').resolves('c89291eb-969f-4b04-b653-82deb5ee0ba1');
             // Invoke the add function.
             return businessNetworkConnection
                 .submitTransaction(tx)

--- a/packages/composer-common/lib/connection.js
+++ b/packages/composer-common/lib/connection.js
@@ -594,6 +594,35 @@ class Connection extends EventEmitter {
         throw new Error('abstract function called');
     }
 
+
+    /**
+     * Create a Transaction Id
+     * @param {SecurityContext} securityContext The participant's security context.
+     * @return {Promise} A promise that will be resolved with a representation of the id
+     */
+    createTransactionId(securityContext) {
+        return new Promise((resolve, reject) => {
+            this._createTransactionId(securityContext, (error, result) => {
+                if (error) {
+                    return reject(error);
+                }
+                return resolve(result);
+            });
+        });
+    }
+
+    /**
+     * List all of the deployed business networks. The connection must
+     * be connected for this method to succeed.
+     * @abstract
+     * @param {SecurityContext} securityContext The participant's security context.
+     * @param {listCallback} callback The callback function to call when complete.
+     * @return {String} id string of the transaction id (or null which will prompt common to create one)
+     */
+    _createTransactionId(securityContext, callback) {
+        throw new Error('abstract function called');
+    }
+
 }
 
 module.exports = Connection;

--- a/packages/composer-common/lib/connection.js
+++ b/packages/composer-common/lib/connection.js
@@ -612,12 +612,17 @@ class Connection extends EventEmitter {
     }
 
     /**
-     * List all of the deployed business networks. The connection must
-     * be connected for this method to succeed.
+     * @callback transactionIdCallback
+     * @protected
+     * @param {Error} error The error if any.
+     * @param {string} result Transaction id.
+     */
+
+    /**
+     * Create a transaction id
      * @abstract
      * @param {SecurityContext} securityContext The participant's security context.
      * @param {listCallback} callback The callback function to call when complete.
-     * @return {String} id string of the transaction id (or null which will prompt common to create one)
      */
     _createTransactionId(securityContext, callback) {
         throw new Error('abstract function called');

--- a/packages/composer-common/lib/modelmanager.js
+++ b/packages/composer-common/lib/modelmanager.js
@@ -198,9 +198,9 @@ class ModelManager {
             throw new Error('model file does not exist');
         } else if (namespace === ModelUtil.getSystemNamespace()) {
             throw new Error('Cannot delete system namespace');
-
+        } else {
+            delete this.modelFiles[namespace];
         }
-        delete this.modelFiles[namespace];
     }
 
     /**

--- a/packages/composer-common/lib/util.js
+++ b/packages/composer-common/lib/util.js
@@ -17,6 +17,7 @@
 const Globalize = require('./globalize');
 const SecurityContext = require('./securitycontext');
 const SecurityException = require('./securityexception');
+const uuid = require('uuid');
 
 /**
  * Internal Utility Class
@@ -98,6 +99,22 @@ class Util {
      */
     static isNull(obj) {
         return(typeof(obj) === 'undefined' || obj === null);
+    }
+
+   /** Obtain a UUID for use as a TransactionId
+     * @param {SecurityContext} securityContext - The user's security context
+     * @return {Object} Object representing the transaction Id to be used later when invoking chain code
+    */
+    static createTransactionId(securityContext){
+        Util.securityCheck(securityContext);
+        return securityContext.getConnection().createTransactionId()
+        .then((id)=>{
+            if (this.isNull(id)){
+                id = uuid.v4();
+            }
+            return id;
+        });
+
     }
 
 }

--- a/packages/composer-common/lib/util.js
+++ b/packages/composer-common/lib/util.js
@@ -103,7 +103,7 @@ class Util {
 
    /** Obtain a UUID for use as a TransactionId
      * @param {SecurityContext} securityContext - The user's security context
-     * @return {Object} Object representing the transaction Id to be used later when invoking chain code
+     * @return {Promise}  resolved with a string representing the transaction Id to be used later when invoking chain code
     */
     static createTransactionId(securityContext){
         Util.securityCheck(securityContext);

--- a/packages/composer-common/lib/util.js
+++ b/packages/composer-common/lib/util.js
@@ -107,7 +107,7 @@ class Util {
     */
     static createTransactionId(securityContext){
         Util.securityCheck(securityContext);
-        return securityContext.getConnection().createTransactionId()
+        return securityContext.getConnection().createTransactionId(securityContext)
         .then((id)=>{
             if (this.isNull(id)){
                 id = uuid.v4();

--- a/packages/composer-common/test/businessnetworkdefinition.js
+++ b/packages/composer-common/test/businessnetworkdefinition.js
@@ -220,5 +220,7 @@ describe('BusinessNetworkDefinition', () => {
                 });
             });
         });
+
+
     });
 });

--- a/packages/composer-common/test/connection.js
+++ b/packages/composer-common/test/connection.js
@@ -536,4 +536,37 @@ describe('Connection', () => {
 
     });
 
+
+    describe('#createTransactionId', () => {
+
+        it('should call _createTransactionId and handle no error', () => {
+            sinon.stub(connection, '_createTransactionId').yields(null,['5d5s6s78d7f6']);
+            return connection.createTransactionId(mockSecurityContext)
+                        .should.eventually.be.deep.equal(['5d5s6s78d7f6'])
+                        .then(() => {
+                            sinon.assert.calledWith(connection._createTransactionId, mockSecurityContext);
+                        });
+        });
+
+        it('should call _createTransactionId and handle an error', () => {
+            sinon.stub(connection, '_createTransactionId').yields(new Error('error'));
+            return connection.createTransactionId(mockSecurityContext)
+                        .should.be.rejectedWith(/error/)
+                        .then(() => {
+                            sinon.assert.calledWith(connection._createTransactionId, mockSecurityContext);
+                        });
+        });
+
+    });
+
+    describe('#_createTransactionId', () => {
+
+        it('should throw as abstract method', () => {
+            (() => {
+                connection._createTransactionId(mockSecurityContext);
+            }).should.throw(/abstract function called/);
+        });
+
+    });
+
 });

--- a/packages/composer-common/test/modelmanager.js
+++ b/packages/composer-common/test/modelmanager.js
@@ -88,6 +88,14 @@ describe('ModelManager', () => {
                 err.getFileLocation().start.offset.should.equal(err.getFileLocation().start.offset);
             }
         });
+
+        it('should cope with object as modelfile', ()=>{
+            let mockModelFile = sinon.createStubInstance(ModelFile);
+            modelManager.validateModelFile(mockModelFile);
+            sinon.assert.calledOnce(mockModelFile.validate);
+
+
+        });
     });
 
     describe('#addModelFile', () => {
@@ -371,8 +379,8 @@ describe('ModelManager', () => {
 
         it('should not be possible to delete a system model file', ()=>{
             (() => {
-                modelManager.deleteModelFile(mockSystemModelFile);
-            }).should.throw();
+                modelManager.deleteModelFile('org.hyperledger.composer.system');
+            }).should.throw(/Cannot delete system namespace/);
         });
 
     });

--- a/packages/composer-common/test/util.js
+++ b/packages/composer-common/test/util.js
@@ -18,7 +18,7 @@ const Connection = require('../lib/connection');
 const SecurityContext = require('../lib/securitycontext');
 const SecurityException = require('../lib/securityexception');
 const Util = require('../lib/util');
-
+const uuid = require('uuid');
 require('chai').should();
 const sinon = require('sinon');
 
@@ -102,6 +102,44 @@ describe('Util', function () {
                     sinon.assert.calledOnce(mockConnection.queryChainCode);
                     sinon.assert.calledWith(mockConnection.queryChainCode, mockSecurityContext, 'function', ['arg1', 'arg2']);
                 });
+        });
+
+        it('should query the chain-code and return the result', function () {
+            return Util.queryChainCode(mockSecurityContext, 'function', [true, false])
+                .then(() => {
+                    sinon.assert.calledOnce(mockConnection.queryChainCode);
+                    sinon.assert.calledWith(mockConnection.queryChainCode, mockSecurityContext, 'function', ['true', 'false']);
+                });
+        });
+
+    });
+
+    describe('#createTransactionId', function() {
+        it('should perform a security check', function () {
+            mockConnection.createTransactionId.resolves('42');
+            let stub = sandbox.stub(Util, 'securityCheck');
+            return Util
+                .createTransactionId(mockSecurityContext)
+                .then(() => {
+                    sinon.assert.called(stub);
+                });
+        });
+
+        it('call the connection to get a txid',function(){
+            mockConnection.createTransactionId.resolves('42');
+            // let stub = sandbox.stub(Util, 'securityCheck');
+            return Util
+                .createTransactionId(mockSecurityContext)
+                .should.eventually.be.equal('42');
+        });
+
+
+        it('call the connection to get a txid and cope with null',function(){
+            mockConnection.createTransactionId.resolves(null);
+            sandbox.stub(uuid, 'v4').returns('56');
+            return Util
+                .createTransactionId(mockSecurityContext)
+                .should.eventually.be.equal('56');
         });
 
     });

--- a/packages/composer-connector-embedded/lib/embeddedconnection.js
+++ b/packages/composer-connector-embedded/lib/embeddedconnection.js
@@ -400,6 +400,17 @@ class EmbeddedConnection extends Connection {
             });
     }
 
+
+    /**
+     * Create a new transaction id
+     * Note: as this is not a real fabric it returns null to let the composer-common use uuid to create one.
+     * @param {SecurityContext} securityContext The participant's security context.
+     * @return {Promise} A promise that is resolved with a generated user
+     * secret once the new identity has been created, or rejected with an error.
+     */
+    createTransactionId(securityContext){
+        return Promise.resolve(null);
+    }
 }
 
 module.exports = EmbeddedConnection;

--- a/packages/composer-connector-embedded/test/embeddedconnection.js
+++ b/packages/composer-connector-embedded/test/embeddedconnection.js
@@ -96,6 +96,16 @@ describe('EmbeddedConnection', () => {
 
     });
 
+    describe('#createTransactionId', () => {
+        it('should just return null ', ()=>{
+            connection.createTransactionId(mockSecurityContext)
+            .then(result=>{
+                should.be.equal(result,null);
+            }
+            );
+        });
+    });
+
     describe('#login', () => {
 
         beforeEach(() => {

--- a/packages/composer-connector-embedded/test/embeddedconnection.js
+++ b/packages/composer-connector-embedded/test/embeddedconnection.js
@@ -99,7 +99,7 @@ describe('EmbeddedConnection', () => {
     describe('#createTransactionId', () => {
         it('should just return null ', ()=>{
             connection.createTransactionId(mockSecurityContext)
-            .then(result=>{
+            .then((result)=>{
                 should.be.equal(result,null);
             }
             );

--- a/packages/composer-connector-hlfv1/lib/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/lib/hlfconnection.js
@@ -1075,6 +1075,17 @@ class HLFConnection extends Connection {
             });
     }
 
+   /**
+     * Get a transaction id from the fabric client
+     * @param {any} securityContext security context
+     * @return {Promise} A promise that is resolved when with a transaction id
+     */
+    createTransactionId(){
+        // Check that a valid security context has been specified.
+        let id = this.client.newTransactionID();
+        return Promise.resolve(id.getTransactionID());
+    }
+
 }
 
 module.exports = HLFConnection;

--- a/packages/composer-connector-hlfv1/lib/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/lib/hlfconnection.js
@@ -1078,7 +1078,7 @@ class HLFConnection extends Connection {
    /**
      * Get a transaction id from the fabric client
      * @param {any} securityContext security context
-     * @return {Promise} A promise that is resolved when with a transaction id
+     * @return {Promise} A promise that is resolved with a transaction id
      */
     createTransactionId(){
         // Check that a valid security context has been specified.

--- a/packages/composer-connector-hlfv1/test/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/test/hlfconnection.js
@@ -2491,4 +2491,20 @@ describe('HLFConnection', () => {
         });
     });
 
+    describe('#createTransactionID', ()=>{
+
+        beforeEach(() => {
+            mockChannel.initialize.resolves();
+        });
+
+        it('should create a transaction id', () => {
+            connection.initialized = true;
+
+            connection.createTransactionId().then((result) =>{
+                sinon.assert.calledOnce(mockClient.getTransactionID);
+                result.should.deep.equal('00000000-0000-0000-0000-000000000000');
+            });
+        });
+    });
+
 });

--- a/packages/composer-connector-proxy/lib/proxyconnection.js
+++ b/packages/composer-connector-proxy/lib/proxyconnection.js
@@ -280,6 +280,23 @@ class ProxyConnection extends Connection {
         });
     }
 
+    /**
+     * Create a new transaction id
+     * @param {SecurityContext} securityContext The participant's security context.
+     * @return {Promise} A promise that is resolved with a generated user
+     * secret once the new identity has been created, or rejected with an error.
+     */
+    createTransactionId(securityContext){
+        return new Promise((resolve, reject) => {
+            this.socket.emit('/api/connectionCreateTransactionId', this.connectionID, securityContext.securityContextID, (error, result) => {
+                if (error) {
+                    return reject(ProxyUtil.inflaterr(error));
+                }
+                resolve(result);
+            });
+        });
+    }
+
 }
 
 module.exports = ProxyConnection;

--- a/packages/composer-connector-proxy/test/proxyconnection.js
+++ b/packages/composer-connector-proxy/test/proxyconnection.js
@@ -329,4 +329,23 @@ describe('ProxyConnection', () => {
 
     });
 
+    describe('#createTransactionId', () => {
+
+        it('should send a list call to the connector server', () => {
+            mockSocket.emit.withArgs('/api/connectionCreateTransactionId', connectionID, securityContextID, sinon.match.func).yields(null, ['32']);
+            return connection.createTransactionId(mockSecurityContext)
+                        .then((result) => {
+                            sinon.assert.calledOnce(mockSocket.emit);
+                            sinon.assert.calledWith(mockSocket.emit, '/api/connectionCreateTransactionId', connectionID, securityContextID, sinon.match.func);
+                            result.should.deep.equal(['32']);
+                        });
+        });
+
+        it('should handle an error from the connector server', () => {
+            mockSocket.emit.withArgs('/api/connectionCreateTransactionId', connectionID, securityContextID, sinon.match.func).yields(serializedError);
+            return connection.createTransactionId(mockSecurityContext)
+                        .should.be.rejectedWith(TypeError, /such type error/);
+        });
+
+    });
 });

--- a/packages/composer-connector-server/lib/connectorserver.js
+++ b/packages/composer-connector-server/lib/connectorserver.js
@@ -721,6 +721,43 @@ class ConnectorServer {
             });
     }
 
+    /**
+     * Handle a request from the client to create a transaction id
+     * @param {string} connectionID The connection ID.
+     * @param {string} securityContextID The security context ID.
+     * @param {function} callback The callback to call when complete.
+     * @return {Promise} A promise that is resolved when complete.
+     */
+    connectionCreateTransactionId(connectionID, securityContextID, callback) {
+        const method = 'connectionCreateTransactionId';
+        LOG.entry(method, connectionID, securityContextID);
+        let connection = this.connections[connectionID];
+        if (!connection) {
+            let error = new Error(`No connection found with ID ${connectionID}`);
+            LOG.error(error);
+            callback(ConnectorServer.serializerr(error));
+            LOG.exit(method, null);
+            return Promise.resolve();
+        }
+        let securityContext = this.securityContexts[securityContextID];
+        if (!securityContext) {
+            let error = new Error(`No security context found with ID ${securityContextID}`);
+            LOG.error(error);
+            callback(ConnectorServer.serializerr(error));
+            LOG.exit(method, null);
+            return Promise.resolve();
+        }
+        return connection.createTransactionId(securityContext)
+            .then((result) => {
+                callback(null, result);
+                LOG.exit(method, result);
+            })
+            .catch((error) => {
+                LOG.error(error);
+                callback(ConnectorServer.serializerr(error));
+                LOG.exit(method, null);
+            });
+    }
 }
 
 module.exports = ConnectorServer;

--- a/packages/composer-connector-server/test/connectorserver.js
+++ b/packages/composer-connector-server/test/connectorserver.js
@@ -1034,7 +1034,7 @@ describe('ConnectorServer', () => {
             connectorServer.securityContexts[securityContextID] = mockSecurityContext;
         });
 
-        it('should list', () => {
+        it('should list business networks', () => {
             mockConnection.list.withArgs(mockSecurityContext).resolves(['org-acme-biznet1', 'org-acme-biznet2']);
             const cb = sinon.stub();
             return connectorServer.connectionList(connectionID, securityContextID, cb)
@@ -1070,7 +1070,7 @@ describe('ConnectorServer', () => {
                 });
         });
 
-        it('should handle list errors', () => {
+        it('should handle  errors', () => {
             mockConnection.list.rejects(new Error('such error'));
             const cb = sinon.stub();
             return connectorServer.connectionList(connectionID, securityContextID, cb)
@@ -1092,7 +1092,7 @@ describe('ConnectorServer', () => {
             connectorServer.securityContexts[securityContextID] = mockSecurityContext;
         });
 
-        it('should list', () => {
+        it('should create a transaction id', () => {
             mockConnection.createTransactionId.withArgs(mockSecurityContext).resolves(['42']);
             const cb = sinon.stub();
             return connectorServer.connectionCreateTransactionId(connectionID, securityContextID, cb)
@@ -1128,7 +1128,7 @@ describe('ConnectorServer', () => {
                         });
         });
 
-        it('should handle list errors', () => {
+        it('should handle errors when creating transaction id', () => {
             mockConnection.createTransactionId.rejects(new Error('such error'));
             const cb = sinon.stub();
             return connectorServer.connectionCreateTransactionId(connectionID, securityContextID, cb)

--- a/packages/composer-connector-web/lib/webconnection.js
+++ b/packages/composer-connector-web/lib/webconnection.js
@@ -489,6 +489,16 @@ class WebConnection extends Connection {
             });
     }
 
+    /**
+     * Create a new transaction id
+     * Note: as this is not a real fabric it returns null to let the composer-common use uuid to create one.
+     * @param {SecurityContext} securityContext The participant's security context.
+     * @return {Promise} A promise that is resolved with a generated user
+     * secret once the new identity has been created, or rejected with an error.
+     */
+    createTransactionId(securityContext){
+        return Promise.resolve(null);
+    }
 }
 
 module.exports = WebConnection;

--- a/packages/composer-connector-web/lib/webconnection.js
+++ b/packages/composer-connector-web/lib/webconnection.js
@@ -493,8 +493,7 @@ class WebConnection extends Connection {
      * Create a new transaction id
      * Note: as this is not a real fabric it returns null to let the composer-common use uuid to create one.
      * @param {SecurityContext} securityContext The participant's security context.
-     * @return {Promise} A promise that is resolved with a generated user
-     * secret once the new identity has been created, or rejected with an error.
+     * @return {Promise} A promise that is resolved with a transaction id
      */
     createTransactionId(securityContext){
         return Promise.resolve(null);

--- a/packages/composer-connector-web/test/webconnection.js
+++ b/packages/composer-connector-web/test/webconnection.js
@@ -84,10 +84,9 @@ describe('WebConnection', () => {
     describe('#createTransactionId', () => {
         it('should just return null ', ()=>{
             connection.createTransactionId(mockSecurityContext)
-            .then(result=>{
+            .then((result)=>{
                 should.be.equal(result,null);
-            }
-            );
+            });
         });
     });
 

--- a/packages/composer-connector-web/test/webconnection.js
+++ b/packages/composer-connector-web/test/webconnection.js
@@ -81,6 +81,16 @@ describe('WebConnection', () => {
 
     });
 
+    describe('#createTransactionId', () => {
+        it('should just return null ', ()=>{
+            connection.createTransactionId(mockSecurityContext)
+            .then(result=>{
+                should.be.equal(result,null);
+            }
+            );
+        });
+    });
+
     describe('#createEngine', () => {
 
         it('should create a new engine', () => {


### PR DESCRIPTION
The transaction id has been delegated to each connector - such that the hlfv1 connector use fabric client. The other connectors will return null so the common layer 'fall back option is used. This uses uuid to create a id as previously. 