### PR TITLE
Allow ACL wildcards at root level (contributes to #670)

### DIFF
--- a/packages/composer-common/lib/acl/modelbinding.js
+++ b/packages/composer-common/lib/acl/modelbinding.js
@@ -153,6 +153,11 @@ class ModelBinding {
         if (ModelUtil.isRecursiveWildcardName(this.qualifiedName)) {
             const namespaces = mm.getNamespaces();
 
+            // Check for recursive glob only
+            if (!ns) {
+                return;
+            }
+
             if (namespaces.findIndex(function (element, index, array) {
                 return (ns === element || element.startsWith(ns + '.'));
             })=== -1) {

--- a/packages/composer-common/lib/acl/parser.pegjs
+++ b/packages/composer-common/lib/acl/parser.pegjs
@@ -1449,12 +1449,20 @@ BindingNoInstance
   };
 }
 
+BindingRootRecursive
+  = '**'
+    {
+        return {
+            type: "BindingRootRecursive",
+            qualifiedName: '**',
+            location: location()
+        };
+    }
+
 Noun
  = Binding
  / BindingNoInstance
-
-NounNoInstance
- = BindingNoInstance
+ / BindingRootRecursive
 
 /**
  * A single verb.
@@ -1494,6 +1502,7 @@ Participant
  = 'ANY'
  / Binding
  / BindingNoInstance
+ / BindingRootRecursive
 
 Predicate
  = "(" __ test:$Expression __ ")" __
@@ -1509,8 +1518,12 @@ StringSequence "string"
         return chars.join("");
       }
 
+Transaction
+ = BindingNoInstance
+ / BindingRootRecursive
+
 SimpleTransactionSpecification
- = "transaction:" __ "\"" binding:BindingNoInstance "\"" __
+ = "transaction:" __ "\"" binding:Transaction "\"" __
 {
     return {
         binding: binding
@@ -1518,7 +1531,7 @@ SimpleTransactionSpecification
 }
 
 ConditionalTransactionSpecification
- = "transaction" __ variableBinding:VariableBinding? __ ":" __ "\"" binding:BindingNoInstance "\"" __
+ = "transaction" __ variableBinding:VariableBinding? __ ":" __ "\"" binding:Transaction "\"" __
 {
     return {
         variableBinding: variableBinding,

--- a/packages/composer-common/lib/modelutil.js
+++ b/packages/composer-common/lib/modelutil.js
@@ -82,6 +82,8 @@ class ModelUtil {
             // matching namespace
         } else if (ModelUtil.isRecursiveWildcardName(fqn) && (typeNS + '.').startsWith(ns + '.')) {
             // matching recursive namespace
+        } else if (ModelUtil.isRecursiveWildcardName(fqn) && !ns) {
+            // matching root recursive namespace
         } else {
             // does not match
             return false;

--- a/packages/composer-common/test/acl/modelbinding.js
+++ b/packages/composer-common/test/acl/modelbinding.js
@@ -35,6 +35,7 @@ describe('ModelBinding', () => {
     const classAst = {'type':'Binding','qualifiedName':'org.acme.Car'};
     const classWithIdentifierAst = {'type':'Binding','qualifiedName':'org.acme.Car','instanceId':'ABC123'};
     const variableAst = {'type':'Identifier','name':'dan'};
+    const rootRecursiveNamespaceAst = {'type':'BindingRootRecursive','qualifiedName':'**'};
 
     const missingClass = {'type':'Binding','qualifiedName':'org.acme.Missing','instanceId':'ABC123'};
     const missingNamespace = {'type':'Binding','qualifiedName':'org.missing.Missing.*'};
@@ -92,6 +93,12 @@ describe('ModelBinding', () => {
             modelBinding = new ModelBinding( aclRule, classAst );
             modelBinding.validate();
             modelBinding.toString().should.equal('ModelBinding org.acme.Car');
+        });
+
+        it('should validate correct contents for a root recursive namespace reference', () => {
+            modelBinding = new ModelBinding( aclRule, rootRecursiveNamespaceAst );
+            modelBinding.validate();
+            modelBinding.toString().should.equal('ModelBinding **');
         });
 
         it('should validate correct contents for a class reference with an identifier', () => {

--- a/packages/composer-common/test/modelutil.js
+++ b/packages/composer-common/test/modelutil.js
@@ -154,6 +154,10 @@ describe('ModelUtil', function () {
         it('should return false for a non-matching recursive wildcard', () => {
             ModelUtil.isMatchingType(type, 'org.ac.**').should.be.false;
         });
+
+        it('should return true for a root recursive wildcard match', () => {
+            ModelUtil.isMatchingType(type, '**').should.be.true;
+        });
     });
 
     describe('#getNamespace', function() {

--- a/packages/composer-runtime/test/accesscontroller.js
+++ b/packages/composer-runtime/test/accesscontroller.js
@@ -377,6 +377,12 @@ describe('AccessController', () => {
                 .should.be.true;
         });
 
+        it('should return true if the ACL rule specifies a matching root recursive namespace', () => {
+            setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "**" action: ALLOW}');
+            controller.matchNoun(asset, aclManager.getAclRules()[0])
+                .should.be.true;
+        });
+
         it('should return false if the ACL rule specifies a non-matching fully qualified identifier', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P5678" operation: READ resource: "org.acme.test.TestAsset#A5678" action: ALLOW}');
             controller.matchNoun(asset, aclManager.getAclRules()[0])
@@ -482,6 +488,12 @@ describe('AccessController', () => {
                 .should.be.true;
         });
 
+        it('should return true if the ACL rule specifies a matching root recursive namespace', () => {
+            setAclFile('rule R1 {description: "Test R1" participant: "**" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}');
+            controller.matchParticipant(participant, aclManager.getAclRules()[0])
+                .should.be.true;
+        });
+
         it('should return false if the ACL rule specifies a non-matching fully qualified identifier', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "org.acme.test.TestParticipant#P1234" operation: READ resource: "org.acme.test.TestAsset#A1234" action: ALLOW}');
             controller.matchParticipant(participant, aclManager.getAclRules()[0])
@@ -556,8 +568,14 @@ describe('AccessController', () => {
                 .should.be.true;
         });
 
-        it('should return true if the ACL rule specifies a matching recusive namespace', () => {
+        it('should return true if the ACL rule specifies a matching recursive namespace', () => {
             setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction: "org.acme.test.**" action: ALLOW}');
+            controller.matchTransaction(transaction, aclManager.getAclRules()[0])
+                .should.be.true;
+        });
+
+        it('should return true if the ACL rule specifies a matching root recursive namespace', () => {
+            setAclFile('rule R1 {description: "Test R1" participant: "ANY" operation: READ resource: "org.acme.test.TestAsset#A1234" transaction: "**" action: ALLOW}');
             controller.matchTransaction(transaction, aclManager.getAclRules()[0])
                 .should.be.true;
         });


### PR DESCRIPTION
As a network starter, I can bind an initial set of identities to participants at deployment time #670

Permit an ACL rule to reference _all_ types in the business network without knowledge of the namespace. I'm introducing this so we can deliver sample ACL rules that work for all business networks without having to force us or users to provide the right namespace in those rules.

Should permit ACL rules such as:

```
rule EverybodyCanReadEverything {
    description: "Allow all participants read access to all resources"
    participant: "org.acme.sample.SampleParticipant"
    operation: READ
    resource: "**"
    action: ALLOW
}
```

All instances of SampleParticipant have READ access to all instances of all types in the business network, including the system types.