### PR TITLE
Store issuer flag in identity in fake CA (resolves #1770)

### DIFF
--- a/packages/composer-connector-embedded/lib/embeddedconnection.js
+++ b/packages/composer-connector-embedded/lib/embeddedconnection.js
@@ -314,7 +314,10 @@ class EmbeddedConnection extends Connection {
                 issuer: DEFAULT_ISSUER,
                 secret: 'adminpw',
                 certificate,
-                imported: false
+                imported: false,
+                options: {
+                    issuer: true
+                }
             });
         }
         return this.getIdentities()
@@ -359,6 +362,10 @@ class EmbeddedConnection extends Connection {
      */
     createIdentity(securityContext, identityName, options) {
         let identities;
+        const currentIdentity = securityContext.getIdentity();
+        if (!currentIdentity.options.issuer) {
+            throw new Error(`The identity ${currentIdentity.name} does not have permission to create a new identity ${identityName}`);
+        }
         return this.getIdentities()
             .then((identities_) => {
                 identities = identities_;
@@ -388,7 +395,8 @@ class EmbeddedConnection extends Connection {
                     issuer: DEFAULT_ISSUER,
                     secret,
                     certificate,
-                    imported: false
+                    imported: false,
+                    options: options || {}
                 };
                 return identities.add(identityName, identity)
                     .then(() => {

--- a/packages/composer-connector-web/lib/webconnection.js
+++ b/packages/composer-connector-web/lib/webconnection.js
@@ -328,7 +328,10 @@ class WebConnection extends Connection {
                 issuer: DEFAULT_ISSUER,
                 secret: 'adminpw',
                 certificate,
-                imported: false
+                imported: false,
+                options: {
+                    issuer: true
+                }
             });
         }
         return this.getIdentities()
@@ -373,6 +376,10 @@ class WebConnection extends Connection {
      */
     createIdentity(securityContext, identityName, options) {
         let identities;
+        const currentIdentity = securityContext.getIdentity();
+        if (!currentIdentity.options.issuer) {
+            throw new Error(`The identity ${currentIdentity.name} does not have permission to create a new identity ${identityName}`);
+        }
         return this.getIdentities()
             .then((identities_) => {
                 identities = identities_;
@@ -402,7 +409,8 @@ class WebConnection extends Connection {
                     issuer: DEFAULT_ISSUER,
                     secret,
                     certificate,
-                    imported: false
+                    imported: false,
+                    options: options || {}
                 };
                 return identities.add(identityName, identity)
                     .then(() => {

--- a/packages/composer-connector-web/test/webconnection.js
+++ b/packages/composer-connector-web/test/webconnection.js
@@ -37,19 +37,12 @@ const sinon = require('sinon');
 
 describe('WebConnection', () => {
 
-    const identity = {
-        identifier: 'ae360f8a430cc34deb2a8901ef3efed7a2eed753d909032a009f6984607be65a',
-        name: 'bob1',
-        issuer: 'ce295bc0df46512670144b84af55f3d9a3e71b569b1e38baba3f032dc3000665',
-        secret: 'suchsecret',
-        certificate: ''
-    };
-
     let sandbox;
     let mockConnectionManager;
     let mockConnectionProfileManager;
     let mockConnectionProfileStore;
     let mockSecurityContext;
+    let identity;
     let connection;
 
     beforeEach(() => {
@@ -66,6 +59,17 @@ describe('WebConnection', () => {
         });
         mockConnectionProfileStore.save.resolves();
         mockSecurityContext = sinon.createStubInstance(WebSecurityContext);
+        identity = {
+            identifier: 'ae360f8a430cc34deb2a8901ef3efed7a2eed753d909032a009f6984607be65a',
+            name: 'bob1',
+            issuer: 'ce295bc0df46512670144b84af55f3d9a3e71b569b1e38baba3f032dc3000665',
+            secret: 'suchsecret',
+            certificate: '',
+            options: {
+                issuer: true
+            }
+        };
+        mockSecurityContext.getIdentity.returns(identity);
         connection = new WebConnection(mockConnectionManager, 'devFabric1', 'org.acme.business');
     });
 
@@ -368,7 +372,10 @@ describe('WebConnection', () => {
                         'YWRtaW4=',
                         '----- END CERTIFICATE -----'
                     ].join('\n').concat('\n'),
-                    imported: false
+                    imported: false,
+                    options: {
+                        issuer: true
+                    }
                 });
         });
 
@@ -464,10 +471,44 @@ describe('WebConnection', () => {
                         issuer: '89e0c13fa652f52d91fc90d568b70070d6ed1a59c5d9f452dfb1b2a199b1928e',
                         name: 'doge',
                         secret: 'f892c30a',
-                        imported: false
+                        imported: false,
+                        options: { }
                     });
                     result.should.be.deep.equal({ userID: 'doge', userSecret: 'f892c30a' });
                 });
+        });
+
+        it('should store a new identity along with additional options if it does not exists', () => {
+            sandbox.stub(uuid, 'v4').returns('f892c30a-7799-4eac-8377-06da53600e5');
+            mockIdentitiesDataCollection.exists.withArgs('doge').resolves(false);
+            mockIdentitiesDataCollection.add.withArgs('doge').resolves();
+            return connection.createIdentity(mockSecurityContext, 'doge', { issuer: true })
+                .then((result) => {
+                    sinon.assert.calledOnce(mockIdentitiesDataCollection.add);
+                    sinon.assert.calledWith(mockIdentitiesDataCollection.add, 'doge', {
+                        certificate: [
+                            '----- BEGIN CERTIFICATE -----',
+                            'ZG9nZTpmODkyYzMwYS03Nzk5LTRlYWMtODM3Ny0wNmRhNTM2MDBlNQ==',
+                            '----- END CERTIFICATE -----'
+                        ].join('\n').concat('\n'),
+                        identifier: '8b36964b0cd0b9aea800b3fb293b3024d5cd6346f6aff4a589eb4d408ea76799',
+                        issuer: '89e0c13fa652f52d91fc90d568b70070d6ed1a59c5d9f452dfb1b2a199b1928e',
+                        name: 'doge',
+                        secret: 'f892c30a',
+                        imported: false,
+                        options: {
+                            issuer: true
+                        }
+                    });
+                    result.should.be.deep.equal({ userID: 'doge', userSecret: 'f892c30a' });
+                });
+        });
+
+        it('should throw if the current identity is not an issuer', () => {
+            identity.options.issuer = false;
+            (() => {
+                connection.createIdentity(mockSecurityContext, 'doge');
+            }).should.throw(/does not have permission to create a new identity/);
         });
 
     });


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?

## Issue/User story
<!--- What issue / user story is this for -->
Web profile lets you add new ids even if not issuer #1770

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
The fake CA used by the embedded and the web runtime stores all of the identities that are issued. We need to store the issuer flag (along with any other options) so we can simulate the ACL check performed by the Fabric CA during `createIdentity`.

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->