### PR TITLE
Use FF-Headless for UT

### DIFF
--- a/.travis/before-install.sh
+++ b/.travis/before-install.sh
@@ -96,8 +96,6 @@ fi
 #
 cd ${DIR}
 
-wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-sudo dpkg -i google-chrome*.deb
 wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
 echo "deb http://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
 sudo apt-get update && sudo apt-get install cf-cli

--- a/contrib-notes/coding-guidelines.md
+++ b/contrib-notes/coding-guidelines.md
@@ -108,7 +108,7 @@ Our current test suites make use of:
 Hyperledger Composer requires that all code added to the project is provided with unit tests. These tests operate inside a test framework called [mocha](https://mochajs.org/) which controls their execution. Mocha is triggered every time code is pushed to either a user's repository or the Hyperledger Composer repository.
 
 ### Unit Test Framework using Karma and Jasmine
-The default configuration is set to target the Chrome browser, and this is the target browser during the build process. Unit tests should rigorously test controller files and where appropriate inspect the view to ensure that mapped logic is operating as expected.
+The default configuration is set to target the Firefox browser, and this is the target browser during the build process. Unit tests should rigorously test controller files and where appropriate inspect the view to ensure that mapped logic is operating as expected.
 
 ### Simplify writing tests using the chai assertion library, chai-things and sinon
 

--- a/contrib-notes/getting-started.md
+++ b/contrib-notes/getting-started.md
@@ -32,7 +32,7 @@ This is a summary of the tools that will be required to work on Hyperledger Comp
 - **Node.js  v6** The main runtime of Hyperledger Composer and also has the NPM tool that is used for a lot of the package management.
     - Ubuntu: Simply installed [follow these notes](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions).
 
-- **Chrome** Web test suites use **karma** to launch a browser, and consequently **Chrome** must be installed to prevent test failures without editing the karma configuration to use a supported browser that you already have installed.
+- **Firefox** Web test suites use **karma** to launch a browser, and consequently **Firefox** must be installed to prevent test failures without editing the karma configuration to use a supported browser that you already have installed.
 
 ## Forking and Cloning the Hyperledger Composer Repository
 

--- a/packages/composer-connector-web/karma.conf.js
+++ b/packages/composer-connector-web/karma.conf.js
@@ -71,9 +71,13 @@ module.exports = function(config) {
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: ['Chrome'],
-
-
+        browsers: ['FirefoxHeadless'],
+        customLaunchers: {
+          FirefoxHeadless: {
+            base: 'Firefox',
+            flags: [ '-headless' ],
+          },
+        },
         // Continuous Integration mode
         // if true, Karma captures browsers, runs the tests and exits
         singleRun: false,

--- a/packages/composer-connector-web/package.json
+++ b/packages/composer-connector-web/package.json
@@ -51,7 +51,7 @@
     "jsdoc": "^3.4.3",
     "karma": "^1.3.0",
     "karma-browserify": "^5.1.0",
-    "karma-chrome-launcher": "^2.0.0",
+    "karma-firefox-launcher": "^1.0.0",
     "karma-coverage": "^1.1.1",
     "karma-mocha": "^1.3.0",
     "karma-spec-reporter": "0.0.26",

--- a/packages/composer-playground/config/karma.conf.js
+++ b/packages/composer-playground/config/karma.conf.js
@@ -76,10 +76,13 @@ module.exports = function(config) {
      * start these browsers
      * available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
      */
-    browsers: [
-      'Chrome'
-    ],
-
+    browsers: ['FirefoxHeadless'],
+    customLaunchers: {
+      FirefoxHeadless: {
+        base: 'Firefox',
+        flags: [ '-headless' ],
+      },
+    },
     browserNoActivityTimeout: 30000,
 
     client : {
@@ -89,25 +92,12 @@ module.exports = function(config) {
       level: 'log'
     },
 
-    customLaunchers: {
-      ChromeTravisCi: {
-        base: 'Chrome',
-        flags: ['--no-sandbox']
-      }
-    },
-
     /*
      * Continuous Integration mode
      * if true, Karma captures browsers, runs the tests and exits
      */
     singleRun: true
   };
-
-  if (process.env.TRAVIS){
-    configuration.browsers = [
-      'ChromeTravisCi'
-    ];
-  }
 
   config.set(configuration);
 };

--- a/packages/composer-playground/package.json
+++ b/packages/composer-playground/package.json
@@ -162,7 +162,7 @@
     "jszip": "^3.1.3",
     "karma": "^1.3.0",
     "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^2.0.0",
+    "karma-firefox-launcher": "^1.0.0",
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "^1.1.0",
     "karma-mocha-reporter": "^2.2.1",

--- a/packages/composer-runtime-web/karma.conf.js
+++ b/packages/composer-runtime-web/karma.conf.js
@@ -71,9 +71,13 @@ module.exports = function(config) {
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: ['Chrome'],
-
-
+        browsers: ['FirefoxHeadless'],
+        customLaunchers: {
+            FirefoxHeadless: {
+                base: 'Firefox',
+                flags: [ '-headless' ],
+            },
+        },
         // Continuous Integration mode
         // if true, Karma captures browsers, runs the tests and exits
         singleRun: false,

--- a/packages/composer-runtime-web/package.json
+++ b/packages/composer-runtime-web/package.json
@@ -39,7 +39,7 @@
     "karma": "^1.3.0",
     "karma-browserify": "^5.1.0",
     "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^2.0.0",
+    "karma-firefox-launcher": "^1.0.0",
     "karma-coverage": "^1.1.1",
     "karma-mocha": "^1.3.0",
     "karma-spec-reporter": "0.0.26",

--- a/packages/composer-systests/karma.conf.js
+++ b/packages/composer-systests/karma.conf.js
@@ -74,9 +74,13 @@ module.exports = function(config) {
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: ['Chrome'],
-
-
+        browsers: ['FirefoxHeadless'],
+        customLaunchers: {
+          FirefoxHeadless: {
+            base: 'Firefox',
+            flags: [ '-headless' ],
+          },
+        },
         // Continuous Integration mode
         // if true, Karma captures browsers, runs the tests and exits
         singleRun: false,

--- a/packages/composer-systests/package.json
+++ b/packages/composer-systests/package.json
@@ -53,7 +53,7 @@
     "homedir": "^0.6.0",
     "karma": "^1.3.0",
     "karma-browserify": "^5.1.0",
-    "karma-chrome-launcher": "^2.0.0",
+    "karma-firefox-launcher": "^1.0.0",
     "karma-mocha": "^1.3.0",
     "karma-spec-reporter": "0.0.26",
     "license-check": "^1.1.5",

--- a/packages/composer-website/jekylldocs/prereqs-ubuntu.sh
+++ b/packages/composer-website/jekylldocs/prereqs-ubuntu.sh
@@ -67,6 +67,9 @@ npm install npm@latest -g
 # Ensure that CA certificates are installed
 sudo apt-get -y install apt-transport-https ca-certificates
 
+# Install firefox
+sudo apt-get -y install firefox
+
 # Add Docker repository key to APT keychain
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 

--- a/packages/generator-hyperledger-composer/generators/angular/templates/karma.conf.js
+++ b/packages/generator-hyperledger-composer/generators/angular/templates/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function (config) {
     frameworks: ['jasmine', '@angular/cli'],
     plugins: [
       require('karma-jasmine'),
-      require('karma-chrome-launcher'),
+      require('karma-firefox-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
       require('@angular/cli/plugins/karma')
@@ -38,7 +38,13 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['FirefoxHeadless'],
+    customLaunchers: {
+       FirefoxHeadless: {
+         base: 'Firefox',
+         flags: [ '-headless' ],
+       },
+    },
     singleRun: false
   });
 };

--- a/packages/generator-hyperledger-composer/generators/angular/templates/package.json
+++ b/packages/generator-hyperledger-composer/generators/angular/templates/package.json
@@ -48,7 +48,7 @@
     "jasmine-core": "~2.5.2",
     "jasmine-spec-reporter": "~3.2.0",
     "karma": "~1.4.1",
-    "karma-chrome-launcher": "~2.0.0",
+    "karma-firefox-launcher": "^1.0.0",
     "karma-cli": "~1.0.1",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",


### PR DESCRIPTION
Fix #2180 
Updating relevant package.json and karma.conf.js files to pick up karma-firefox-launcher
and run relevant UT(s) in Firefox's headless mode.

The need for firefox arouse because of it's availability across all arch.

Signed-off-by: Krishna Harsha Voora krishvoor@in.ibm.com