### PR TITLE
Add banner to homepage announcing 0.14

### DIFF
--- a/packages/composer-website/jekylldocs/index.html
+++ b/packages/composer-website/jekylldocs/index.html
@@ -33,10 +33,10 @@ title: Hyperledger Composer - Create business networks and blockchain applicatio
   </div>
 </div>
 </div>
-<!-- <div class="homepage-callout">
+<div class="homepage-callout">
   <div class="callout-copy">
-  <p><strong>Update April 27: </strong>Now with experimental Hyperledger Fabric V1.0 support, for more information please see our <a href="https://github.com/hyperledger/composer/releases">release notes</a></p>
-</div> -->
+  <p><strong>Update October 12: </strong>Version 0.14 has been released.  To deliver major enhancements to the security model, this update may break existing projects.  Please see our <a href=“https://github.com/hyperledger/composer/releases“>release notes</a></p>
+</div>
 </div>
 <div class="trio">
   <div class="trio-left">


### PR DESCRIPTION
Banner announces 0.14 coming out, warns of breaking changes, and links to the release notes.

This is item (10) on the checklist in #2319 