### PR TITLE
Add network admin participant (contributes to #670)

### DIFF
--- a/packages/composer-common/lib/system/org.hyperledger.composer.system.cto
+++ b/packages/composer-common/lib/system/org.hyperledger.composer.system.cto
@@ -83,6 +83,10 @@ asset Network identified by networkId {
   o String networkId
 }
 
+participant NetworkAdmin identified by participantId {
+    o String participantId
+}
+
 // -----------------------------------------------------------------------------
 // Historian
 
@@ -167,5 +171,5 @@ transaction RevokeIdentity {
 
 // --------------------------------------------------------------------------
 transaction UpdateBusinessNetwork {
-  o String businessNetworkArchive
+    o String businessNetworkArchive
 }

--- a/packages/composer-common/test/codegen/loopbackvisitorcircular.js
+++ b/packages/composer-common/test/codegen/loopbackvisitorcircular.js
@@ -54,7 +54,7 @@ describe('LoopbackVisitor with Circular Model', () => {
 
                     // Visit all of the loaded model files and check that they were all generated
                     const schemas = modelManager.accept(visitor, { fileWriter: mockFileWriter });
-                    schemas.length.should.equal(45);
+                    schemas.length.should.equal(46);
                 });
 
             });

--- a/packages/composer-runtime/test/registrymanager.js
+++ b/packages/composer-runtime/test/registrymanager.js
@@ -123,7 +123,7 @@ describe('RegistryManager', () => {
             sinon.stub(registryManager, 'ensure').resolves(mockRegistry);
             return registryManager.createSystemDefaults()
                 .then(() => {
-                    sinon.assert.callCount(registryManager.ensure,16);
+                    sinon.assert.callCount(registryManager.ensure,17);
                     sinon.assert.calledWith(registryManager.ensure, 'Asset', 'org.hyperledger.composer.system.HistorianRecord', 'Asset registry for org.hyperledger.composer.system.HistorianRecord', true);
                     sinon.assert.calledWith(registryManager.ensure, 'Asset', 'org.hyperledger.composer.system.Identity', 'Asset registry for org.hyperledger.composer.system.Identity', true);
                     sinon.assert.calledWith(registryManager.ensure, 'Asset', 'org.hyperledger.composer.system.AssetRegistry', sinon.match.any, sinon.match.any);


### PR DESCRIPTION
As a network starter, I can bind an initial set of identities to participants at deployment time #670

Add a NetworkAdmin participant that we can bind an identity to during deployment if no bootstrap participants are specified. Adding this in ASAP so we can get the ACLs prepared ahead of time.