### PR TITLE
Added new option to Factory API

### DIFF
--- a/packages/composer-common/api.txt
+++ b/packages/composer-common/api.txt
@@ -31,11 +31,11 @@ class BusinessNetworkMetadata {
 }
 class Factory {
    + void constructor(ModelManager) 
-   + Resource newResource(string,string,string,Object,boolean,string,boolean) throws TypeNotFoundException
+   + Resource newResource(string,string,string,Object,boolean,string,boolean,boolean) throws TypeNotFoundException
    + Resource newConcept(string,string,Object,boolean,string,boolean) throws TypeNotFoundException
    + Relationship newRelationship(string,string,string) throws TypeNotFoundException
-   + Resource newTransaction(string,string,string,Object,string,boolean) 
-   + Resource newEvent(string,string,string,Object,string,boolean) 
+   + Resource newTransaction(string,string,string,Object,string,boolean,boolean) 
+   + Resource newEvent(string,string,string,Object,string,boolean,boolean) 
 }
 class FileWallet extends Wallet {
    + string getHomeDirectory() 

--- a/packages/composer-common/changelog.txt
+++ b/packages/composer-common/changelog.txt
@@ -11,6 +11,9 @@
 #
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
+Version 0.14.0  {06b9fe19f8d0de36b494e9a3d3e0776f} 2017-10-16
+- Added allowEmptyId option to Factory.newResource Factory.newEvent and Factory.newTransaction
+
 Version 0.13.2 {9298d9135c88f3d3e2e508de1981f1b9} 2017-09-29
 - Added validate option to Serializer.fromJSON
 - Remove IdCard from public API

--- a/packages/composer-common/lib/factory.js
+++ b/packages/composer-common/lib/factory.js
@@ -69,11 +69,15 @@ class Factory {
      * <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl>
      * @param {boolean} [options.includeOptionalFields] - if <code>options.generate</code>
      * is specified, whether optional fields should be generated.
+     * @param {boolean} [options.allowEmptyId] - if <code>options.allowEmptyId</code>
+     * is specified as true, a zero length string for id is allowed (allows it to be filled in later).
      * @return {Resource} the new instance
      * @throws {TypeNotFoundException} if the type is not registered with the ModelManager
      */
     newResource(ns, type, id, options) {
-        if(!id || typeof(id) !== 'string') {
+        options = options || {};
+
+        if(typeof(id) !== 'string') {
             let formatter = Globalize.messageFormatter('factory-newinstance-invalididentifier');
             throw new Error(formatter({
                 namespace: ns,
@@ -81,12 +85,14 @@ class Factory {
             }));
         }
 
-        if(id.trim().length === 0) {
-            let formatter = Globalize.messageFormatter('factory-newinstance-missingidentifier');
-            throw new Error(formatter({
-                namespace: ns,
-                type: type
-            }));
+        if(!(options.allowEmptyId && id==='')) {
+            if(id.trim().length === 0) {
+                let formatter = Globalize.messageFormatter('factory-newinstance-missingidentifier');
+                throw new Error(formatter({
+                    namespace: ns,
+                    type: type
+                }));
+            }
         }
 
         const qualifiedName = ModelUtil.getFullyQualifiedName(ns, type);
@@ -105,7 +111,6 @@ class Factory {
         }
 
         let newObj = null;
-        options = options || {};
         if(options.disableValidation) {
             newObj = new Resource(this.modelManager, ns, type, id);
         }
@@ -202,6 +207,8 @@ class Factory {
      * <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl>
      * @param {boolean} [options.includeOptionalFields] - if <code>options.generate</code>
      * is specified, whether optional fields should be generated.
+     * @param {boolean} [options.allowEmptyId] - if <code>options.allowEmptyId</code>
+     * is specified as true, a zero length string for id is allowed (allows it to be filled in later).
      * @return {Resource} A resource for the new transaction.
      */
     newTransaction(ns, type, id, options) {
@@ -237,6 +244,8 @@ class Factory {
      * <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl>
      * @param {boolean} [options.includeOptionalFields] - if <code>options.generate</code>
      * is specified, whether optional fields should be generated.
+     * @param {boolean} [options.allowEmptyId] - if <code>options.allowEmptyId</code>
+     * is specified as true, a zero length string for id is allowed (allows it to be filled in later).
      * @return {Resource} A resource for the new event.
      */
     newEvent(ns, type, id, options) {

--- a/packages/composer-common/lib/introspect/validator.js
+++ b/packages/composer-common/lib/introspect/validator.js
@@ -41,7 +41,7 @@ class Validator {
      * @throws {Error} throws an error to report the message
      */
     reportError(id, msg) {
-        throw new Error( 'Invalid validator for field ' + id + ' ' + this.getField().getFullyQualifiedName() + ': ' + msg );
+        throw new Error( 'Validator error for field ' + id + ' ' + this.getField().getFullyQualifiedName() + ': ' + msg );
     }
 
     /**

--- a/packages/composer-common/test/factory.js
+++ b/packages/composer-common/test/factory.js
@@ -67,9 +67,27 @@ describe('Factory', function() {
     });
 
     describe('#newResource', function() {
-        it('should throw creating a new instance without an ID', function() {
+
+        it('should not throw creating a new instance with a zero length string as the ID if the option to allowEmptyId is set to boolean true', function() {
+            const resource = factory.newResource(namespace, assetName, '', {allowEmptyId: true});
+            resource.assetId.should.equal('');
+        });
+
+        it('should throw creating a new instance with a non-zero length string as the ID if the option to allowEmptyId is not set to boolean true', function() {
+            (() => {
+                factory.newResource(namespace, assetName, '     ', {});
+            }).should.throw(/Missing identifier/);
+        });
+
+        it('should throw creating a new instance with a null ID', function() {
             (() => {
                 factory.newResource(namespace, assetName, null);
+            }).should.throw(/Invalid or missing identifier/);
+        });
+
+        it('should throw creating a new instance with an ID of an invalid type', function() {
+            (() => {
+                factory.newResource(namespace, assetName, 1);
             }).should.throw(/Invalid or missing identifier/);
         });
 
@@ -78,6 +96,19 @@ describe('Factory', function() {
                 factory.newResource(namespace, assetName, '     ');
             }).should.throw(/Missing identifier/);
         });
+
+        it('should throw creating a new instance with an ID that is just whitespace if the option to allowEmptyId is not set to boolean true', function() {
+            (() => {
+                factory.newResource(namespace, assetName, '     ', {allowEmptyId: 'true'});
+            }).should.throw(/Missing identifier/);
+        });
+
+        it('should throw creating a new instance with an ID that is just whitespace if the option to allowEmptyId is set to boolean true', function() {
+            (() => {
+                factory.newResource(namespace, assetName, '     ', {allowEmptyId: true});
+            }).should.throw(/Missing identifier/);
+        });
+
 
         it('should throw creating an abstract asset', function() {
             (() => {

--- a/packages/composer-common/test/introspect/stringvalidator.js
+++ b/packages/composer-common/test/introspect/stringvalidator.js
@@ -34,7 +34,7 @@ describe('StringValidator', () => {
         it('should throw for invalid regexes', () => {
             (() => {
                 new StringValidator(mockField, '/^[A-z/' );
-            }).should.throw(/Invalid validator for field/);
+            }).should.throw(/Validator error for field/);
         });
 
     });
@@ -56,7 +56,7 @@ describe('StringValidator', () => {
 
             (() => {
                 v.validate('id', 'xyz');
-            }).should.throw(/Invalid validator for field id org.acme.myField/);
+            }).should.throw(/Validator error for field id org.acme.myField/);
         });
     });
 });

--- a/packages/composer-playground/src/app/test/resource/resource.component.spec.ts
+++ b/packages/composer-playground/src/app/test/resource/resource.component.spec.ts
@@ -212,7 +212,15 @@ describe('ResourceComponent', () => {
             component['resourceDefinition'].should.equal('{\n  "$class": "com.org"\n}');
 
             // We use the following internal calls
-            mockFactory.newResource.should.be.called;
+            mockFactory.newResource.should.be.calledWith(undefined,
+                                                         'class.declaration',
+                                                         '',
+                                                         {
+                                                            generate: 'empty',
+                                                            includeOptionalFields: false,
+                                                            disableValidation: true,
+                                                            allowEmptyId: true
+                                                         });
             component.onDefinitionChanged.should.be.calledOn;
         });
 

--- a/packages/composer-playground/src/app/test/resource/resource.component.ts
+++ b/packages/composer-playground/src/app/test/resource/resource.component.ts
@@ -117,11 +117,13 @@ export class ResourceComponent implements OnInit {
         let factory = businessNetworkDefinition.getFactory();
         let idx = Math.round(Math.random() * 9999).toString();
         idx = leftPad(idx, 4, '0');
-        let id = `${this.resourceDeclaration.getIdentifierFieldName()}:${idx}`;
+        let id = '';
         try {
             const generateParameters = {
                 generate: withSampleData ? 'sample' : 'empty',
-                includeOptionalFields: this.includeOptionalFields
+                includeOptionalFields: this.includeOptionalFields,
+                disableValidation: true,
+                allowEmptyId: true
             };
             let resource = factory.newResource(
                 this.resourceDeclaration.getModelFile().getNamespace(),
@@ -129,7 +131,12 @@ export class ResourceComponent implements OnInit {
                 id,
                 generateParameters);
             let serializer = this.clientService.getBusinessNetwork().getSerializer();
-            let json = serializer.toJSON(resource);
+
+            const serializeValidationOptions = {
+                validate: false
+            };
+
+            let json = serializer.toJSON(resource, serializeValidationOptions);
             this.resourceDefinition = JSON.stringify(json, null, 2);
             this.onDefinitionChanged();
         } catch (error) {


### PR DESCRIPTION
## Issue/User story
<!--- What issue / user story is this for -->
issue1012
The original issue was that the user couldn't use a regex on an asset/participant identifier because the automatic generation of ids was highly unlikely to pass the regex test (e.g. email address).
This then moved into a discussion about what the behaviour of Playground should be when creating new instances. The design team have observed that in many cases, the users' first action is to change the generated ID to something they'd prefer and so the idea now is that the playground should not generate any sample data (even the ID) when a new instance is being created via the 'Add Asset\Participant' buttons. 
The effect of this is that a skeleton object can always be generated now but the user will have to add a valid ID before it can be committed to the blockchain.  Also, since validation is only disabled for the generation of the resource, a regex can now be used to restrict IDs and other fields as desired.

<!-- please include any links to issues here -->
I've hit another bug while testing this which is that clicking the 'Include optional properties' checkbox after you've populated the instance via the codemirror editor, resets all your current changes (so you'll lose the ID you entered) and I'll raise that as a separate issue after this.

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
Added the capability to 'allowEmptyId' field upon creation of an object instance by the factory in the common project. This is so that the Playground UI and other application clients can create new instances which don't have an identifier immediately. 

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->
Manual checks of the Playground UI 

This should probably be checked by @dselman or @sstone1 since it's a change to a couple of classes in composer-common, and by @caroline-church or @nklincoln from the UI team too.

Signed-off-by: Sam Smith <smithsj@uk.ibm.com>