### PR TITLE
Move IdCard migration from fromArchive to constructor

### DIFF
--- a/packages/composer-common/test/idcard.js
+++ b/packages/composer-common/test/idcard.js
@@ -104,6 +104,12 @@ describe('IdCard', function() {
                 new IdCard(metadata, minimalConnectionProfile);
             }, new RegExp(metadata.version.toString(10)));
         });
+
+        it('should throw error on missing metadata', function() {
+            should.throw(() => {
+                new IdCard(null, minimalConnectionProfile);
+            }, /metadata/);
+        });
     });
 
     describe('#fromArchive', function() {

--- a/packages/composer-playground/src/app/identity/identity-issued/identity-issued.component.ts
+++ b/packages/composer-playground/src/app/identity/identity-issued/identity-issued.component.ts
@@ -33,6 +33,7 @@ export class IdentityIssuedComponent implements OnInit {
         let businessNetworkName = currentCard.getBusinessNetworkName();
 
         let newCardData = {
+            version: 1,
             userName: this.userID,
             enrollmentSecret: this.userSecret,
             businessNetwork: businessNetworkName

--- a/packages/composer-playground/src/app/services/identity-card.service.spec.ts
+++ b/packages/composer-playground/src/app/services/identity-card.service.spec.ts
@@ -93,12 +93,14 @@ describe('IdentityCardService', () => {
             mockAdminService.exportIdentity.withArgs(sinon.match.any, 'card2').resolves(credentials);
 
             idCard1 = new IdCard({
+                version: 1,
                 userName: 'card1',
                 businessNetworkName: 'assassin-network',
                 enrollmentSecret: 'adminpw'
             }, { name: 'hlfv1' });
 
             idCard2 = new IdCard({
+                version: 1,
                 userName: 'card2',
                 businessNetworkName: 'assassin-network',
                 enrollmentSecret: 'adminpw'

--- a/packages/composer-playground/src/app/services/identity-card.service.ts
+++ b/packages/composer-playground/src/app/services/identity-card.service.ts
@@ -15,6 +15,7 @@ const hash = require('object-hash');
 
 const defaultCardProperties = {
     metadata: {
+        version: 1,
         userName: 'admin',
         enrollmentSecret: 'adminpw',
         roles: ['PeerAdmin', 'ChannelAdmin'],
@@ -171,6 +172,7 @@ export class IdentityCardService {
 
     createIdentityCard(userName: string, businessNetworkName: string, enrollmentSecret: string, connectionProfile: any, credentials?: any, roles?: string[]): Promise<string> {
         const metadata: any = {
+            version: 1,
             userName: userName,
             businessNetwork: businessNetworkName,
         };


### PR DESCRIPTION
This mitigates the impact of version changes for code that uses
the constructor directly, provided the metadata supplied includes
a version property.

Contributes to #2115 

Signed-off-by: Mark S. Lewis <Mark_Lewis@uk.ibm.com>