### PR TITLE
Correctly handle default double values in grammar (resolves #2187)

### DIFF
--- a/packages/composer-common/lib/introspect/parser.pegjs
+++ b/packages/composer-common/lib/introspect/parser.pegjs
@@ -1267,7 +1267,7 @@ NamespaceToken    = "namespace"   !IdentifierPart
 AbstractToken     = "abstract"    !IdentifierPart
 ConceptToken      = "concept"     !IdentifierPart
 AssetToken        = "asset"       !IdentifierPart
-TransactionToken  = "transaction" !IdentifierPart 
+TransactionToken  = "transaction" !IdentifierPart
 EventToken        = "event"       !IdentifierPart
 ParticipantToken  = "participant" !IdentifierPart
 
@@ -1344,7 +1344,7 @@ DecoratorNumber =
         location: location()
       }
   }
-  
+
 DecoratorBoolean =
   b:$BooleanLiteral {
       return {
@@ -1353,7 +1353,7 @@ DecoratorBoolean =
         location: location()
       }
   }
-  
+
 DecoratorLiteral =
   DecoratorString
   / DecoratorBoolean
@@ -1378,7 +1378,7 @@ Decorator
             location: location()
           };
   }
-  
+
 Decorators
   = decorators:(d:Decorator __ {return d;})*
 
@@ -1493,7 +1493,7 @@ IntegerDefault
     }
 
 RealDefault
-   = "default" __ "=" __ def:SignedRealLiteral{
+   = "default" __ "=" __ def:$SignedRealLiteral{
       return def;
     }
 

--- a/packages/composer-common/test/model/typed.js
+++ b/packages/composer-common/test/model/typed.js
@@ -65,4 +65,38 @@ describe('Typed', () => {
 
     });
 
+    describe('#assignFieldDefaults', () => {
+
+        const defaultValues = {
+            'Boolean': true,
+            'String': 'foobar',
+            'DateTime': '2017-09-26T22:35:53.871Z',
+            'Double': 3.142,
+            'Integer': 32768,
+            'Long': 10485760
+        };
+
+        Object.keys(defaultValues).forEach((defaultValueType) => {
+
+            it(`should assign the default value for primitive type ${defaultValueType}`, () => {
+                const defaultValue = defaultValues[defaultValueType];
+                modelManager.addModelFile(`
+                namespace org.acme.defaults
+                asset DefaultAsset identified by assetId {
+                    o String assetId
+                    o ${defaultValueType} value default=${JSON.stringify(defaultValue)}
+                }`);
+                const typed = new Typed(modelManager, 'org.acme.defaults', 'DefaultAsset');
+                typed.assignFieldDefaults();
+                if (typed.value instanceof Date) {
+                    typed.value.toISOString().should.equal(defaultValue);
+                } else {
+                    typed.value.should.equal(defaultValue);
+                }
+            });
+
+        });
+
+    });
+
 });


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->
Asset attributes with a type of Double are unable to have a default value #2187

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
Grammar is incorrect and parses the default double value literal into an object that we then call `parseFloat` on - this causes a wild `NaN` to appear. Fix the grammar to parse the default double value literal as a string so we can parse it into the correct type later on.

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->