### PR TITLE
Add a lamer version of the header with no link

### DIFF
--- a/packages/composer-website/jekylldocs/index.html
+++ b/packages/composer-website/jekylldocs/index.html
@@ -33,10 +33,10 @@ title: Hyperledger Composer - Create business networks and blockchain applicatio
   </div>
 </div>
 </div>
-<!-- <div class="homepage-callout">
+<div class="homepage-callout">
   <div class="callout-copy">
-  <p><strong>Update April 27: </strong>Now with experimental Hyperledger Fabric V1.0 support, for more information please see our <a href="https://github.com/hyperledger/composer/releases">release notes</a></p>
-</div> -->
+  <p><strong>Update Oct 11: </strong>Version 0.14 has been released.  To deliver major enhancements to the security model, this update may break existing projects.  Please see https://github.com/hyperledger/composer/releases</p>
+</div>
 </div>
 <div class="trio">
   <div class="trio-left">


### PR DESCRIPTION
Because the link checker is failing when I include a href to the release notes, for now we'll just get in a lame version where the user has to copy/paste the URL, and then when we figure out what's up with the link checker failing it, we can improve!

This is adding in the homepage banner stating that 0.14 may break existing projects, and offering the URL to the release notes.