### PR TITLE
Improve portability of Connection Profiles

### DIFF
--- a/packages/composer-client/lib/businessnetworkconnection.js
+++ b/packages/composer-client/lib/businessnetworkconnection.js
@@ -447,9 +447,13 @@ class BusinessNetworkConnection extends EventEmitter {
         let card;
 
         return this.cardStore.get(cardName)
-            .then((card_)=>{
-                card = card_;
-                return this.connectionProfileManager.connectWithData(card.getConnectionProfile(),card.getBusinessNetworkName(), additionalConnectOptions);
+            .then((retrievedCard)=>{
+                card = retrievedCard;
+                if (!additionalConnectOptions) {
+                    additionalConnectOptions = {};
+                }
+                additionalConnectOptions.cardName = cardName;
+                return this.connectionProfileManager.connectWithData(card.getConnectionProfile(), card.getBusinessNetworkName(), additionalConnectOptions);
             })
             .then((connection) => {
                 LOG.exit(method);

--- a/packages/composer-common/lib/cardstore/filesystemcardstore.js
+++ b/packages/composer-common/lib/cardstore/filesystemcardstore.js
@@ -14,13 +14,13 @@
 
 'use strict';
 
+const composerUtil = require('../util');
 const nodeFs = require('fs');
-const os = require('os');
 const path = require('path');
 const rimraf = require('rimraf');
 const thenifyAll = require('thenify-all');
-const IdCard = require('../idcard');
 const BusinessNetworkCardStore = require('./businessnetworkcardstore');
+const IdCard = require('../idcard');
 
 const thenifyRimraf = thenifyAll(rimraf);
 
@@ -50,19 +50,7 @@ class FileSystemCardStore extends BusinessNetworkCardStore {
         this.thenifyFs = thenifyAll(this.fs);
         this.rimrafOptions = Object.assign({}, this.fs);
         this.rimrafOptions.disableGlob = true;
-        this.storePath = options.storePath || FileSystemCardStore._defaultStorePath(os.homedir);
-    }
-
-    /**
-     * Get the default store path based on the user's home directory, or based on the filesystem root
-     * directory if the supplied function does not exist or returns a falsy value.
-     * @private
-     * @param {Function} homedirFunction Function to obtain the user's home directory
-     * @returns {String} Absolute path
-     */
-    static _defaultStorePath(homedirFunction) {
-        const homeDirectory = (homedirFunction && homedirFunction()) || path.sep;
-        return path.join(homeDirectory, '.composer', 'cards');
+        this.storePath = options.storePath || path.join(composerUtil.homeDirectory(), '.composer', 'cards');
     }
 
     /**

--- a/packages/composer-common/lib/idcard.js
+++ b/packages/composer-common/lib/idcard.js
@@ -131,7 +131,7 @@ class IdCard {
      * @return {Object} connection profile.
      */
     getConnectionProfile() {
-        return this.connectionProfile;
+        return Object.assign({}, this.connectionProfile);
     }
 
     /**

--- a/packages/composer-common/lib/util.js
+++ b/packages/composer-common/lib/util.js
@@ -15,6 +15,8 @@
 'use strict';
 
 const Globalize = require('./globalize');
+const os = require('os');
+const path = require('path');
 const SecurityContext = require('./securitycontext');
 const SecurityException = require('./securityexception');
 const uuid = require('uuid');
@@ -120,6 +122,15 @@ class Util {
             return id;
         });
 
+    }
+
+    /**
+     * Get the home directory path for the current user. Returns root directory for environments where there is no
+     * file system path available.
+     * @returns {String} A file system path.
+     */
+    static homeDirectory() {
+        return (os.homedir && os.homedir()) || path.sep;
     }
 
 }

--- a/packages/composer-common/test/cardstore/filesystemcardstore.js
+++ b/packages/composer-common/test/cardstore/filesystemcardstore.js
@@ -59,19 +59,6 @@ describe('FileSystemCardStore', function() {
         });
     });
 
-    describe('#_defaultStorePath', function() {
-        it('should handle undefined homedir function', function() {
-            FileSystemCardStore._defaultStorePath(undefined).should.be.a('String').that.is.not.empty;
-        });
-
-        it('should handle empty value returned from homedir function', function() {
-            const homedir = () => {
-                return null;
-            };
-            FileSystemCardStore._defaultStorePath(homedir).should.be.a('String').that.is.not.empty;
-        });
-    });
-
     describe('#get', function() {
         it('should get a valid identity card', function() {
             const options = { storePath: testStorePath };

--- a/packages/composer-common/test/idcard.js
+++ b/packages/composer-common/test/idcard.js
@@ -473,4 +473,12 @@ describe('IdCard', function() {
         });
     });
 
+    describe('#getConnectionProfile', function() {
+        it('should make defensive copy of connection profile', function() {
+            const connectionProfile = minimalCard.getConnectionProfile();
+            connectionProfile.CONGA = 'CONGA';
+            minimalCard.getConnectionProfile().should.not.equal(connectionProfile);
+        });
+    });
+
 });

--- a/packages/composer-common/test/util.js
+++ b/packages/composer-common/test/util.js
@@ -15,12 +15,18 @@
 'use strict';
 
 const Connection = require('../lib/connection');
+const os = require('os');
+const path = require('path');
 const SecurityContext = require('../lib/securitycontext');
 const SecurityException = require('../lib/securityexception');
 const Util = require('../lib/util');
 const uuid = require('uuid');
-require('chai').should();
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
 const sinon = require('sinon');
+
+chai.use(chaiAsPromised);
+chai.should();
 
 describe('Util', function () {
 
@@ -196,6 +202,19 @@ describe('Util', function () {
             Util.isNull('hello').should.equal(false);
         });
 
+    });
+
+    describe('#homeDirectory', function() {
+        it('should return valid path', function() {
+            const result = Util.homeDirectory();
+            path.isAbsolute(result).should.be.true;
+        });
+
+        it('should return root directory if os.homedir function returns undefined', function() {
+            sandbox.stub(os, 'homedir').returns(undefined);
+            const result = Util.homeDirectory();
+            result.should.equal(path.sep);
+        });
     });
 
 });

--- a/packages/composer-connector-hlfv1/lib/hlfconnectionmanager.js
+++ b/packages/composer-connector-hlfv1/lib/hlfconnectionmanager.js
@@ -14,9 +14,11 @@
 
 'use strict';
 
+const composerUtil = require('composer-common').Util;
 const Logger = require('composer-common').Logger;
 const util = require('util');
 const fs = require('fs');
+const path = require('path');
 
 const LOG = Logger.getLog('HLFConnectionManager');
 
@@ -245,8 +247,8 @@ class HLFConnectionManager extends ConnectionManager {
             throw new Error('The peers array has not been specified in the connection profile');
         } else if (!profileDefinition.peers.length) {
             throw new Error('No peer URLs have been specified in the connection profile');
-        }  else if (!wallet && !profileDefinition.keyValStore) {
-            throw new Error('No key value store directory or wallet has been specified');
+        }  else if (!wallet && !profileDefinition.keyValStore && !profileDefinition.cardName) {
+            throw new Error('No key value store directory, wallet or card name has been specified');
         } else if (!profileDefinition.ca) {
             throw new Error('The certificate authority URL has not been specified in the connection profile');
         } else if (!profileDefinition.channel) {
@@ -263,53 +265,74 @@ class HLFConnectionManager extends ConnectionManager {
      *
      * @param {Client} client the fabric-client
      * @param {Wallet} wallet the wallet implementation or null/undefined
-     * @param {string} keyValStorePath a path for the fileKeyValStore to use or null/undefined if a wallet specified.
+     * @param {Object} profileData The connection profile.
      * @returns {Promise} resolves to a client configured with the required stores
      *
      * @memberOf HLFConnectionManager
      */
-    _setupWallet(client, wallet, keyValStorePath) {
-        const method = '_setupWallet';
-        // If a wallet has been specified, then we want to use that.
-        //let result;
-        LOG.entry(method, client, wallet, keyValStorePath);
+    _setupClientStore(client, wallet, profileData) {
+        const method = '_setupClientStore';
+        LOG.entry(method, client, wallet, profileData);
 
         if (wallet) {
-            LOG.debug(method, 'A wallet has been specified, using wallet proxy');
-            return new HLFWalletProxy(wallet)
-                .then((store) => {
-                    let cryptostore = Client.newCryptoKeyStore(HLFWalletProxy, wallet);
-                    client.setStateStore(store);
-                    let cryptoSuite = Client.newCryptoSuite();
-                    cryptoSuite.setCryptoKeyStore(cryptostore);
-                    client.setCryptoSuite(cryptoSuite);
-                    return store;
-                })
-                .catch((error) => {
-                    LOG.error(method, error);
-                    let newError = new Error('error trying to setup a wallet. ' + error);
-                    throw newError;
-                });
-
-        } else {
-            // No wallet specified, so create a file based key value store.
-            LOG.debug(method, 'Using key value store', keyValStorePath);
-            return Client.newDefaultKeyValueStore({path: keyValStorePath})
-                .then((store) => {
-                    client.setStateStore(store);
-
-                    let cryptoSuite = Client.newCryptoSuite();
-                    cryptoSuite.setCryptoKeyStore(Client.newCryptoKeyStore({path: keyValStorePath}));
-                    client.setCryptoSuite(cryptoSuite);
-
-                    return store;
-                })
-                .catch((error) => {
-                    LOG.error(method, error);
-                    let newError = new Error('error trying to setup a keystore path. ' + error);
-                    throw newError;
-                });
+            return this._setupWallet(client, wallet);
         }
+
+        let storePath;
+        if (profileData.cardName) {
+            storePath = path.join(composerUtil.homeDirectory(), '.composer', 'client-data', profileData.cardName);
+        } else {
+            storePath = profileData.keyValStore;
+        }
+
+        return this._setupFileStore(client, storePath);
+
+    }
+
+    /**
+     * Link a wallet to the fabric-client store and cryptostore
+     * @param {Client} client the fabric client
+     * @param {Wallet} wallet the wallet implementation
+     * @returns {Promise} resolves to a client configured with the required stores
+     */
+    _setupWallet(client, wallet) {
+        const method = '_setupWallet';
+        LOG.entry(method, client, wallet);
+        return new HLFWalletProxy(wallet).then((store) => {
+            const cryptostore = Client.newCryptoKeyStore(HLFWalletProxy, wallet);
+            client.setStateStore(store);
+            const cryptoSuite = Client.newCryptoSuite();
+            cryptoSuite.setCryptoKeyStore(cryptostore);
+            client.setCryptoSuite(cryptoSuite);
+            return store;
+        }).catch((error) => {
+            LOG.error(method, error);
+            const newError = new Error('error trying to setup a wallet. ' + error);
+            throw newError;
+        });
+    }
+
+    /**
+     * Configure the Fabric client with a file-based store.
+     * @param {Client} client The Fabric client
+     * @param {String} keyValStorePath File system location to use for the store
+     * @returns {Promise} resolves to a client configured with the required stores
+     */
+    _setupFileStore(client, keyValStorePath) {
+        const method = '_setupFileStore';
+        LOG.entry(method, client, keyValStorePath);
+        return Client.newDefaultKeyValueStore({path: keyValStorePath}).then((store) => {
+            client.setStateStore(store);
+            const cryptoSuite = Client.newCryptoSuite();
+            cryptoSuite.setCryptoKeyStore(Client.newCryptoKeyStore({path: keyValStorePath}));
+            client.setCryptoSuite(cryptoSuite);
+            return store;
+        })
+        .catch((error) => {
+            LOG.error(method, error);
+            const newError = new Error('error trying to setup a keystore path. ' + error);
+            throw newError;
+        });
     }
 
     /**
@@ -398,7 +421,7 @@ class HLFConnectionManager extends ConnectionManager {
 
         let mspID = connectionOptions.mspID;
         const client = HLFConnectionManager.createClient();
-        return this._setupWallet(client, wallet, connectionOptions.keyValStore)
+        return this._setupClientStore(client, wallet, connectionOptions)
             .then(() => {
                 return client.createUser({
                     username: id,
@@ -492,7 +515,7 @@ class HLFConnectionManager extends ConnectionManager {
         });
 
         // Set up the wallet.
-        return this._setupWallet(client, wallet, connectOptions.keyValStore)
+        return this._setupClientStore(client, wallet, connectOptions)
             .then(() => {
 
                 // Create a CA client.
@@ -521,7 +544,7 @@ class HLFConnectionManager extends ConnectionManager {
         const method = 'exportIdentity';
         LOG.entry(method, connectionProfileName, connectionOptions, id);
         const client = HLFConnectionManager.createClient();
-        return this._setupWallet(client, connectionOptions.wallet, connectionOptions.keyValStore)
+        return this._setupClientStore(client, connectionOptions.wallet, connectionOptions)
             .then(() => {
                 return client.getUserContext(id, true);
             })


### PR DESCRIPTION
Contributes to #935 

Remove portability constraint for connection profiles due to keyValStore path.

Store Fabric client data in a defined path based on the name of the Business
Network Card being used, rather than the absolute path specified in the keyValStore
property of the connection profile.