### PR TITLE
Fix for user updating namespaces in playground (Issue 1796)

### DIFF
--- a/packages/composer-playground/src/app/test/test.component.ts
+++ b/packages/composer-playground/src/app/test/test.component.ts
@@ -45,11 +45,17 @@ export class TestComponent implements OnInit, OnDestroy {
 
                 return this.clientService.getBusinessNetworkConnection().getAllAssetRegistries()
                     .then((assetRegistries) => {
-                        assetRegistries.forEach((assetRegistry) => {
+                        let modelFileAssetTypes = this.clientService.getBusinessNetwork().getModelManager().getAssetDeclarations(false).map((a) => a.name);
+
+                        for (let i = assetRegistries.length - 1; i >= 0; i--) {
+                            let assetRegistry = assetRegistries[i];
                             let index = assetRegistry.id.lastIndexOf('.');
                             let displayName = assetRegistry.id.substring(index + 1);
                             assetRegistry.displayName = displayName;
-                        });
+                            if (modelFileAssetTypes.indexOf(displayName) === -1) {
+                              assetRegistries.splice(i, 1);
+                            }
+                        }
 
                         this.registries['assets'] = assetRegistries.sort((a, b) => {
                             return a.id.localeCompare(b.id);
@@ -58,11 +64,17 @@ export class TestComponent implements OnInit, OnDestroy {
                         return this.clientService.getBusinessNetworkConnection().getAllParticipantRegistries();
                     })
                     .then((participantRegistries) => {
-                        participantRegistries.forEach((participantRegistry) => {
+                        let modelFileParticipantTypes = this.clientService.getBusinessNetwork().getModelManager().getParticipantDeclarations(false).map((a) => a.name);
+
+                        for (let i = participantRegistries.length - 1; i >= 0; i--) {
+                            let participantRegistry = participantRegistries[i];
                             let index = participantRegistry.id.lastIndexOf('.');
                             let displayName = participantRegistry.id.substring(index + 1);
                             participantRegistry.displayName = displayName;
-                        });
+                            if (modelFileParticipantTypes.indexOf(displayName) === -1) {
+                              participantRegistries.splice(i, 1);
+                            }
+                        }
 
                         this.registries['participants'] = participantRegistries.sort((a, b) => {
                             return a.id.localeCompare(b.id);

--- a/packages/composer-runtime/lib/registry.js
+++ b/packages/composer-runtime/lib/registry.js
@@ -69,6 +69,19 @@ class Registry extends EventEmitter {
             .then((objects) => {
                 return objects.map((object) => {
                     object = Registry.removeInternalProperties(object);
+                    return object;
+                }).filter((object) => {
+                    try {
+                        this.serializer.fromJSON(object);
+                        return true;
+                    } catch (err) {
+                        if(err.message.includes('Cannot instantiate Type')) {
+                            return false;
+                        } else {
+                            throw new Error(err);
+                        }
+                    }
+                }).map((object) => {
                     return this.serializer.fromJSON(object);
                 }).reduce((promise, resource) => {
                     return promise.then((resources) => {

--- a/packages/composer-runtime/test/registry.js
+++ b/packages/composer-runtime/test/registry.js
@@ -104,6 +104,28 @@ describe('Registry', () => {
             }).returns(mockResource2);
         });
 
+        it('should filter objects that cannot be serialized using fromJSON due to cannot instantiate type error', () => {
+            mockSerializer.fromJSON.withArgs({
+                $class: 'org.doge.Doge',
+                assetId: 'doge2'
+            }).throws(new Error('Cannot instantiate Type'));
+
+            registry.getAll()
+                .then((resources) => {
+                    resources.length.should.deep.equal(1);
+                    resources[0].should.deep.equal({theValue: 'the value 1'});
+                });
+        });
+
+        it('should throw error if serializing using fromJSON throws an error that is not cannot instantiate type', () => {
+            mockSerializer.fromJSON.withArgs({
+                $class: 'org.doge.Doge',
+                assetId: 'doge2'
+            }).throws(new Error('Another type of error'));
+
+            registry.getAll().should.be.rejectedWith('Another type of error');
+        });
+
         it('should get and parse all of the resources in the registry', () => {
             return registry.getAll()
                 .then((resources) => {


### PR DESCRIPTION
#1796 

Pull request to fix defect 1796. Removes from the left panel of composer test assets and participants that no longer exist in the current model and allows for them to be reinstated later with no loss of data. Removes from view of all transactions transactions that refer to types not in the current deployed model to avoid error popup. Allows transactions to be reinstated once all data in the transaction works with current model.

Code changes
- Updated playground test component to compare data from registries against current model data and remove from data array elements not in current model. (Used for removing them from left column of test view)
- Updated runtime registry component to filter the resource array based on if the cannot instantiate type error is returned from the serializer and throw an error otherwise (Used for removing the error popup on the all transactions view)
- Updated tests to check new functionality