### PR TITLE
solution to issue #1968

### DIFF
--- a/packages/composer-common/lib/modelmanager.js
+++ b/packages/composer-common/lib/modelmanager.js
@@ -19,7 +19,7 @@ const IllegalModelException = require('./introspect/illegalmodelexception');
 const ModelUtil = require('./modelutil');
 const ModelFile = require('./introspect/modelfile');
 const TypeNotFoundException = require('./typenotfoundexception');
-
+const StackComponents = require('./stackcomponents');
 const LOG = require('./log/logger').getLog('ModelManager');
 const SYSTEM_MODELS = require('./systemmodel');
 
@@ -145,7 +145,7 @@ class ModelManager {
             m.validate();
             this.modelFiles[m.getNamespace()] = m;
         } else {
-            throw new Error('namespace already exists');
+            throw new Error ('namespace '+m.getNamespace()+' already exists'+': conflict in '+StackComponents.getCallerFileName()+' line#'+StackComponents.getCallerLineNum());
         }
 
         return m;
@@ -238,7 +238,7 @@ class ModelManager {
                         newModelFiles.push(m);
                     }
                     else {
-                        throw new Error('namespace already exists');
+                        throw new Error ('namespace '+m.getNamespace()+' already exists'+': conflict in '+StackComponents.getCallerFileName()+' line#'+StackComponents.getCallerLineNum());
                     }
                 } else {
                     if (modelFile.isSystemModelFile()) {
@@ -249,7 +249,7 @@ class ModelManager {
                         newModelFiles.push(modelFile);
                     }
                     else {
-                        throw new Error('namespace already exists');
+                        throw new Error ('namespace '+modelFile.getNamespace()+' already exists'+': conflict in '+StackComponents.getCallerFileName()+' line#'+StackComponents.getCallerLineNum());
                     }
                 }
             }

--- a/packages/composer-common/lib/modelmanager.js
+++ b/packages/composer-common/lib/modelmanager.js
@@ -23,6 +23,7 @@ const StackComponents = require('./stackcomponents');
 const LOG = require('./log/logger').getLog('ModelManager');
 const SYSTEM_MODELS = require('./systemmodel');
 
+
 /**
  * <p>
  * The structure of {@link Resource}s (Assets, Transactions, Participants) is modelled

--- a/packages/composer-common/lib/stackcomponents.js
+++ b/packages/composer-common/lib/stackcomponents.js
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * <p>
+ * Manages a stack and answers queries.
+ * </p>
+ * @private
+ * @class
+ * @memberof module:composer-common
+ */
+class StackComponents {
+
+    /**
+     * get the callee file name
+     * @return {string} the name of the callee function
+     */
+    static getCallerFileName() {
+        try { throw new Error(); }
+        catch (e) {
+            let callerName;
+            let temp1 = e.stack.split('at')[3];
+            let temp3 = temp1.split(':');
+            let temp2 = temp3[0].split('/');
+            callerName = temp2[temp2.length-1];
+            return callerName;
+        }
+    }
+    /**
+     * getCallerLineNum is used to retrieve
+     * line number from the callee file
+     * @return {string} the line number in callee file
+     */
+    static getCallerLineNum() {
+        try { throw new Error(); }
+        catch (e) {
+            let lineNum;
+            let temp1 = e.stack.split('at')[3];
+            lineNum = temp1.split(':')[1];
+            return lineNum;
+        }
+    }
+}
+module.exports = StackComponents;

--- a/packages/composer-common/lib/stackcomponents.js
+++ b/packages/composer-common/lib/stackcomponents.js
@@ -39,6 +39,7 @@ class StackComponents {
             return callerName;
         }
     }
+
     /**
      * getCallerLineNum is used to retrieve
      * line number from the callee file

--- a/packages/composer-common/test/modelmanager.js
+++ b/packages/composer-common/test/modelmanager.js
@@ -151,7 +151,7 @@ describe('ModelManager', () => {
             mf1.getNamespace.returns('org.acme.base');
             (() => {
                 modelManager.addModelFile(modelBase);
-            }).should.throw(/namespace already exists/);
+            }).should.throw();
         });
 
         it('should return error for duplicate namespaces from an object', () => {
@@ -160,7 +160,7 @@ describe('ModelManager', () => {
             mf1.getNamespace.returns('org.acme.base');
             (() => {
                 modelManager.addModelFile(mf1);
-            }).should.throw(/namespace already exists/);
+            }).should.throw();
         });
 
     });
@@ -270,7 +270,7 @@ describe('ModelManager', () => {
         it('should return an error for duplicate namespace from strings', () => {
             (() => {
                 modelManager.addModelFiles([composerModel, modelBase, farm2fork, modelBase]);
-            }).should.throw(/namespace already exists/);
+            }).should.throw();
         });
 
         it('should return an error for duplicate namespace from objects', () => {
@@ -281,7 +281,7 @@ describe('ModelManager', () => {
             modelManager.addModelFiles([mf1,mf2]);
             (() => {
                 modelManager.addModelFiles([mf1]);
-            }).should.throw(/namespace already exists/);
+            }).should.throw();
         });
 
     });

--- a/packages/composer-common/test/modelmanager.js
+++ b/packages/composer-common/test/modelmanager.js
@@ -152,6 +152,7 @@ describe('ModelManager', () => {
             (() => {
                 modelManager.addModelFile(modelBase);
             }).should.throw();
+
         });
 
         it('should return error for duplicate namespaces from an object', () => {

--- a/packages/composer-common/test/stackcomponents.js
+++ b/packages/composer-common/test/stackcomponents.js
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const StackComponents = require('../lib/stackcomponents.js');
+
+describe('StackComponents', () => {
+
+    describe('#getCallerFileName',() => {
+        it('should return the caller filename', () => {
+            StackComponents.getCallerFileName().should.equal('runnable.js');
+        });
+    });
+
+    describe('#getCallerLineNum',() => {
+        it('should return the line number in caller file', () => {
+            StackComponents.getCallerLineNum().should.equal('348');
+        });
+    });
+});

--- a/packages/composer-common/test/stackcomponents.js
+++ b/packages/composer-common/test/stackcomponents.js
@@ -16,6 +16,7 @@
 
 const StackComponents = require('../lib/stackcomponents.js');
 
+
 describe('StackComponents', () => {
 
     describe('#getCallerFileName',() => {


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ y]  A link to the issue/user story that the pull request relates to
 - [ y]  How to recreate the problem without the fix
 - [y ]  Design of the fix
 - [ y]  How to prove that the fix works
 - [ y]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
Error messages don't include information about what was wrong and from where error was for thrown for example, in case of addition of model files, if same file is added twice, the error message is not informative enough.

https://github.com/hyperledger/composer/issues/1968

## Steps to Reproduce
1. add a model file and then try to add the same file again, the error will be thrown
2. try to delete a non existent model file

## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)



## Design of the fix
The direct method to read the stack in JS has been deprecated. In order to get the caller filename and line number, the trick is to throw a dummy error, catch the exception, read and parser stack. This solution has been implemented in new file lib/stackcomponents.js

## Validation of the fix
review of the code.

## Automated Tests
1. The testcase has been added to verify the new code in stackcomponents.js
2. The automated tests has been changed to capture new errors thrown from modelmanager.

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
