### PR TITLE
add redirect for original jsdoc location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,12 +49,11 @@ jspm_packages
 # vscode folder
 .vscode
 
-#generated jsdoc
-packages/composer-website/jekylldocs/jsdoc/
-
 #Broken link report
 packages/composer-website/linkresults.txt
 
+packages/composer-website/jsondata
+packages/composer-website/jekyll-docs/api-doc-inline
 
 packages/composer-playground/src/assets/npmlist.json
 

--- a/packages/composer-website/.gitignore
+++ b/packages/composer-website/.gitignore
@@ -49,10 +49,6 @@ out
 
 # Ignore temporary built installers.
 installers/*/install.sh
-<<<<<<< 4b6e003898216b4b101ca9793443d0072efd85a6
-jekylldocs/install*.sh
-=======
 jekylldocs/install*.sh
 jsondata/**
 jekylldocs/api-doc-inline/**/*
->>>>>>> updates for unittests

--- a/packages/composer-website/jekylldocs/jsdoc/index.html
+++ b/packages/composer-website/jekylldocs/jsdoc/index.html
@@ -1,0 +1,12 @@
+---
+---
+ <html xmlns="http://www.w3.org/1999/xhtml">    
+  <head>      
+    <title>Hyperledger Composer</title>      
+    <meta http-equiv="refresh" content="0;URL='{{site.baseurl}}/api-doc-inline/api-doc-index.html'" />    
+  </head>    
+  <body> 
+    <p>This page has moved to a <a href="{{site.baseurl}}/api-doc-inline/api-doc-index.html">
+      {{site.baseurl}}/api-doc-inline/api-doc-index.html</a>.</p> 
+  </body>  
+</html>   


### PR DESCRIPTION
Signed-off-by: Matthew B White <whitemat@uk.ibm.com>
Added a simple redirect.
Note that if a file has the --- then jekyll will run it's template engine over it. therefore the correct base url is usable.