### PR TITLE
only allow a single enrollment per issued identity

### DIFF
--- a/packages/composer-connector-hlfv1/lib/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/lib/hlfconnection.js
@@ -871,7 +871,7 @@ class HLFConnection extends Connection {
                 enrollmentID: userID,
                 affiliation: options.affiliation || 'org1',  // or eg. org1.department1
                 attrs: [],
-                maxEnrollments: options.maxEnrollments || 0,
+                maxEnrollments: options.maxEnrollments || 1,
                 role: options.role || 'client'
             };
 

--- a/packages/composer-connector-hlfv1/test/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/test/hlfconnection.js
@@ -2276,7 +2276,7 @@ describe('HLFConnection', () => {
                         enrollmentID: 'auser',
                         affiliation: 'org1',
                         attrs: [],
-                        maxEnrollments: 0,
+                        maxEnrollments: 1,
                         role: 'client'
                     }, mockUser);
                 });
@@ -2296,7 +2296,7 @@ describe('HLFConnection', () => {
                         attrs: [
                             {name: 'hf.Registrar.Roles', value: 'client'}
                         ],
-                        maxEnrollments: 0,
+                        maxEnrollments: 1,
                         role: 'client'
                     }, mockUser);
                 });
@@ -2332,7 +2332,7 @@ describe('HLFConnection', () => {
                         enrollmentID: 'auser',
                         affiliation: 'bank_b',
                         attrs: [],
-                        maxEnrollments: 0,
+                        maxEnrollments: 1,
                         role: 'client'
                     }, mockUser);
                 });
@@ -2350,7 +2350,7 @@ describe('HLFConnection', () => {
                         enrollmentID: 'auser',
                         affiliation: 'org1',
                         attrs: [],
-                        maxEnrollments: 0,
+                        maxEnrollments: 1,
                         role: 'peer,auditor'
                     }, mockUser);
                 });
@@ -2371,7 +2371,7 @@ describe('HLFConnection', () => {
                             {name: 'attr1', value: 'value1'},
                             {name: 'attr2', value: 'value2'}
                         ],
-                        maxEnrollments: 0,
+                        maxEnrollments: 1,
                         role: 'client'
                     }, mockUser);
                 });
@@ -2392,7 +2392,7 @@ describe('HLFConnection', () => {
                             {name: 'attr1', value: 'value1'},
                             {name: 'attr2', value: 20}
                         ],
-                        maxEnrollments: 0,
+                        maxEnrollments: 1,
                         role: 'client'
                     }, mockUser);
                 });


### PR DESCRIPTION
This pull request addresses
https://github.com/hyperledger/composer/issues/2056

where rather than allowing an issued identity to be enrolled indefinitely it restricts it to a single enrollment and if you lose the crypto material then you cannot automatically re-enroll the user. Basically it will stop the confusion of identity not being registered when a user someone re-enrolls a user they had already bound to a participant and not understand why it doesn’t work as effectively it is a new certificate (admittedly for the same identity) and it would then output a different error message this time from the CA saying cannot enroll.

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
