### PR TITLE
Make Business Network Cards portable between systems

### DIFF
--- a/packages/composer-client/lib/hlfstorelocator.js
+++ b/packages/composer-client/lib/hlfstorelocator.js
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const path = require('path');
+const FileSystemCardStore = require('composer-common').FileSystemCardStore;
+
+/**
+ * Provide locations to use for HLF client data and crypto stores.
+ *
+ * @private
+ * @class
+ * @memberof module:composer-client
+ */
+class HLFStoreLocator {
+    /**
+     * Constructor.
+     * @param {FileSystemCardStore} [cardStore] Card store currently in use.
+     */
+    constructor(cardStore) {
+        this.cardStore = (cardStore instanceof FileSystemCardStore) ? cardStore : new FileSystemCardStore();
+    }
+
+    /**
+     * Get the location in which to store HLF client data for a given card.
+     * @param {String} cardName Name of a card.
+     * @returns {String} File system path.
+     */
+    clientDataStorePath(cardName) {
+        return path.join(this.cardStore.cardPath(cardName), 'client-data-store');
+    }
+
+    /**
+     * Update the supplied connection profile to include additional information required for a given card to be used
+     * to connect to the Fabric instance it describes.
+     * @param {Object} connectionProfile Connection profile data.
+     * @param {String} cardName Name of the card.
+     * @returns {Object} Connection profile data.
+     */
+    updateConnectionProfile(connectionProfile, cardName) {
+        connectionProfile.keyValStore = this.clientDataStorePath(cardName);
+        return connectionProfile;
+    }
+}
+
+module.exports = HLFStoreLocator;

--- a/packages/composer-client/test/hlfstorelocator.js
+++ b/packages/composer-client/test/hlfstorelocator.js
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const FileSystemCardStore = require('composer-common').FileSystemCardStore;
+const HLFStoreLocator = require('../lib/hlfstorelocator');
+const path = require('path');
+
+const chai = require('chai');
+chai.should();
+
+describe('HLFStoreLocator', function() {
+    const assertValidStorePath = (storePath) => {
+        path.isAbsolute(storePath).should.be.true;
+        storePath.should.include('client-data-store');
+    };
+
+    describe('#clientDataStorePath', function() {
+        it('should return absolute path with no card store', function() {
+            const storeLocator = new HLFStoreLocator();
+            const cardName = 'conga-card';
+            const result = storeLocator.clientDataStorePath(cardName);
+            assertValidStorePath(result);
+        });
+
+        it('should return absolute path with valid card store', function() {
+            const cardStore = new FileSystemCardStore();
+            const storeLocator = new HLFStoreLocator(cardStore);
+            const cardName = 'conga-card';
+            const result = storeLocator.clientDataStorePath(cardName);
+            assertValidStorePath(result);
+        });
+    });
+
+    describe('#updateConnectionProfile', function() {
+        it('should set keyValStore property', function() {
+            const storeLocator = new HLFStoreLocator();
+            const result = storeLocator.updateConnectionProfile({}, 'conga');
+            assertValidStorePath(result.keyValStore);
+        });
+    });
+
+});

--- a/packages/composer-common/lib/cardstore/filesystemcardstore.js
+++ b/packages/composer-common/lib/cardstore/filesystemcardstore.js
@@ -50,28 +50,26 @@ class FileSystemCardStore extends BusinessNetworkCardStore {
         this.thenifyFs = thenifyAll(this.fs);
         this.rimrafOptions = Object.assign({}, this.fs);
         this.rimrafOptions.disableGlob = true;
-        this.storePath = options.storePath || FileSystemCardStore._defaultStorePath(os.homedir);
+        this.storePath = options.storePath || FileSystemCardStore.defaultStorePath(os.homedir);
     }
 
     /**
      * Get the default store path based on the user's home directory, or based on the filesystem root
      * directory if the supplied function does not exist or returns a falsy value.
-     * @private
      * @param {Function} homedirFunction Function to obtain the user's home directory
      * @returns {String} Absolute path
      */
-    static _defaultStorePath(homedirFunction) {
+    static defaultStorePath(homedirFunction) {
         const homeDirectory = (homedirFunction && homedirFunction()) || path.sep;
         return path.join(homeDirectory, '.composer', 'cards');
     }
 
     /**
      * Get the file system path for a given card.
-     * @private
      * @param {String} cardName name of the card.
      * @return {String} directory in which the card is stored.
      */
-    _cardPath(cardName) {
+    cardPath(cardName) {
         return path.join(this.storePath, cardName);
     }
 
@@ -82,7 +80,7 @@ class FileSystemCardStore extends BusinessNetworkCardStore {
      */
     get(cardName) {
         const method = 'get';
-        return IdCard.fromDirectory(this._cardPath(cardName), this.fs).catch(cause => {
+        return IdCard.fromDirectory(this.cardPath(cardName), this.fs).catch(cause => {
             LOG.error(method, cause);
             const error = new Error('Card not found: ' + cardName);
             error.cause = cause;
@@ -103,7 +101,7 @@ class FileSystemCardStore extends BusinessNetworkCardStore {
             return Promise.reject(new Error('Invalid card name'));
         }
 
-        return card.toDirectory(this._cardPath(cardName), this.fs).catch(cause => {
+        return card.toDirectory(this.cardPath(cardName), this.fs).catch(cause => {
             LOG.error(method, cause);
             const error = new Error('Failed to save card: ' + cardName);
             error.cause = cause;
@@ -146,7 +144,7 @@ class FileSystemCardStore extends BusinessNetworkCardStore {
     delete(cardName) {
         const method = 'delete';
 
-        const cardPath = this._cardPath(cardName);
+        const cardPath = this.cardPath(cardName);
         return this.thenifyFs.access(cardPath).then(() => {
             return thenifyRimraf(cardPath, this.rimrafOptions);
         }).catch(cause => {

--- a/packages/composer-common/lib/idcard.js
+++ b/packages/composer-common/lib/idcard.js
@@ -131,7 +131,7 @@ class IdCard {
      * @return {Object} connection profile.
      */
     getConnectionProfile() {
-        return this.connectionProfile;
+        return Object.assign({}, this.connectionProfile);
     }
 
     /**

--- a/packages/composer-common/test/cardstore/filesystemcardstore.js
+++ b/packages/composer-common/test/cardstore/filesystemcardstore.js
@@ -59,16 +59,16 @@ describe('FileSystemCardStore', function() {
         });
     });
 
-    describe('#_defaultStorePath', function() {
+    describe('#defaultStorePath', function() {
         it('should handle undefined homedir function', function() {
-            FileSystemCardStore._defaultStorePath(undefined).should.be.a('String').that.is.not.empty;
+            FileSystemCardStore.defaultStorePath(undefined).should.be.a('String').that.is.not.empty;
         });
 
         it('should handle empty value returned from homedir function', function() {
             const homedir = () => {
                 return null;
             };
-            FileSystemCardStore._defaultStorePath(homedir).should.be.a('String').that.is.not.empty;
+            FileSystemCardStore.defaultStorePath(homedir).should.be.a('String').that.is.not.empty;
         });
     });
 

--- a/packages/composer-common/test/idcard.js
+++ b/packages/composer-common/test/idcard.js
@@ -473,4 +473,12 @@ describe('IdCard', function() {
         });
     });
 
+    describe('#getConnectionProfile', function() {
+        it('should make defensive copy of connection profile', function() {
+            const connectionProfile = minimalCard.getConnectionProfile();
+            connectionProfile.CONGA = 'CONGA';
+            minimalCard.getConnectionProfile().should.not.equal(connectionProfile);
+        });
+    });
+
 });


### PR DESCRIPTION
Contributes to #935 

Modify the keyValStore property in connection profiles retrieved from
Business Network Cards to ensure that HLFConnectionManager saves Fabric
client data in a suitable location on the local filsystem, regardless
of any absolute path specified in the connection profile.