### PR TITLE
Cannot use business networks deployed using playground

### DIFF
--- a/packages/composer-playground/src/app/import/deploy.component.spec.ts
+++ b/packages/composer-playground/src/app/import/deploy.component.spec.ts
@@ -15,6 +15,7 @@ import { SampleBusinessNetworkService } from '../services/samplebusinessnetwork.
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { AlertService } from '../basic-modals/alert.service';
 import { DeployComponent } from './deploy.component';
+import { BusinessNetworkDefinition } from 'composer-common';
 
 import * as sinon from 'sinon';
 import * as chai from 'chai';
@@ -185,21 +186,19 @@ describe('DeployComponent', () => {
     });
 
     describe('deployEmptyNetwork', () => {
-        beforeEach(() => {
-            mockBusinessNetworkService.createNewBusinessDefinition.returns({network: 'myNetwork'});
-        });
-
         it('should create the empty business network if chosen', fakeAsync(() => {
             component['networkName'] = 'myName';
             component['networkDescription'] = 'myDescription';
 
-            mockBusinessNetworkService.createNewBusinessDefinition.returns({network: 'myNetwork'});
+            const businessNetworkDefinition = new BusinessNetworkDefinition('my-network@1.0.0');
+            mockBusinessNetworkService.createNewBusinessDefinition.returns(businessNetworkDefinition);
 
             component.deployEmptyNetwork();
 
             tick();
             mockBusinessNetworkService.createNewBusinessDefinition.should.have.been.calledWith('', '', sinon.match.object, sinon.match.string);
-            component['currentBusinessNetwork'].should.deep.equal({network: 'myNetwork'});
+            component['currentBusinessNetwork'].should.equal(businessNetworkDefinition);
+            businessNetworkDefinition.getAclManager().getAclFile().getDefinitions().should.be.a('string');
         }));
     });
 

--- a/packages/composer-playground/src/app/import/import.component.ts
+++ b/packages/composer-playground/src/app/import/import.component.ts
@@ -121,9 +121,28 @@ export abstract class ImportComponent implements OnInit {
                 test: 'mocha --recursive'
             }
         };
+        let permissions =
+`rule NetworkAdminUser {
+    description: "Grant business network administrators full access to user resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "**"
+    action: ALLOW
+}
+
+rule NetworkAdminSystem {
+    description: "Grant business network administrators full access to system resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "org.hyperledger.composer.system.**"
+    action: ALLOW
+}`;
 
         this.currentBusinessNetworkPromise = Promise.resolve().then(() => {
             this.currentBusinessNetwork = this.sampleBusinessNetworkService.createNewBusinessDefinition('', '', packageJson, readme);
+            const aclManager = this.currentBusinessNetwork.getAclManager();
+            const aclFile = aclManager.createAclFile('permissions.acl', permissions);
+            aclManager.setAclFile(aclFile);
             return this.currentBusinessNetwork;
         });
     }

--- a/packages/composer-playground/src/app/import/update.component.spec.ts
+++ b/packages/composer-playground/src/app/import/update.component.spec.ts
@@ -16,6 +16,7 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { AlertService } from '../basic-modals/alert.service';
 import { UpdateComponent } from './update.component';
 import { ActiveDrawer } from '../common/drawer';
+import { BusinessNetworkDefinition } from 'composer-common';
 
 import * as sinon from 'sinon';
 import * as chai from 'chai';
@@ -190,21 +191,19 @@ describe('UpdateComponent', () => {
     });
 
     describe('deployEmptyNetwork', () => {
-        beforeEach(() => {
-            mockBusinessNetworkService.createNewBusinessDefinition.returns({network: 'myNetwork'});
-        });
-
         it('should create the empty business network if chosen', fakeAsync(() => {
             component['networkName'] = 'myName';
             component['networkDescription'] = 'myDescription';
 
-            mockBusinessNetworkService.createNewBusinessDefinition.returns({network: 'myNetwork'});
+            const businessNetworkDefinition = new BusinessNetworkDefinition('my-network@1.0.0');
+            mockBusinessNetworkService.createNewBusinessDefinition.returns(businessNetworkDefinition);
 
             component.deployEmptyNetwork();
 
             tick();
             mockBusinessNetworkService.createNewBusinessDefinition.should.have.been.calledWith('', '', sinon.match.object, sinon.match.string);
-            component['currentBusinessNetwork'].should.deep.equal({network: 'myNetwork'});
+            component['currentBusinessNetwork'].should.equal(businessNetworkDefinition);
+            businessNetworkDefinition.getAclManager().getAclFile().getDefinitions().should.be.a('string');
         }));
     });
 

--- a/packages/composer-playground/src/app/services/admin.service.spec.ts
+++ b/packages/composer-playground/src/app/services/admin.service.spec.ts
@@ -526,7 +526,7 @@ describe('AdminService', () => {
     });
 
     describe('start', () => {
-        it('should start a business network', fakeAsync(inject([AdminService], (service: AdminService) => {
+        it('should start a business network without options', fakeAsync(inject([AdminService], (service: AdminService) => {
             sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
 
             service.start(businessNetworkDefMock);
@@ -534,6 +534,17 @@ describe('AdminService', () => {
             tick();
 
             adminConnectionMock.start.should.have.been.calledWith(businessNetworkDefMock);
+        })));
+
+        it('should start a business network with options', fakeAsync(inject([AdminService], (service: AdminService) => {
+            sinon.stub(service, 'getAdminConnection').returns(adminConnectionMock);
+
+            const startOptions = { option: 1 };
+            service.start(businessNetworkDefMock, startOptions);
+
+            tick();
+
+            adminConnectionMock.start.should.have.been.calledWith(businessNetworkDefMock, startOptions);
         })));
     });
 

--- a/packages/composer-playground/src/app/services/admin.service.ts
+++ b/packages/composer-playground/src/app/services/admin.service.ts
@@ -187,8 +187,9 @@ export class AdminService {
         return this.getAdminConnection().install(businessNetworkDefinitionName);
     }
 
-    public start(businessNetworkDefinition: BusinessNetworkDefinition): Promise<void> {
-        return this.getAdminConnection().start(businessNetworkDefinition);
+    public start(businessNetworkDefinition: BusinessNetworkDefinition, startOptions?: object): Promise<void> {
+        // Cast to <any> as TypeScript does not know about default parameters :-(
+        return (<any> this.getAdminConnection()).start(businessNetworkDefinition, startOptions);
     }
 
     public importIdentity(connectionProfileName: string, id: string, certificate: string, privateKey: string): Promise<void> {

--- a/packages/composer-playground/src/app/services/samplebusinessnetwork.service.spec.ts
+++ b/packages/composer-playground/src/app/services/samplebusinessnetwork.service.spec.ts
@@ -8,7 +8,7 @@ import { AlertService } from '../basic-modals/alert.service';
 import { IdentityCardService } from './identity-card.service';
 import { AdminService } from './admin.service';
 import { ClientService } from './client.service';
-import { BusinessNetworkDefinition, AclFile } from 'composer-common';
+import { BusinessNetworkDefinition, AclFile, Serializer, Factory, ModelManager } from 'composer-common';
 
 import * as sinon from 'sinon';
 import * as chai from 'chai';
@@ -41,6 +41,12 @@ describe('SampleBusinessNetworkService', () => {
         aclFileMock = sinon.createStubInstance(AclFile);
         alertMock = sinon.createStubInstance(AlertService);
         businessNetworkMock = sinon.createStubInstance(BusinessNetworkDefinition);
+
+        const modelManager = new ModelManager();
+        const factory = new Factory(modelManager);
+        const serializer = new Serializer(factory, modelManager);
+        businessNetworkMock.getFactory.returns(factory);
+        businessNetworkMock.getSerializer.returns(serializer);
 
         alertMock.busyStatus$ = {next: sinon.stub()};
 
@@ -148,6 +154,38 @@ describe('SampleBusinessNetworkService', () => {
         })));
     });
 
+    describe('generateBootstrapTransactions', () => {
+        const sanitize = (result) => {
+            result.forEach((tx) => {
+                delete tx.timestamp;
+                delete tx.transactionId;
+                return tx;
+            });
+        };
+
+        it('should generate bootstrap transactions for the specified identity name', fakeAsync(inject([SampleBusinessNetworkService], (service: SampleBusinessNetworkService) => {
+            const bootstrapTransactions = service.generateBootstrapTransactions(businessNetworkMock, 'doggoship1');
+            sanitize(bootstrapTransactions);
+            bootstrapTransactions.should.deep.equal([
+                {
+                    $class: 'org.hyperledger.composer.system.AddParticipant',
+                    resources: [
+                        {
+                            $class: 'org.hyperledger.composer.system.NetworkAdmin',
+                            participantId: 'doggoship1'
+                        }
+                    ],
+                    targetRegistry: 'resource:org.hyperledger.composer.system.ParticipantRegistry#org.hyperledger.composer.system.NetworkAdmin'
+                },
+                {
+                    $class: 'org.hyperledger.composer.system.IssueIdentity',
+                    participant: 'resource:org.hyperledger.composer.system.NetworkAdmin#doggoship1',
+                    identityName: 'doggoship1'
+                }
+            ]);
+        })));
+    });
+
     describe('deployBusinessNetwork', () => {
         it('should deploy the business network definition', fakeAsync(inject([SampleBusinessNetworkService], (service: SampleBusinessNetworkService) => {
             let metaData = {getPackageJson: sinon.stub().returns({})};
@@ -185,6 +223,7 @@ describe('SampleBusinessNetworkService', () => {
 
             adminMock.install.should.have.been.called;
             adminMock.start.should.have.been.called;
+            adminMock.start.should.have.been.calledWith(sinon.match.object, sinon.match.object);
 
             alertMock.busyStatus$.next.should.have.been.calledWith(null);
         })));

--- a/packages/composer-playground/src/app/services/samplebusinessnetwork.service.ts
+++ b/packages/composer-playground/src/app/services/samplebusinessnetwork.service.ts
@@ -10,6 +10,7 @@ import { IdentityCardService } from './identity-card.service';
 
 @Injectable()
 export class SampleBusinessNetworkService {
+
     constructor(private adminService: AdminService,
                 private clientService: ClientService,
                 private alertService: AlertService,
@@ -54,6 +55,30 @@ export class SampleBusinessNetworkService {
             });
     }
 
+    generateBootstrapTransactions(businessNetworkDefinition: BusinessNetworkDefinition, identityName: string): Object[] {
+        const factory = businessNetworkDefinition.getFactory();
+        const serializer = businessNetworkDefinition.getSerializer();
+        const participant = factory.newResource('org.hyperledger.composer.system', 'NetworkAdmin', identityName);
+        const targetRegistry = factory.newRelationship('org.hyperledger.composer.system', 'ParticipantRegistry', participant.getFullyQualifiedType());
+        const addParticipantTransaction = factory.newTransaction('org.hyperledger.composer.system', 'AddParticipant');
+        Object.assign(addParticipantTransaction, {
+            resources: [ participant ],
+            targetRegistry
+        });
+        const issueIdentityTransaction = factory.newTransaction('org.hyperledger.composer.system', 'IssueIdentity');
+        Object.assign(issueIdentityTransaction, {
+            participant: factory.newRelationship('org.hyperledger.composer.system', 'NetworkAdmin', identityName),
+            identityName
+        });
+        const result = [
+            addParticipantTransaction,
+            issueIdentityTransaction
+        ].map((bootstrapTransaction) => {
+            return serializer.toJSON(bootstrapTransaction);
+        });
+        return result;
+    }
+
     public deployBusinessNetwork(businessNetworkDefinition: BusinessNetworkDefinition, networkName: string, networkDescription: string): Promise<void> {
         let packageJson = businessNetworkDefinition.getMetadata().getPackageJson();
         packageJson.name = networkName;
@@ -88,7 +113,9 @@ export class SampleBusinessNetworkService {
                     title: 'Starting Business Network'
                 });
 
-                return this.adminService.start(newNetwork);
+                const bootstrapTransactions = this.generateBootstrapTransactions(businessNetworkDefinition, 'admin');
+
+                return this.adminService.start(newNetwork, { bootstrapTransactions });
             })
             .then(() => {
                 return this.identityCardService.createIdentityCard('admin', newNetwork.getName(), 'adminpw', this.identityCardService.getCurrentIdentityCard().getConnectionProfile());


### PR DESCRIPTION
As a network starter, I can bind an initial set of identities to participants at deployment time #670 

Playground doesn't work - oops.

Need to bind the `admin` identity to a `NetworkAdmin` participant so the `admin` identity can be used to access the newly deployed business network. Whilst I'm in here, I'm adding a `permissions.acl` file for the empty network so it can be used.