### PR TITLE
Story2333 network cli

### DIFF
--- a/packages/composer-cli/lib/cmds/network/deployCommand.js
+++ b/packages/composer-cli/lib/cmds/network/deployCommand.js
@@ -20,12 +20,9 @@ module.exports.command = 'deploy [options]';
 module.exports.describe = 'Deploys a business network to the Hyperledger Fabric';
 module.exports.builder = {
     archiveFile: {alias: 'a', required: true, describe: 'The business network archive file name', type: 'string' },
-    connectionProfileName: {alias: 'p', required: false, describe: '', type: 'string' },
-    enrollId: { alias: 'i', required: false, describe: '', type: 'string' },
-    loglevel: { alias: 'l', required: false, describe: 'The initial loglevel to set (INFO|WARNING|ERROR|DEBUG)', type: 'string' },
+    loglevel: { alias: 'l', required: false, describe: 'The initial loglevel to set', choices : ['INFO', 'WARNING', 'ERROR', 'DEBUG'] },
     option: { alias: 'o', required: false, describe: 'Options that are specific specific to connection. Multiple options are specified by repeating this option', type: 'string' },
     optionsFile: { alias: 'O', required: false, describe: 'A file containing options that are specific to connection', type: 'string' },
-    enrollSecret: { alias: 's', required: false, describe: '', type: 'string' },
     networkAdmin: { alias: 'A', required: false, description: 'The identity name of the business network administrator', type: 'string' },
     networkAdminCertificateFile: { alias: 'C', required: false, description: 'The certificate of the business network administrator', type: 'string' },
     networkAdminEnrollSecret: { alias: 'S', required: false, description: 'Use enrollment secret for the business network administrator', type: 'boolean' },

--- a/packages/composer-cli/lib/cmds/network/downloadCommand.js
+++ b/packages/composer-cli/lib/cmds/network/downloadCommand.js
@@ -20,10 +20,6 @@ module.exports.command = 'download [options]';
 module.exports.describe = 'Downloads a business network from the Hyperledger Fabric, does not undeploy';
 module.exports.builder = {
     archiveFile: {alias: 'a', required: true, describe: 'The business network archive file name', type: 'string' },
-    businessNetworkName: {alias: 'n', required: false, describe: 'The business network name', type: 'string' },
-    connectionProfileName: {alias: 'p', required: false, describe: 'The connection profile name', type: 'string' },
-    enrollId: { alias: 'i', required: false, describe: 'The enrollment ID of the user', type: 'string' },
-    enrollSecret: { alias: 's', required: false, describe: 'The enrollment secret of the user', type: 'string' },
     card: { alias: 'c', required: false, description: 'The cardname to use to download the network', type:'string'}
 };
 

--- a/packages/composer-cli/lib/cmds/network/lib/deploy.js
+++ b/packages/composer-cli/lib/cmds/network/lib/deploy.js
@@ -19,7 +19,6 @@ const BusinessNetworkDefinition = Admin.BusinessNetworkDefinition;
 const chalk = require('chalk');
 const cmdUtil = require('../../utils/cmdutils');
 const fs = require('fs');
-const LogLevel = require('./loglevel');
 const ora = require('ora');
 
 /**
@@ -43,7 +42,7 @@ class Deploy {
         let adminConnection;
         let businessNetworkName;
         let spinner;
-        let loglevel;
+        let loglevel = argv.loglevel;
         let cardName = argv.card;
 
         return  Promise.resolve()
@@ -75,7 +74,7 @@ class Deploy {
                 // Build the deploy options.
                 let deployOptions = cmdUtil.parseOptions(argv);
                 if (loglevel) {
-                    deployOptions.logLevel = loglevel;
+                    deployOptions.loglevel = loglevel;
                 }
 
                 // Build the bootstrap tranactions.

--- a/packages/composer-cli/lib/cmds/network/lib/deploy.js
+++ b/packages/composer-cli/lib/cmds/network/lib/deploy.js
@@ -42,14 +42,15 @@ class Deploy {
         let adminConnection;
         let businessNetworkName;
         let spinner;
-        let loglevel = argv.loglevel;
+        let logLevel = argv.loglevel;
         let cardName = argv.card;
 
-        return  Promise.resolve()
-        .then (() => {
-            console.log(chalk.blue.bold('Deploying business network from archive: ')+argv.archiveFile);
-            let archiveFileContents = null;
+
+        console.log(chalk.blue.bold('Deploying business network from archive: ')+argv.archiveFile);
+        let archiveFileContents = null;
             // Read archive file contents
+        return Promise.resolve().then(()=>{
+            // getArchiveFileContents, is a sync function, so use Promise.resolve() to ensure it gives a rejected promise
             archiveFileContents = Deploy.getArchiveFileContents(argv.archiveFile);
             return BusinessNetworkDefinition.fromArchive(archiveFileContents);
         })
@@ -73,8 +74,8 @@ class Deploy {
 
                 // Build the deploy options.
                 let deployOptions = cmdUtil.parseOptions(argv);
-                if (loglevel) {
-                    deployOptions.loglevel = loglevel;
+                if (logLevel) {
+                    deployOptions.logLevel = logLevel;
                 }
 
                 // Build the bootstrap tranactions.

--- a/packages/composer-cli/lib/cmds/network/lib/deploy.js
+++ b/packages/composer-cli/lib/cmds/network/lib/deploy.js
@@ -23,10 +23,7 @@ const LogLevel = require('./loglevel');
 const ora = require('ora');
 
 /**
- * <p>
  * Composer deploy command
- * </p>
- * <p><a href="diagrams/Deploy.svg"><img src="diagrams/deploy.svg" style="width:100%;"/></a></p>
  * @private
  */
 class Deploy {
@@ -43,48 +40,15 @@ class Deploy {
                                   ? true
                                   : false;
         let businessNetworkDefinition;
-
         let adminConnection;
-        let enrollId;
-        let enrollSecret;
-        let connectionProfileName = argv.connectionProfileName;
         let businessNetworkName;
         let spinner;
         let loglevel;
-
         let cardName = argv.card;
-        let usingCard = !(cardName===undefined);
 
-        if (argv.loglevel) {
-            // validate log level as yargs cannot at this time
-            // https://github.com/yargs/yargs/issues/849
-            loglevel = argv.loglevel.toUpperCase();
-            if (!LogLevel.validLogLevel(loglevel)) {
-                return Promise.reject(new Error('loglevel unspecified or not one of (INFO|WARNING|ERROR|DEBUG)'));
-            }
-        }
-
-        return (() => {
-            console.log(chalk.blue.bold('Deploying business network from archive: ')+argv.archiveFile);
-
-            if (!argv.enrollSecret && !usingCard) {
-                return cmdUtil.prompt({
-                    name: 'enrollmentSecret',
-                    description: 'What is the enrollment secret of the user?',
-                    required: true,
-                    hidden: true,
-                    replace: '*'
-                })
-                .then((result) => {
-                    argv.enrollSecret = result.enrollmentSecret;
-                });
-            } else {
-                return Promise.resolve();
-            }
-        })()
+        return  Promise.resolve()
         .then (() => {
-            enrollId = argv.enrollId;
-            enrollSecret = argv.enrollSecret;
+            console.log(chalk.blue.bold('Deploying business network from archive: ')+argv.archiveFile);
             let archiveFileContents = null;
             // Read archive file contents
             archiveFileContents = Deploy.getArchiveFileContents(argv.archiveFile);
@@ -100,11 +64,9 @@ class Deploy {
             adminConnection = cmdUtil.createAdminConnection();
             // if we are performing an update we have to actually connect to the network
             // we want to update!
-            if (!usingCard){
-                return adminConnection.connect(connectionProfileName, enrollId, enrollSecret, updateBusinessNetwork ? businessNetworkDefinition.getName() : null);
-            } else {
-                return adminConnection.connect(cardName, updateBusinessNetwork);
-            }
+
+            return adminConnection.connect(cardName, updateBusinessNetwork);
+
         })
         .then((result) => {
             if (updateBusinessNetwork === false) {
@@ -139,11 +101,9 @@ class Deploy {
 
             return result;
         }).catch((error) => {
-
             if (spinner) {
                 spinner.fail();
             }
-
             console.log();
 
             throw error;

--- a/packages/composer-cli/lib/cmds/network/lib/download.js
+++ b/packages/composer-cli/lib/cmds/network/lib/download.js
@@ -37,39 +37,19 @@ class Download {
     */
     static handler(argv) {
 
-
         let businessNetworkDefinition;
         let businessNetworkName;
         let spinner;
         let cardName = argv.card;
-        let usingCard = !(cardName===undefined);
+
         let businessNetworkConnection = cmdUtil.createBusinessNetworkConnection();
 
-        return (() => {
-
-
-            if (!argv.enrollSecret && !usingCard) {
-                return cmdUtil.prompt({
-                    name: 'enrollmentSecret',
-                    description: 'What is the enrollment secret of the user?',
-                    required: true,
-                    hidden: true,
-                    replace: '*'
-                })
-                .then((result) => {
-                    argv.enrollSecret = result.enrollmentSecret;
-                });
-            } else {
-                return Promise.resolve();
-            }
-        })()
+        return Promise.resolve()
         .then (() => {
             spinner = ora('Downloading deployed Business Network Archive').start();
-            if (!usingCard){
-                return businessNetworkConnection.connect(argv.connectionProfileName, argv.businessNetworkName, argv.enrollId, argv.enrollSecret);
-            } else {
-                return businessNetworkConnection.connect(cardName);
-            }
+
+            return businessNetworkConnection.connect(cardName);
+
         })
         .then((result) => {
             businessNetworkDefinition = result;
@@ -86,7 +66,8 @@ class Download {
             if (!argv.archiveFile){
                 argv.archiveFile = sanitize(businessNetworkName,{replacement:'_'})+'.bna';
             }
-          // need to write this out to the required file now.
+
+            // need to write this out to the required file now.
             return businessNetworkDefinition.toArchive();
         }).then ( (result) => {
             //write the buffer to a file

--- a/packages/composer-cli/lib/cmds/network/lib/download.js
+++ b/packages/composer-cli/lib/cmds/network/lib/download.js
@@ -44,13 +44,10 @@ class Download {
 
         let businessNetworkConnection = cmdUtil.createBusinessNetworkConnection();
 
-        return Promise.resolve()
-        .then (() => {
-            spinner = ora('Downloading deployed Business Network Archive').start();
 
-            return businessNetworkConnection.connect(cardName);
+        spinner = ora('Downloading deployed Business Network Archive').start();
 
-        })
+        return businessNetworkConnection.connect(cardName)
         .then((result) => {
             businessNetworkDefinition = result;
             return businessNetworkConnection.disconnect();

--- a/packages/composer-cli/lib/cmds/network/lib/list.js
+++ b/packages/composer-cli/lib/cmds/network/lib/list.js
@@ -43,17 +43,11 @@ class List {
         let spinner;
         let cardName = argv.card;
 
+        spinner = ora('List business network from card '+ cardName );
+        spinner.start();
 
-
-        return Promise.resolve()
-        .then(() => {
-            spinner = ora('List business network from card '+ cardName );
-            spinner.start();
-
-            businessNetworkConnection = cmdUtil.createBusinessNetworkConnection();
-            return businessNetworkConnection.connect(cardName);
-
-        })
+        businessNetworkConnection = cmdUtil.createBusinessNetworkConnection();
+        return businessNetworkConnection.connect(cardName)
         .then ((result) => {
             businessNetworkDefinition = result;
 

--- a/packages/composer-cli/lib/cmds/network/lib/list.js
+++ b/packages/composer-cli/lib/cmds/network/lib/list.js
@@ -36,46 +36,22 @@ class List {
     static handler(argv) {
 
         let businessNetworkConnection;
-        let enrollId;
-        let enrollSecret;
-        let connectionProfileName = argv.connectionProfileName;
+
         let businessNetworkName = argv.businessNetworkName;
         let businessNetworkDefinition;
         let listOutput;
         let spinner;
         let cardName = argv.card;
 
-        let usingCard = !(cardName===undefined);
 
-        return (() => {
-            spinner = ora('List business network '+ (usingCard ?  'from card "'+ cardName +'"' : 'with name "'+businessNetworkName+'"' ));
 
-            if (!argv.enrollSecret && !usingCard) {
-                return cmdUtil.prompt({
-                    name: 'enrollmentSecret',
-                    description: 'What is the enrollment secret of the user?',
-                    required: true,
-                    hidden: true,
-                    replace: '*'
-                })
-                .then((result) => {
-                    argv.enrollSecret = result.enrollmentSecret;
-                });
-            } else {
-                return Promise.resolve();
-            }
-        })()
-        .then (() => {
+        return Promise.resolve()
+        .then(() => {
+            spinner = ora('List business network from card '+ cardName );
             spinner.start();
-            enrollId = argv.enrollId;
-            enrollSecret = argv.enrollSecret;
+
             businessNetworkConnection = cmdUtil.createBusinessNetworkConnection();
-            // check to see if we are using a card, if so use card API
-            if (!usingCard){
-                return businessNetworkConnection.connect(connectionProfileName, businessNetworkName, enrollId, enrollSecret);
-            } else {
-                return businessNetworkConnection.connect(cardName);
-            }
+            return businessNetworkConnection.connect(cardName);
 
         })
         .then ((result) => {

--- a/packages/composer-cli/lib/cmds/network/lib/loglevel.js
+++ b/packages/composer-cli/lib/cmds/network/lib/loglevel.js
@@ -32,50 +32,15 @@ class LogLevel {
     */
     static handler(argv) {
         let adminConnection;
-        let enrollId;
-        let enrollSecret;
-        let connectionProfileName;
         let businessNetworkName;
         let newlevel;
         let cardName = argv.card;
-        let usingCard = !(cardName===undefined);
 
-        if (argv.newlevel) {
-            // validate log level as yargs cannot at this time
-            // https://github.com/yargs/yargs/issues/849
-            newlevel = argv.newlevel.toUpperCase();
-            if (!LogLevel.validLogLevel(newlevel)) {
-                return Promise.reject(new Error('newlevel unspecified or not one of (INFO|WARNING|ERROR|DEBUG)'));
-            }
-        }
 
-        return (() => {
-            if (!argv.enrollSecret && !usingCard) {
-                return cmdUtil.prompt({
-                    name: 'enrollmentSecret',
-                    description: 'What is the enrollment secret of the user?',
-                    required: true,
-                    hidden: true,
-                    replace: '*'
-                })
-                .then((result) => {
-                    argv.enrollSecret = result.enrollmentSecret;
-                });
-            } else {
-                return Promise.resolve();
-            }
-        })()
+        return Promise.resolve()
         .then(() => {
-            enrollId = argv.enrollId;
-            enrollSecret = argv.enrollSecret;
-            businessNetworkName = argv.businessNetworkName;
-            connectionProfileName = argv.connectionProfileName;
             adminConnection = cmdUtil.createAdminConnection();
-            if (!usingCard){
-                return adminConnection.connect(connectionProfileName, enrollId, enrollSecret, businessNetworkName);
-            } else {
-                return adminConnection.connect(cardName);
-            }
+            return adminConnection.connect(cardName);
         })
         .then(() => {
             if (newlevel) {
@@ -94,27 +59,6 @@ class LogLevel {
             throw error;
         });
     }
-
-    /**
-     * check the loglevel specified matches the known set
-     *
-     * @static
-     * @param {string} logLevel the loglevel to check
-     * @returns {boolean} true if valid, false otherwise
-     * @memberof LogLevel
-     */
-    static validLogLevel(logLevel) {
-
-        switch (logLevel) {
-        case 'INFO':
-        case 'WARNING':
-        case 'ERROR':
-        case 'DEBUG':
-            return true;
-        }
-        return false;
-    }
-
 }
 
 module.exports = LogLevel;

--- a/packages/composer-cli/lib/cmds/network/lib/loglevel.js
+++ b/packages/composer-cli/lib/cmds/network/lib/loglevel.js
@@ -33,7 +33,7 @@ class LogLevel {
     static handler(argv) {
         let adminConnection;
         let businessNetworkName;
-        let newlevel;
+        let newlevel =argv.newlevel;
         let cardName = argv.card;
 
 

--- a/packages/composer-cli/lib/cmds/network/lib/loglevel.js
+++ b/packages/composer-cli/lib/cmds/network/lib/loglevel.js
@@ -33,15 +33,11 @@ class LogLevel {
     static handler(argv) {
         let adminConnection;
         let businessNetworkName;
-        let newlevel =argv.newlevel;
+        let newlevel = argv.newlevel;
         let cardName = argv.card;
 
-
-        return Promise.resolve()
-        .then(() => {
-            adminConnection = cmdUtil.createAdminConnection();
-            return adminConnection.connect(cardName);
-        })
+        adminConnection = cmdUtil.createAdminConnection();
+        return adminConnection.connect(cardName)
         .then(() => {
             if (newlevel) {
                 return adminConnection.setLogLevel(newlevel);

--- a/packages/composer-cli/lib/cmds/network/lib/ping.js
+++ b/packages/composer-cli/lib/cmds/network/lib/ping.js
@@ -33,45 +33,20 @@ class Ping {
     */
     static handler(argv) {
         let businessNetworkConnection;
-        let enrollId;
-        let enrollSecret;
-        let connectionProfileName = argv.connectionProfileName;
-        let businessNetworkName;
+        let businessNetworkDefinition;
         let cardName = argv.card;
-        let usingCard = !(cardName===undefined);
 
-        return (() => {
-            if (!argv.enrollSecret && !usingCard) {
-                return cmdUtil.prompt({
-                    name: 'enrollmentSecret',
-                    description: 'What is the enrollment secret of the user?',
-                    required: true,
-                    hidden: true,
-                    replace: '*'
-                })
-                .then((result) => {
-                    argv.enrollSecret = result.enrollmentSecret;
-                });
-            } else {
-                return Promise.resolve();
-            }
-        })()
+        return Promise.resolve()
         .then(() => {
-            enrollId = argv.enrollId;
-            enrollSecret = argv.enrollSecret;
-            businessNetworkName = argv.businessNetworkName;
             businessNetworkConnection = cmdUtil.createBusinessNetworkConnection();
-            if (!usingCard){
-                return businessNetworkConnection.connect(connectionProfileName, businessNetworkName, enrollId, enrollSecret);
-            } else {
-                return businessNetworkConnection.connect(cardName);
-            }
+            return businessNetworkConnection.connect(cardName);
         })
-        .then(() => {
+        .then((result) => {
+            businessNetworkDefinition = result;
             return businessNetworkConnection.ping();
         })
         .then((result) => {
-            console.log(chalk.blue.bold('The connection to the network was successfully tested: ')+businessNetworkName);
+            console.log(chalk.blue.bold('The connection to the network was successfully tested: ')+businessNetworkDefinition.getName());
             console.log(chalk.blue('\tversion: ') + result.version);
             console.log(chalk.blue('\tparticipant: ') + (result.participant ? result.participant : '<no participant found>'));
         }).catch((error) => {

--- a/packages/composer-cli/lib/cmds/network/lib/ping.js
+++ b/packages/composer-cli/lib/cmds/network/lib/ping.js
@@ -36,11 +36,8 @@ class Ping {
         let businessNetworkDefinition;
         let cardName = argv.card;
 
-        return Promise.resolve()
-        .then(() => {
-            businessNetworkConnection = cmdUtil.createBusinessNetworkConnection();
-            return businessNetworkConnection.connect(cardName);
-        })
+        businessNetworkConnection = cmdUtil.createBusinessNetworkConnection();
+        return businessNetworkConnection.connect(cardName)
         .then((result) => {
             businessNetworkDefinition = result;
             return businessNetworkConnection.ping();

--- a/packages/composer-cli/lib/cmds/network/lib/reset.js
+++ b/packages/composer-cli/lib/cmds/network/lib/reset.js
@@ -32,56 +32,24 @@ class Reset {
     */
     static handler(argv) {
         let adminConnection;
-        let enrollId;
-        let enrollSecret;
-        let connectionProfileName = argv.connectionProfileName;
-        let businessNetworkName;
         let cardName = argv.card;
-        let usingCard = !(cardName===undefined);
         let spinner;
 
-        return (() => {
-            if (!argv.enrollSecret && !usingCard) {
-                return cmdUtil.prompt({
-                    name: 'enrollmentSecret',
-                    description: 'What is the enrollment secret of the user?',
-                    required: true,
-                    hidden: true,
-                    replace: '*'
-                })
-                .then((result) => {
-                    argv.enrollSecret = result.enrollmentSecret;
-                });
-            } else {
-                return Promise.resolve();
-            }
-        })()
-        .then(() => {
-
-            enrollId = argv.enrollId;
-            enrollSecret = argv.enrollSecret;
-            businessNetworkName = argv.businessNetworkName;
-            adminConnection = cmdUtil.createAdminConnection();
-            if (!cardName){
-                return adminConnection.connect(connectionProfileName, enrollId, enrollSecret,  businessNetworkName);
-            } else {
+        return Promise.resolve()
+            .then(() => {
+                adminConnection = cmdUtil.createAdminConnection();
                 return adminConnection.connect(cardName);
-            }
-        })
+            })
           .then((result) => {
-
-              spinner = ora('Reseting business network definition. This may take some seconds...').start();
-              return adminConnection.reset(businessNetworkName);
-
+              spinner = ora('Resetting business network definition. This may take some seconds...').start();
+              return adminConnection.reset();
           }).then((result) => {
               spinner.succeed();
               return result;
           }).catch((error) => {
-              console.log(error.stack);
               if (spinner) {
                   spinner.fail();
               }
-
               throw error;
           });
     }

--- a/packages/composer-cli/lib/cmds/network/lib/reset.js
+++ b/packages/composer-cli/lib/cmds/network/lib/reset.js
@@ -35,23 +35,25 @@ class Reset {
         let cardName = argv.card;
         let spinner;
 
-        return Promise.resolve()
+
+        adminConnection = cmdUtil.createAdminConnection();
+        return adminConnection.connect(cardName)
             .then(() => {
-                adminConnection = cmdUtil.createAdminConnection();
-                return adminConnection.connect(cardName);
+                // nothing is returned from connect
+                return adminConnection.getCard(cardName);
             })
-          .then((result) => {
-              spinner = ora('Resetting business network definition. This may take some seconds...').start();
-              return adminConnection.reset();
-          }).then((result) => {
-              spinner.succeed();
-              return result;
-          }).catch((error) => {
-              if (spinner) {
-                  spinner.fail();
-              }
-              throw error;
-          });
+            .then((card)=>{
+                spinner = ora('Resetting business network definition. This may take some seconds...').start();
+                return adminConnection.reset(card.getBusinessNetworkName());
+            }).then((result) => {
+                spinner.succeed();
+                return result;
+            }).catch((error) => {
+                if (spinner) {
+                    spinner.fail();
+                }
+                throw error;
+            });
     }
 
 }

--- a/packages/composer-cli/lib/cmds/network/lib/start.js
+++ b/packages/composer-cli/lib/cmds/network/lib/start.js
@@ -19,7 +19,6 @@ const BusinessNetworkDefinition = Admin.BusinessNetworkDefinition;
 const chalk = require('chalk');
 const cmdUtil = require('../../utils/cmdutils');
 const fs = require('fs');
-const LogLevel = require('../../network/lib/loglevel');
 const ora = require('ora');
 
 /**
@@ -46,7 +45,7 @@ class Start {
         let adminConnection;
         let businessNetworkName;
         let spinner;
-        let loglevel;
+        let loglevel = argv.loglevel;
         let cardName = argv.card;
 
         return Promise.resolve().then(() => {
@@ -74,7 +73,7 @@ class Start {
                 // Build the start options.
                 let startOptions = cmdUtil.parseOptions(argv);
                 if (loglevel) {
-                    startOptions.logLevel = loglevel;
+                    startOptions.loglevel = loglevel;
                 }
 
                 // Build the bootstrap tranactions.

--- a/packages/composer-cli/lib/cmds/network/lib/start.js
+++ b/packages/composer-cli/lib/cmds/network/lib/start.js
@@ -48,24 +48,14 @@ class Start {
         let spinner;
         let loglevel;
         let cardName = argv.card;
-        let usingCard = !(cardName===undefined);
 
-        if (argv.loglevel) {
-            // validate log level as yargs cannot at this time
-            // https://github.com/yargs/yargs/issues/849
-            loglevel = argv.loglevel.toUpperCase();
-            if (!LogLevel.validLogLevel(loglevel)) {
-                return Promise.reject(new Error('loglevel unspecified or not one of (INFO|WARNING|ERROR|DEBUG)'));
-            }
-        }
-
-        return (() => {
+        return Promise.resolve().then(() => {
             console.log(chalk.blue.bold('Starting business network from archive: ')+argv.archiveFile);
             let archiveFileContents = null;
             // Read archive file contents
             archiveFileContents = Start.getArchiveFileContents(argv.archiveFile);
             return BusinessNetworkDefinition.fromArchive(archiveFileContents);
-        })()
+        })
         .then ((result) => {
             businessNetworkDefinition = result;
             businessNetworkName = businessNetworkDefinition.getIdentifier();
@@ -74,11 +64,8 @@ class Start {
             console.log(chalk.blue('\tDescription: ')+businessNetworkDefinition.getDescription());
             console.log();
             adminConnection = cmdUtil.createAdminConnection();
-            if (!usingCard){
-                return adminConnection.connect(argv.connectionProfileName, argv.startId, argv.startSecret, updateBusinessNetwork ? businessNetworkDefinition.getName() : null);
-            } else {
-                return adminConnection.connect(cardName, updateBusinessNetwork );
-            }
+
+            return adminConnection.connect(cardName, updateBusinessNetwork );
         })
         .then((result) => {
             if (updateBusinessNetwork === false) {

--- a/packages/composer-cli/lib/cmds/network/lib/start.js
+++ b/packages/composer-cli/lib/cmds/network/lib/start.js
@@ -45,16 +45,15 @@ class Start {
         let adminConnection;
         let businessNetworkName;
         let spinner;
-        let loglevel = argv.loglevel;
+        let logLevel = argv.loglevel;
         let cardName = argv.card;
 
-        return Promise.resolve().then(() => {
-            console.log(chalk.blue.bold('Starting business network from archive: ')+argv.archiveFile);
-            let archiveFileContents = null;
+
+        console.log(chalk.blue.bold('Starting business network from archive: ')+argv.archiveFile);
+        let archiveFileContents = null;
             // Read archive file contents
-            archiveFileContents = Start.getArchiveFileContents(argv.archiveFile);
-            return BusinessNetworkDefinition.fromArchive(archiveFileContents);
-        })
+        archiveFileContents = Start.getArchiveFileContents(argv.archiveFile);
+        return BusinessNetworkDefinition.fromArchive(archiveFileContents)
         .then ((result) => {
             businessNetworkDefinition = result;
             businessNetworkName = businessNetworkDefinition.getIdentifier();
@@ -72,8 +71,8 @@ class Start {
 
                 // Build the start options.
                 let startOptions = cmdUtil.parseOptions(argv);
-                if (loglevel) {
-                    startOptions.loglevel = loglevel;
+                if (logLevel) {
+                    startOptions.logLevel = logLevel;
                 }
 
                 // Build the bootstrap tranactions.

--- a/packages/composer-cli/lib/cmds/network/lib/undeploy.js
+++ b/packages/composer-cli/lib/cmds/network/lib/undeploy.js
@@ -32,56 +32,29 @@ class Undeploy {
     */
     static handler(argv) {
         let adminConnection;
-        let enrollId;
-        let enrollSecret;
-        let connectionProfileName = argv.connectionProfileName;
-        let businessNetworkName;
         let cardName = argv.card;
-        let usingCard = !(cardName===undefined);
         let spinner;
 
-        return (() => {
-            if (!argv.enrollSecret && !usingCard) {
-                return cmdUtil.prompt({
-                    name: 'enrollmentSecret',
-                    description: 'What is the enrollment secret of the user?',
-                    required: true,
-                    hidden: true,
-                    replace: '*'
-                })
-                .then((result) => {
-                    argv.enrollSecret = result.enrollmentSecret;
-                });
-            } else {
-                return Promise.resolve();
-            }
-        })()
-        .then(() => {
-            enrollId = argv.enrollId;
-            enrollSecret = argv.enrollSecret;
-            businessNetworkName = argv.businessNetworkName;
-            adminConnection = cmdUtil.createAdminConnection();
-            if (!usingCard){
-                return adminConnection.connect(connectionProfileName, enrollId, enrollSecret,  businessNetworkName);
-            } else {
+        return Promise.resolve()
+            .then(() => {
+                adminConnection = cmdUtil.createAdminConnection();
                 return adminConnection.connect(cardName);
-            }
-        })
-          .then((result) => {
-              spinner = ora('Undeploying business network definition. This may take some seconds...').start();
-              return adminConnection.undeploy(businessNetworkName);
+            })
+            .then((result) => {
+                spinner = ora('Undeploying business network definition. This may take some seconds...').start();
+                return adminConnection.undeploy();
 
-          }).then((result) => {
-              spinner.succeed();
-              return result;
-          }).catch((error) => {
+            }).then((result) => {
+                spinner.succeed();
+                return result;
+            }).catch((error) => {
 
-              if (spinner) {
-                  spinner.fail();
-              }
+                if (spinner) {
+                    spinner.fail();
+                }
 
-              throw error;
-          });
+                throw error;
+            });
     }
 
 }

--- a/packages/composer-cli/lib/cmds/network/lib/undeploy.js
+++ b/packages/composer-cli/lib/cmds/network/lib/undeploy.js
@@ -48,11 +48,7 @@ class Undeploy {
                 spinner.succeed();
                 return result;
             }).catch((error) => {
-
-                if (spinner) {
-                    spinner.fail();
-                }
-
+                spinner.fail();
                 throw error;
             });
     }

--- a/packages/composer-cli/lib/cmds/network/lib/undeploy.js
+++ b/packages/composer-cli/lib/cmds/network/lib/undeploy.js
@@ -35,15 +35,16 @@ class Undeploy {
         let cardName = argv.card;
         let spinner;
 
-        return Promise.resolve()
-            .then(() => {
-                adminConnection = cmdUtil.createAdminConnection();
-                return adminConnection.connect(cardName);
-            })
-            .then((result) => {
-                spinner = ora('Undeploying business network definition. This may take some seconds...').start();
-                return adminConnection.undeploy();
 
+        adminConnection = cmdUtil.createAdminConnection();
+        return adminConnection.connect(cardName)
+            .then(() => {
+                // nothing is returned from connect
+                return adminConnection.getCard(cardName);
+            })
+            .then((card)=>{
+                spinner = ora('Undeploying business network definition. This may take some seconds...').start();
+                return adminConnection.undeploy(card.getBusinessNetworkName());
             }).then((result) => {
                 spinner.succeed();
                 return result;

--- a/packages/composer-cli/lib/cmds/network/lib/upgrade.js
+++ b/packages/composer-cli/lib/cmds/network/lib/upgrade.js
@@ -36,17 +36,14 @@ class Upgrade {
         let spinner;
 
         let cardName = argv.card;
-        let usingCard = !(cardName===undefined);
+
 
         return Promise.resolve()
         .then(() => {
             spinner = ora('Upgrading runtime for business network ' + argv.businessNetworkName + '. This may take a minute...').start();
             adminConnection = cmdUtil.createAdminConnection();
-            if (!usingCard){
-                return adminConnection.connect(argv.connectionProfileName, argv.upgradeId, argv.upgradeSecret, argv.businessNetworkName);
-            } else {
-                return adminConnection.connect(cardName);
-            }
+            return adminConnection.connect(cardName);
+
         })
         .then((result) => {
             return adminConnection.upgrade();

--- a/packages/composer-cli/lib/cmds/network/lib/upgrade.js
+++ b/packages/composer-cli/lib/cmds/network/lib/upgrade.js
@@ -37,14 +37,9 @@ class Upgrade {
 
         let cardName = argv.card;
 
-
-        return Promise.resolve()
-        .then(() => {
-            spinner = ora('Upgrading runtime for business network ' + argv.businessNetworkName + '. This may take a minute...').start();
-            adminConnection = cmdUtil.createAdminConnection();
-            return adminConnection.connect(cardName);
-
-        })
+        spinner = ora('Upgrading runtime for business network ' + argv.businessNetworkName + '. This may take a minute...').start();
+        adminConnection = cmdUtil.createAdminConnection();
+        return adminConnection.connect(cardName)
         .then((result) => {
             return adminConnection.upgrade();
         }).then((result) => {

--- a/packages/composer-cli/lib/cmds/network/lib/upgrade.js
+++ b/packages/composer-cli/lib/cmds/network/lib/upgrade.js
@@ -51,11 +51,7 @@ class Upgrade {
             spinner.succeed();
             return result;
         }).catch((error) => {
-
-            if (spinner) {
-                spinner.fail();
-            }
-
+            spinner.fail();
             throw error;
         });
     }

--- a/packages/composer-cli/lib/cmds/network/listCommand.js
+++ b/packages/composer-cli/lib/cmds/network/listCommand.js
@@ -19,12 +19,8 @@ const List = require ('./lib/list.js');
 module.exports.command = 'list [options]';
 module.exports.describe = 'List the contents of a business network';
 module.exports.builder = {
-  //  businessNetworkName: {alias: 'n', required: false, describe: 'The business network name', type: 'string' },
-  //  connectionProfileName: {alias: 'p', required: false, describe: 'The connection profile name', type: 'string' },
     registry: {alias: 'r', optional: true, describe: 'List specific registry', type: 'string' },
     asset: {alias: 'a', optional: true, describe: 'List specific asset', type: 'string' },
-  //  enrollId: { alias: 'i', required: false, describe: 'The enrollment ID of the user', type: 'string' },
-  //  enrollSecret: { alias: 's', required: false, describe: 'The enrollment secret of the user', type: 'string' },
     card: {alias: 'c', required: false, describe: 'The card name used to list the network', type: 'string'}
 };
 

--- a/packages/composer-cli/lib/cmds/network/loglevelCommand.js
+++ b/packages/composer-cli/lib/cmds/network/loglevelCommand.js
@@ -19,11 +19,7 @@ const logLevel = require ('./lib/loglevel.js');
 module.exports.command = 'loglevel [options]';
 module.exports.describe = 'Change the logging level of a business network';
 module.exports.builder = {
-    businessNetworkName: {alias: 'n', required: false, describe: 'The business network name', type: 'string' },
-    connectionProfileName: {alias: 'p', required: false, describe: 'The connection profile name', type: 'string' },
-    newlevel: { alias: 'l', optional: true, describe: 'the new logging level (INFO/WARNING/ERROR/DEBUG)', type: 'string'/*, choices : ['INFO', 'WARNING', 'ERROR', 'DEBUG'] */},
-    enrollId: { alias: 'i', required: false, describe: 'The enrollment ID of the user', type: 'string' },
-    enrollSecret: { alias: 's', required: false, describe: 'The enrollment secret of the user', type: 'string' },
+    newlevel: { alias: 'l', optional: true, describe: 'the new logging level', choices : ['INFO', 'WARNING', 'ERROR', 'DEBUG'] },
     card: { alias: 'c', required: false, description: 'The cardname to use to change the log level the network', type:'string'}
 };
 

--- a/packages/composer-cli/lib/cmds/network/pingCommand.js
+++ b/packages/composer-cli/lib/cmds/network/pingCommand.js
@@ -19,10 +19,6 @@ const Ping = require ('./lib/ping.js');
 module.exports.command = 'ping [options]';
 module.exports.describe = 'Test a connection to a business network';
 module.exports.builder = {
-    businessNetworkName: {alias: 'n', required: false, describe: 'The business network name', type: 'string' },
-    connectionProfileName: {alias: 'p', required: false, describe: 'The connection profile name', type: 'string' },
-    enrollId: { alias: 'i', required: false, describe: 'The enrollment ID of the user', type: 'string' },
-    enrollSecret: { alias: 's', required: false, describe: 'The enrollment secret of the user', type: 'string' },
     card: { alias: 'c', required: false, description: 'The cardname to use to ping the network', type:'string'}
 };
 

--- a/packages/composer-cli/lib/cmds/network/resetCommand.js
+++ b/packages/composer-cli/lib/cmds/network/resetCommand.js
@@ -19,10 +19,6 @@ const Reset = require ('./lib/reset.js');
 module.exports.command = 'reset [options]';
 module.exports.describe = 'Resets a business network';
 module.exports.builder = {
-    businessNetworkName: {alias: 'n', required: false, describe: 'The business network name', type: 'string' },
-    connectionProfileName: {alias: 'p', required: false, describe: 'The connection profile name', type: 'string' },
-    enrollId: { alias: 'i', required: false, describe: 'The enrollment ID of the user', type: 'string' },
-    enrollSecret: { alias: 's', required: false, describe: 'The enrollment secret of the user', type: 'string' },
     card: { alias: 'c', required: false, description: 'The cardname to use to reset  the network', type:'string'}
 };
 

--- a/packages/composer-cli/lib/cmds/network/startCommand.js
+++ b/packages/composer-cli/lib/cmds/network/startCommand.js
@@ -19,13 +19,9 @@ const Start = require ('./lib/start.js');
 module.exports.command = 'start [options]';
 module.exports.describe = 'Starts a business network';
 module.exports.builder = {
-    archiveFile: {alias: 'a', required: true, describe: 'The business network archive file name', type: 'string' },
-    connectionProfileName: {alias: 'p', required: false, describe: 'The connection profile name', type: 'string' },
-    loglevel: { alias: 'l', required: false, describe: 'The initial loglevel to set (INFO|WARNING|ERROR|DEBUG)', type: 'string' },
+    loglevel: { alias: 'l', required: false, describe: 'The initial loglevel to set', choices : ['INFO', 'WARNING', 'ERROR', 'DEBUG']},
     option: { alias: 'o', required: false, describe: 'Options that are specific specific to connection. Multiple options are specified by repeating this option', type: 'string' },
     optionsFile: { alias: 'O', required: false, describe: 'A file containing options that are specific to connection', type: 'string' },
-    startId: { alias: 'i', required: true, describe: 'The id of the user permitted to start a network', type: 'string' },
-    startSecret: { alias: 's', required: false, describe: 'The secret of the user permitted to start a network, if required', type: 'string' },
     networkAdmin: { alias: 'A', required: false, description: 'The identity name of the business network administrator', type: 'string' },
     networkAdminCertificateFile: { alias: 'C', required: false, description: 'The certificate of the business network administrator', type: 'string' },
     networkAdminEnrollSecret: { alias: 'S', required: false, description: 'Use enrollment secret for the business network administrator', type: 'boolean', default: undefined },

--- a/packages/composer-cli/lib/cmds/network/undeployCommand.js
+++ b/packages/composer-cli/lib/cmds/network/undeployCommand.js
@@ -19,10 +19,6 @@ const Undeploy = require ('./lib/undeploy.js');
 module.exports.command = 'undeploy [options]';
 module.exports.describe = 'Undeploys a BusinessNetworkDefinition from the Hyperledger Fabric.';
 module.exports.builder = {
-    businessNetworkName: {alias: 'n', required: true, describe: 'The business network name', type: 'string' },
-    connectionProfileName: {alias: 'p', required: false, describe: 'The connection profile name', type: 'string' },
-    enrollId: { alias: 'i', required: false, describe: 'The enrollment ID of the user', type: 'string' },
-    enrollSecret: { alias: 's', required: false, describe: 'The enrollment secret of the user', type: 'string' },
     card: { alias: 'c', required: false, description: 'The cardname to use to download the network', type:'string'}
 };
 

--- a/packages/composer-cli/lib/cmds/network/updateCommand.js
+++ b/packages/composer-cli/lib/cmds/network/updateCommand.js
@@ -19,10 +19,6 @@ const Update = require ('./lib/update.js');
 module.exports.command = 'update [options]';
 module.exports.describe = 'Update a business network';
 module.exports.builder = {
-    archiveFile: {alias: 'a', required: true, describe: 'The business network archive file name', type: 'string' },
-    connectionProfileName: {alias: 'p', required: false, describe: 'The connection profile name', type: 'string' },
-    enrollId: { alias: 'i', required: false, describe: 'The enrollment ID of the user', type: 'string' },
-    enrollSecret: { alias: 's', required: false, describe: 'The enrollment secret of the user', type: 'string' },
     card: { alias: 'c', required: false, description: 'The cardname to use to update the network', type:'string'}
 };
 

--- a/packages/composer-cli/lib/cmds/network/upgradeCommand.js
+++ b/packages/composer-cli/lib/cmds/network/upgradeCommand.js
@@ -19,10 +19,6 @@ const Upgrade = require ('./lib/upgrade.js');
 module.exports.command = 'upgrade [options]';
 module.exports.describe = 'Upgrades the Hyperledger Composer runtime of a business network';
 module.exports.builder = {
-    businessNetworkName: {alias: 'n', required: true, describe: 'The business network name whose runtime will be upgraded', type: 'string' },
-    connectionProfileName: {alias: 'p', required: false, describe: 'The connection profile name', type: 'string' },
-    upgradeId: { alias: 'i', required: false, describe: 'The id of the user permitted to upgrade the runtime', type: 'string' },
-    upgradeSecret: { alias: 's', required: false, describe: 'The secret of the user permitted to upgrade the runtime, if required', type: 'string' },
     card: { alias: 'c', required: false, description: 'The cardname to use to upgrade the network', type:'string'}
 };
 

--- a/packages/composer-cli/test/network/deploy.js
+++ b/packages/composer-cli/test/network/deploy.js
@@ -49,6 +49,7 @@ describe('composer deploy network CLI unit tests', function () {
         mockAdminConnection.createProfile.resolves();
         mockAdminConnection.connect.resolves();
         mockAdminConnection.deploy.resolves();
+        mockAdminConnection.getCard.withArgs('cardname').resolves();
 
         sandbox.stub(BusinessNetworkDefinition, 'fromArchive').resolves(businessNetworkDefinition);
         sandbox.stub(CmdUtil, 'createAdminConnection').returns(mockAdminConnection);
@@ -68,12 +69,10 @@ describe('composer deploy network CLI unit tests', function () {
 
         it('Good path, optional parameter -O /path/to/options.json specified.', function () {
 
-            let argv = {enrollId: 'WebAppAdmin'
-                       ,enrollSecret: 'DJY27pEnl16d'
-                       ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'testProfile'
+            let argv = {card:'cardname'
+                        ,archiveFile: 'testArchiveFile.zip'
                        ,optionsFile: '/path/to/options.json'};
-            let connectionProfileName = argv.connectionProfileName;
+
 
             sandbox.stub(Deploy, 'getArchiveFileContents');
             const optionsObject = {
@@ -102,7 +101,7 @@ describe('composer deploy network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, connectionProfileName, argv.enrollId, argv.enrollSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.deploy);
                 sinon.assert.calledWith(mockAdminConnection.deploy, businessNetworkDefinition,
                     {
@@ -114,12 +113,9 @@ describe('composer deploy network CLI unit tests', function () {
 
         it('Good path, optional parameter -o endorsementPolicyFile= specified.', function () {
 
-            let argv = {enrollId: 'WebAppAdmin'
-                       ,enrollSecret: 'DJY27pEnl16d'
-                       ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'testProfile'
-                       ,option: 'endorsementPolicyFile=/path/to/some/file.json'};
-            let connectionProfileName = argv.connectionProfileName;
+            let argv = {card:'cardname'
+                        ,archiveFile: 'testArchiveFile.zip'
+                        ,option: 'endorsementPolicyFile=/path/to/some/file.json'};
 
             sandbox.stub(Deploy, 'getArchiveFileContents');
 
@@ -133,7 +129,7 @@ describe('composer deploy network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, connectionProfileName, argv.enrollId, argv.enrollSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.deploy);
                 sinon.assert.calledWith(mockAdminConnection.deploy, businessNetworkDefinition,
                     {
@@ -146,12 +142,9 @@ describe('composer deploy network CLI unit tests', function () {
 
         it('Good path, optional parameter -o endorsementPolicy= specified.', function () {
 
-            let argv = {enrollId: 'WebAppAdmin'
-                       ,enrollSecret: 'DJY27pEnl16d'
-                       ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'testProfile'
-                       ,option: 'endorsementPolicy=' + VALID_ENDORSEMENT_POLICY_STRING};
-            let connectionProfileName = argv.connectionProfileName;
+            let argv = {card:'cardname'
+                        ,archiveFile: 'testArchiveFile.zip'
+                        ,option: 'endorsementPolicy=' + VALID_ENDORSEMENT_POLICY_STRING};
 
             sandbox.stub(Deploy, 'getArchiveFileContents');
 
@@ -165,7 +158,7 @@ describe('composer deploy network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, connectionProfileName, argv.enrollId, argv.enrollSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.deploy);
                 sinon.assert.calledWith(mockAdminConnection.deploy, businessNetworkDefinition,
                     {
@@ -177,12 +170,9 @@ describe('composer deploy network CLI unit tests', function () {
 
 
         it('Good path, all parms correctly specified.', function () {
+            let argv = {card:'cardname'
+                        ,archiveFile: 'testArchiveFile.zip'};
 
-            let argv = {enrollId: 'WebAppAdmin'
-                       ,enrollSecret: 'DJY27pEnl16d'
-                       ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'testProfile'};
-            let connectionProfileName = argv.connectionProfileName;
 
             sandbox.stub(Deploy, 'getArchiveFileContents');
 
@@ -196,7 +186,7 @@ describe('composer deploy network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, connectionProfileName, argv.enrollId, argv.enrollSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.deploy);
                 sinon.assert.calledWith(mockAdminConnection.deploy, businessNetworkDefinition, { bootstrapTransactions: [] });
             });
@@ -204,12 +194,9 @@ describe('composer deploy network CLI unit tests', function () {
 
         it('Good path, all parms correctly specified, including optional loglevel.', function () {
 
-            let argv = {enrollId: 'WebAppAdmin'
-                       ,enrollSecret: 'DJY27pEnl16d'
+            let argv = {card:'cardname'
                        ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'testProfile'
                        ,loglevel: 'DEBUG'};
-            let connectionProfileName = argv.connectionProfileName;
 
             sandbox.stub(Deploy, 'getArchiveFileContents');
 
@@ -223,21 +210,16 @@ describe('composer deploy network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, connectionProfileName, argv.enrollId, argv.enrollSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.deploy);
-                sinon.assert.calledWith(mockAdminConnection.deploy, businessNetworkDefinition, { bootstrapTransactions: [], logLevel: 'DEBUG'});
+                sinon.assert.calledWith(mockAdminConnection.deploy, businessNetworkDefinition, { bootstrapTransactions: [], loglevel: 'DEBUG'});
             });
         });
 
         it('Good path, no enrollment secret, all other parms correctly specified.', function () {
 
-            let enrollmentSecret = 'DJY27pEnl16d';
-            sandbox.stub(CmdUtil, 'prompt').resolves({enrollmentSecret:enrollmentSecret});
-
-            let argv = {enrollId: 'WebAppAdmin'
-                       ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'testProfile'};
-            let connectionProfileName = argv.connectionProfileName;
+            let argv = {card:'cardname'
+                        ,archiveFile: 'testArchiveFile.zip'};
 
             sandbox.stub(Deploy, 'getArchiveFileContents');
 
@@ -251,7 +233,7 @@ describe('composer deploy network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, connectionProfileName, argv.enrollId, enrollmentSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.deploy);
                 sinon.assert.calledWith(mockAdminConnection.deploy, businessNetworkDefinition, { bootstrapTransactions: [] });
             });
@@ -267,15 +249,10 @@ describe('composer deploy network CLI unit tests', function () {
 
         it('Good path, network administrator specified', function () {
 
-            let enrollmentSecret = 'DJY27pEnl16d';
-            sandbox.stub(CmdUtil, 'prompt').resolves({enrollmentSecret:enrollmentSecret});
 
-            let argv = {enrollId: 'WebAppAdmin'
-                        ,archiveFile: 'testArchiveFile.zip'
-                        ,connectionProfileName: 'testProfile'
+            let argv = {card:'cardname'
                         ,networkAdmin: ['admin1']
                         ,networkAdminEnrollSecret: [true]};
-            let connectionProfileName = argv.connectionProfileName;
 
             sandbox.stub(Deploy, 'getArchiveFileContents');
 
@@ -289,7 +266,7 @@ describe('composer deploy network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, connectionProfileName, argv.enrollId, enrollmentSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.deploy);
                 const deployOptions = mockAdminConnection.deploy.args[0][1];
                 sanitize(deployOptions.bootstrapTransactions);
@@ -315,16 +292,10 @@ describe('composer deploy network CLI unit tests', function () {
 
         it('Good path, network administrator and bootstrap transactions specified', function () {
 
-            let enrollmentSecret = 'DJY27pEnl16d';
-            sandbox.stub(CmdUtil, 'prompt').resolves({enrollmentSecret:enrollmentSecret});
-
-            let argv = {enrollId: 'WebAppAdmin'
-                                    ,archiveFile: 'testArchiveFile.zip'
-                                    ,connectionProfileName: 'testProfile'
-                                    ,networkAdmin: ['admin1']
-                                    ,networkAdminEnrollSecret: [true]
-                                    ,optionsFile: '/path/to/options.json'};
-            let connectionProfileName = argv.connectionProfileName;
+            let argv = {card:'cardname'
+                        ,networkAdmin: ['admin1']
+                        ,networkAdminEnrollSecret: [true]
+                        ,optionsFile: '/path/to/options.json'};
 
             sandbox.stub(Deploy, 'getArchiveFileContents');
             const optionsObject = {
@@ -347,7 +318,7 @@ describe('composer deploy network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, connectionProfileName, argv.enrollId, enrollmentSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.deploy);
                 const deployOptions = mockAdminConnection.deploy.args[0][1];
                 sanitize(deployOptions.bootstrapTransactions);
@@ -374,15 +345,6 @@ describe('composer deploy network CLI unit tests', function () {
             });
         });
 
-        it('show throw an error if loglevel not valid', function() {
-            let argv = {enrollId: 'WebAppAdmin'
-                       ,enrollSecret: 'DJY27pEnl16d'
-                       ,loglevel: 'BAD'
-                       ,archiveFile: 'testArchiveFile.zip'};
-            return DeployCmd.handler(argv)
-                .should.be.rejectedWith(/or not one of/);
-
-        });
     });
 
     describe('Deploy getArchiveFileContents() method tests', function () {

--- a/packages/composer-cli/test/network/deploy.js
+++ b/packages/composer-cli/test/network/deploy.js
@@ -192,7 +192,7 @@ describe('composer deploy network CLI unit tests', function () {
             });
         });
 
-        it('Good path, all parms correctly specified, including optional loglevel.', function () {
+        it('Good path, all parms correctly specified, including optional logLevel.', function () {
 
             let argv = {card:'cardname'
                        ,archiveFile: 'testArchiveFile.zip'
@@ -212,7 +212,7 @@ describe('composer deploy network CLI unit tests', function () {
                 sinon.assert.calledOnce(mockAdminConnection.connect);
                 sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.deploy);
-                sinon.assert.calledWith(mockAdminConnection.deploy, businessNetworkDefinition, { bootstrapTransactions: [], loglevel: 'DEBUG'});
+                sinon.assert.calledWith(mockAdminConnection.deploy, businessNetworkDefinition, { bootstrapTransactions: [], logLevel: 'DEBUG'});
             });
         });
 
@@ -400,13 +400,9 @@ describe('composer deploy network CLI unit tests', function () {
         });
         it('Failure of the archive functions', function () {
 
-
             let argv = {card: 'cardName'};
-
             sandbox.stub(Deploy, 'getArchiveFileContents');
-
             Deploy.getArchiveFileContents.withArgs(argv.archiveFile).throws(new Error('failure'));
-
             return DeployCmd.handler(argv)
                         .should.be.rejectedWith(/failure/);
         });

--- a/packages/composer-cli/test/network/list.js
+++ b/packages/composer-cli/test/network/list.js
@@ -58,7 +58,6 @@ describe('composer network list CLI unit tests', function () {
         sandbox.stub(CmdUtil, 'createBusinessNetworkConnection').returns(mockBusinessNetworkConnection);
         sandbox.stub(process, 'exit');
         sandbox.stub(ListCmd, 'getMatchingAssets').resolves({});
-        sandbox.stub(ListCmd,'getMatchingRegistries').resolves([{id:'reg1','name':'reg1','registryType':'Asset','assets':{}},{id:'reg2','name':'reg2','registryType':'Asset','assets':{}}]);
     });
 
     afterEach(() => {
@@ -70,8 +69,7 @@ describe('composer network list CLI unit tests', function () {
         it('Good path, all parms correctly specified.', function () {
             let argv = {card:'cardname'
                        ,archiveFile: 'testArchiveFile.zip'};
-
-
+            sandbox.stub(ListCmd,'getMatchingRegistries').resolves([{id:'reg1','name':'reg1','registryType':'Asset','assets':{}},{id:'reg2','name':'reg2','registryType':'Asset','assets':{}}]);
 
             return List.handler(argv)
             .then ((result) => {
@@ -81,6 +79,18 @@ describe('composer network list CLI unit tests', function () {
             });
         });
 
+        it('Good path, all parms correctly specified - single regsitry.', function () {
+            let argv = {card:'cardname'
+                       ,archiveFile: 'testArchiveFile.zip'};
+            sandbox.stub(ListCmd,'getMatchingRegistries').resolves({id:'reg1',participants:[],'name':'reg1','registryType':'Asset','assets':[]});
+
+            return List.handler(argv)
+            .then ((result) => {
+                argv.thePromise.should.be.a('promise');
+                sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
+                sinon.assert.calledWith(mockBusinessNetworkConnection.connect,'cardname');
+            });
+        });
     });
 
 });

--- a/packages/composer-cli/test/network/list.js
+++ b/packages/composer-cli/test/network/list.js
@@ -68,11 +68,8 @@ describe('composer network list CLI unit tests', function () {
     describe('List handler() method tests', function () {
 
         it('Good path, all parms correctly specified.', function () {
-            let argv = {enrollId: 'WebAppAdmin'
-                       ,enrollSecret: 'DJY27pEnl16d'
-                       ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'someOtherProfile'
-                       ,businessNetworkName: 'testBusinessNetworkId'};
+            let argv = {card:'cardname'
+                       ,archiveFile: 'testArchiveFile.zip'};
 
 
 
@@ -80,37 +77,9 @@ describe('composer network list CLI unit tests', function () {
             .then ((result) => {
                 argv.thePromise.should.be.a('promise');
                 sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, argv.connectionProfileName, argv.businessNetworkName, argv.enrollId, argv.enrollSecret);
+                sinon.assert.calledWith(mockBusinessNetworkConnection.connect,'cardname');
             });
         });
-
-        it('Good path, all parms correctly specified no enroll secret', function () {
-            let argv = {enrollId: 'WebAppAdmin'
-                       ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'someOtherProfile'
-                       ,businessNetworkName: 'testBusinessNetworkId'};
-
-            sandbox.stub(CmdUtil, 'prompt').resolves({enrollmentSecret:'usersresponse'});
-
-            return List.handler(argv)
-            .then ((result) => {
-                argv.thePromise.should.be.a('promise');
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, argv.connectionProfileName, argv.businessNetworkName, argv.enrollId, 'usersresponse');
-            });
-        });
-
-
-        it('Good path, all parms correctly specified with card.', function () {
-            let argv = {card: 'cardName'};
-            return List.handler(argv)
-            .then ((result) => {
-                argv.thePromise.should.be.a('promise');
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'cardName');
-            });
-        });
-
 
     });
 

--- a/packages/composer-cli/test/network/loglevel.js
+++ b/packages/composer-cli/test/network/loglevel.js
@@ -24,10 +24,6 @@ const chai = require('chai');
 chai.should();
 chai.use(require('chai-as-promised'));
 
-const BUSINESS_NETWORK_NAME = 'net.biz.TestNetwork-0.0.1';
-const ENROLL_ID = 'SuccessKid';
-const ENROLL_SECRET = 'SuccessKidWin';
-
 describe('composer network logLevel CLI unit tests', () => {
 
     let sandbox;
@@ -47,27 +43,21 @@ describe('composer network logLevel CLI unit tests', () => {
 
     it('should query the current loglevel', () => {
         let argv = {
-            businessNetworkName: BUSINESS_NETWORK_NAME,
-            enrollId: ENROLL_ID,
-            enrollSecret: ENROLL_SECRET,
-            connectionProfileName: 'someOtherProfile'
+            card:'cardname'
         };
 
         return LogLevel.handler(argv)
             .then((res) => {
                 argv.thePromise.should.be.a('promise');
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, 'someOtherProfile', argv.enrollId, argv.enrollSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.getLogLevel);
             });
     });
 
     it('should set the loglevel', () => {
         let argv = {
-            businessNetworkName: BUSINESS_NETWORK_NAME,
-            enrollId: ENROLL_ID,
-            enrollSecret: ENROLL_SECRET,
-            connectionProfileName: 'someOtherProfile',
+            card:'cardname' ,
             newlevel: 'DEBUG'
         };
 
@@ -75,7 +65,7 @@ describe('composer network logLevel CLI unit tests', () => {
             .then((res) => {
                 argv.thePromise.should.be.a('promise');
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, 'someOtherProfile', argv.enrollId, argv.enrollSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.setLogLevel);
                 sinon.assert.calledWith(mockAdminConnection.setLogLevel, 'DEBUG');
             });

--- a/packages/composer-cli/test/network/loglevel.js
+++ b/packages/composer-cli/test/network/loglevel.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const Client = require('composer-admin');
+const AdminConnection = require('composer-admin').AdminConnection;
 
 const LogLevel = require('../../lib/cmds/network/loglevelCommand.js');
 const CmdUtil = require('../../lib/cmds/utils/cmdutils.js');
@@ -31,7 +31,8 @@ describe('composer network logLevel CLI unit tests', () => {
 
     beforeEach(() => {
         sandbox = sinon.sandbox.create();
-        mockAdminConnection = sinon.createStubInstance(Client.AdminConnection);
+        mockAdminConnection = sinon.createStubInstance(AdminConnection);
+        mockAdminConnection.connect.resolves();
         sandbox.stub(CmdUtil, 'createAdminConnection').returns(mockAdminConnection);
         mockAdminConnection.getLogLevel.resolves('INFO');
         sandbox.stub(process, 'exit');
@@ -41,7 +42,7 @@ describe('composer network logLevel CLI unit tests', () => {
         sandbox.restore();
     });
 
-    it('should query the current loglevel', () => {
+    it('should query the current logLevel', () => {
         let argv = {
             card:'cardname'
         };
@@ -55,7 +56,7 @@ describe('composer network logLevel CLI unit tests', () => {
             });
     });
 
-    it('should set the loglevel', () => {
+    it('should set the logLevel', () => {
         let argv = {
             card:'cardname' ,
             newlevel: 'DEBUG'

--- a/packages/composer-cli/test/network/ping.js
+++ b/packages/composer-cli/test/network/ping.js
@@ -16,104 +16,69 @@
 
 const Client = require('composer-client');
 const BusinessNetworkConnection = Client.BusinessNetworkConnection;
+const Admin = require('composer-admin');
+const BusinessNetworkDefinition = Admin.BusinessNetworkDefinition;
 
 const Ping = require('../../lib/cmds/network/pingCommand.js');
 const CmdUtil = require('../../lib/cmds/utils/cmdutils.js');
 
 const sinon = require('sinon');
-
-const BUSINESS_NETWORK_NAME = 'net.biz.TestNetwork-0.0.1';
-const ENROLL_ID = 'SuccessKid';
-const ENROLL_SECRET = 'SuccessKidWin';
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-as-promised'));
 
 describe('composer network ping CLI unit tests', () => {
 
     let sandbox;
     let mockBusinessNetworkConnection;
+    let mockBusinessNetworkDefinition;
 
     beforeEach(() => {
         sandbox = sinon.sandbox.create();
         mockBusinessNetworkConnection = sinon.createStubInstance(BusinessNetworkConnection);
-        mockBusinessNetworkConnection.connect.resolves();
+        mockBusinessNetworkDefinition = sinon.createStubInstance(BusinessNetworkDefinition);
+
+        mockBusinessNetworkConnection.connect.resolves(mockBusinessNetworkDefinition);
         mockBusinessNetworkConnection.ping.resolves({
             version: '9.9.9',
             participant: null
         });
         sandbox.stub(CmdUtil, 'createBusinessNetworkConnection').returns(mockBusinessNetworkConnection);
         sandbox.stub(process, 'exit');
+
     });
 
     afterEach(() => {
         sandbox.restore();
     });
 
-    it('should test the connection to the business network using the default profile', () => {
+    it('should test the connection to the business network using the supplied card', () => {
         let argv = {
-            connectionProfileName: 'someOtherProfile',
-            businessNetworkName: BUSINESS_NETWORK_NAME,
-            enrollId: ENROLL_ID,
-            enrollSecret: ENROLL_SECRET
+            card:'cardname'
         };
         return Ping.handler(argv)
             .then((res) => {
                 argv.thePromise.should.be.a('promise');
                 sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'someOtherProfile', argv.businessNetworkName, argv.enrollId, argv.enrollSecret);
+                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockBusinessNetworkConnection.ping);
                 sinon.assert.calledWith(mockBusinessNetworkConnection.ping);
             });
     });
 
-    it('should test the connection to the business network using the specified profile', () => {
-        let argv = {
-            connectionProfileName: 'someOtherProfile',
-            businessNetworkName: BUSINESS_NETWORK_NAME,
-            enrollId: ENROLL_ID,
-            enrollSecret: ENROLL_SECRET
-        };
-        return Ping.handler(argv)
-            .then((res) => {
-                argv.thePromise.should.be.a('promise');
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'someOtherProfile', argv.businessNetworkName, argv.enrollId, argv.enrollSecret);
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.ping);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.ping);
-            });
-    });
 
-    it('should prompt for the enrollment secret if not specified', () => {
-        sandbox.stub(CmdUtil, 'prompt').resolves(ENROLL_SECRET);
-        let argv = {
-            connectionProfileName: 'someOtherProfile',
-            businessNetworkName: BUSINESS_NETWORK_NAME,
-            enrollId: ENROLL_ID
-        };
-        return Ping.handler(argv)
-            .then((res) => {
-                argv.thePromise.should.be.a('promise');
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'someOtherProfile', argv.businessNetworkName, argv.enrollId, argv.enrollSecret);
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.ping);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.ping);
-            });
-    });
 
     it('should display the participant if a participant was found', () => {
         mockBusinessNetworkConnection.ping.resolves({
             version: '9.9.9',
             participant: 'org.doge.Doge#DOGE_1'
         });
-        let argv = {
-            connectionProfileName: 'someOtherProfile',
-            businessNetworkName: BUSINESS_NETWORK_NAME,
-            enrollId: ENROLL_ID,
-            enrollSecret: ENROLL_SECRET
-        };
+        let argv = {card:'cardname'};
         return Ping.handler(argv)
             .then((res) => {
                 argv.thePromise.should.be.a('promise');
                 sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'someOtherProfile', argv.businessNetworkName, argv.enrollId, argv.enrollSecret);
+                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockBusinessNetworkConnection.ping);
                 sinon.assert.calledWith(mockBusinessNetworkConnection.ping);
             });
@@ -122,16 +87,13 @@ describe('composer network ping CLI unit tests', () => {
     it('should error when the connection cannot be tested', () => {
         mockBusinessNetworkConnection.ping.rejects(new Error('such error'));
         let argv = {
-            connectionProfileName: 'someOtherProfile',
-            businessNetworkName: BUSINESS_NETWORK_NAME,
-            enrollId: ENROLL_ID,
-            enrollSecret: ENROLL_SECRET
+            card:'cardname'
         };
         return Ping.handler(argv)
             .catch((res) => {
                 argv.thePromise.should.be.a('promise');
                 sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'someOtherProfile', argv.businessNetworkName, argv.enrollId, argv.enrollSecret);
+                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockBusinessNetworkConnection.ping);
                 sinon.assert.calledWith(mockBusinessNetworkConnection.ping);
             });

--- a/packages/composer-cli/test/network/reset.js
+++ b/packages/composer-cli/test/network/reset.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const Admin = require('composer-admin');
-
+const IdCard = require('composer-common').IdCard;
 const ResetCMD = require('../../lib/cmds/network/resetCommand.js');
 const CmdUtil = require('../../lib/cmds/utils/cmdutils.js');
 const Reset = require('../../lib/cmds/network/lib/reset.js');
@@ -31,6 +31,7 @@ chai.use(require('chai-as-promised'));
 
 
 let mockAdminConnection;
+let mockIdCard;
 
 describe('composer reset network CLI unit tests', function () {
 
@@ -43,6 +44,9 @@ describe('composer reset network CLI unit tests', function () {
         mockAdminConnection.createProfile.resolves();
         mockAdminConnection.connect.resolves();
         mockAdminConnection.undeploy.resolves();
+        mockIdCard = sinon.createStubInstance(IdCard);
+        mockIdCard.getBusinessNetworkName.returns('penguin-network');
+        mockAdminConnection.getCard.resolves(mockIdCard);
         sandbox.stub(CmdUtil, 'createAdminConnection').returns(mockAdminConnection);
         sandbox.stub(process, 'exit');
 

--- a/packages/composer-cli/test/network/reset.js
+++ b/packages/composer-cli/test/network/reset.js
@@ -75,30 +75,16 @@ describe('composer reset network CLI unit tests', function () {
 
     describe('test main reset logic', () =>{
         it('main line code path', ()=>{
-            let argv = {'businessNetworkName':'networkname','connectionProfileName':'hlfv1','enrollId':'admin','enrollSecret':'adminpw'};
+            let argv = {card:'cardname'};
             mockAdminConnection.reset.resolves();
             return Reset.handler(argv).then(()=>{
-                sinon.assert.calledWith(mockAdminConnection.reset,'networkname');
+                sinon.assert.calledWith(mockAdminConnection.reset);
             });
 
         });
 
-        it('no secret given', ()=>{
-            let argv = {'businessNetworkName':'networkname','connectionProfileName':'hlfv1','enrollId':'admin'};
-            sandbox.stub(CmdUtil, 'prompt').resolves({'enrollmentSecret':'adminpw'});
-
-            return Reset.handler(argv);
-
-        });
-        it('error path - prompt method fails', ()=>{
-            let argv = {'businessNetworkName':'networkname','connectionProfileName':'hlfv1','enrollId':'admin'};
-            sandbox.stub(CmdUtil, 'prompt').rejects(new Error('computer says no'));
-
-            return Reset.handler(argv).should.eventually.be.rejectedWith(/computer says no/);
-
-        });
         it('error path #2 prompt method fails, along with the spinner class', ()=>{
-            let argv = {'businessNetworkName':'networkname','connectionProfileName':'hlfv1','enrollId':'admin','enrollSecret':'adminpw'};
+            let argv = {card:'cardname'};
             mockAdminConnection.reset.rejects(new Error('computer says no'));
             sandbox.stub(ora,'start').returns({});
             sandbox.stub(ora,'fail').returns();

--- a/packages/composer-cli/test/network/start.js
+++ b/packages/composer-cli/test/network/start.js
@@ -68,10 +68,8 @@ describe('composer start network CLI unit tests', function () {
 
         it('Good path, optional parameter -O /path/to/options.json specified.', function () {
 
-            let argv = {startId: 'WebAppAdmin'
-                       ,startSecret: 'DJY27pEnl16d'
-                       ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'testProfile'
+            let argv = {card:'cardname'
+                        ,archiveFile: 'testArchiveFile.zip'
                        ,optionsFile: '/path/to/options.json'};
             sandbox.stub(Start, 'getArchiveFileContents');
             const optionsObject = {
@@ -100,7 +98,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, argv.connectionProfileName, argv.startId, argv.startSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
                 sinon.assert.calledWith(mockAdminConnection.start, businessNetworkDefinition,
                     {
@@ -112,10 +110,7 @@ describe('composer start network CLI unit tests', function () {
 
         it('Good path, optional parameter -o endorsementPolicyFile= specified.', function () {
 
-            let argv = {startId: 'WebAppAdmin'
-                       ,startSecret: 'DJY27pEnl16d'
-                       ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'testProfile'
+            let argv = {card:'cardname'
                        ,option: 'endorsementPolicyFile=/path/to/some/file.json'};
             sandbox.stub(Start, 'getArchiveFileContents');
 
@@ -129,7 +124,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, argv.connectionProfileName, argv.startId, argv.startSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
                 sinon.assert.calledWith(mockAdminConnection.start, businessNetworkDefinition,
                     {
@@ -142,10 +137,8 @@ describe('composer start network CLI unit tests', function () {
 
         it('Good path, optional parameter -o endorsementPolicy= specified.', function () {
 
-            let argv = {startId: 'WebAppAdmin'
-                       ,startSecret: 'DJY27pEnl16d'
+            let argv = {card:'cardname'
                        ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'testProfile'
                        ,option: 'endorsementPolicy=' + VALID_ENDORSEMENT_POLICY_STRING};
 
             sandbox.stub(Start, 'getArchiveFileContents');
@@ -160,7 +153,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, argv.connectionProfileName, argv.startId, argv.startSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect,'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
                 sinon.assert.calledWith(mockAdminConnection.start, businessNetworkDefinition,
                     {
@@ -173,10 +166,8 @@ describe('composer start network CLI unit tests', function () {
 
         it('Good path, all parms correctly specified.', function () {
 
-            let argv = {startId: 'WebAppAdmin'
-                       ,startSecret: 'DJY27pEnl16d'
-                       ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'testProfile'};
+            let argv = {card:'cardname'
+                       ,archiveFile: 'testArchiveFile.zip'};
 
             sandbox.stub(Start, 'getArchiveFileContents');
 
@@ -190,7 +181,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, argv.connectionProfileName, argv.startId, argv.startSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
                 sinon.assert.calledWith(mockAdminConnection.start, businessNetworkDefinition, { bootstrapTransactions: [] });
             });
@@ -198,10 +189,8 @@ describe('composer start network CLI unit tests', function () {
 
         it('Good path, all parms correctly specified, including optional loglevel.', function () {
 
-            let argv = {startId: 'WebAppAdmin'
-                       ,startSecret: 'DJY27pEnl16d'
+            let argv = {card:'cardname'
                        ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'testProfile'
                        ,loglevel: 'DEBUG'};
 
             sandbox.stub(Start, 'getArchiveFileContents');
@@ -216,17 +205,16 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, argv.connectionProfileName, argv.startId, argv.startSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
-                sinon.assert.calledWith(mockAdminConnection.start, businessNetworkDefinition, { bootstrapTransactions: [], logLevel: 'DEBUG' });
+                sinon.assert.calledWith(mockAdminConnection.start, businessNetworkDefinition, { bootstrapTransactions: [], loglevel: 'DEBUG' });
             });
         });
 
         it('Good path, no secret, all other parms correctly specified.', function () {
 
-            let argv = {startId: 'WebAppAdmin'
-                       ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'testProfile'};
+            let argv = {card:'cardname'
+                       ,archiveFile: 'testArchiveFile.zip'};
 
             sandbox.stub(Start, 'getArchiveFileContents');
 
@@ -240,7 +228,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, argv.connectionProfileName, argv.startId, argv.startSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect,'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
                 sinon.assert.calledWith(mockAdminConnection.start, businessNetworkDefinition, { bootstrapTransactions: [] });
             });
@@ -256,13 +244,10 @@ describe('composer start network CLI unit tests', function () {
 
         it('Good path, network administrator specified', function () {
 
-            let argv = {startId: 'WebAppAdmin'
-                        ,startSecret: 'DJY27pEnl16d'
+            let argv = {card:'cardname'
                         ,archiveFile: 'testArchiveFile.zip'
-                        ,connectionProfileName: 'testProfile'
                         ,networkAdmin: ['admin1']
                         ,networkAdminEnrollSecret: [true]};
-            let connectionProfileName = argv.connectionProfileName;
 
             sandbox.stub(Start, 'getArchiveFileContents');
 
@@ -276,7 +261,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, connectionProfileName, argv.startId, argv.startSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
                 const deployOptions = mockAdminConnection.start.args[0][1];
                 sanitize(deployOptions.bootstrapTransactions);
@@ -302,14 +287,13 @@ describe('composer start network CLI unit tests', function () {
 
         it('Good path, network administrator and bootstrap transactions specified', function () {
 
-            let argv = {startId: 'WebAppAdmin'
-                        ,startSecret: 'DJY27pEnl16d'
+            let argv = {card:'cardname'
                         ,archiveFile: 'testArchiveFile.zip'
-                        ,connectionProfileName: 'testProfile'
+
                         ,networkAdmin: ['admin1']
                         ,networkAdminEnrollSecret: [true]
                         ,optionsFile: '/path/to/options.json'};
-            let connectionProfileName = argv.connectionProfileName;
+
 
             sandbox.stub(Start, 'getArchiveFileContents');
             const optionsObject = {
@@ -332,7 +316,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
 
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, connectionProfileName, argv.startId, argv.startSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
                 const startOptions = mockAdminConnection.start.args[0][1];
                 sanitize(startOptions.bootstrapTransactions);
@@ -357,16 +341,6 @@ describe('composer start network CLI unit tests', function () {
                     }
                 ]);
             });
-        });
-
-        it('show throw an error if loglevel not valid', function() {
-            let argv = {enrollId: 'WebAppAdmin'
-                       ,enrollSecret: 'DJY27pEnl16d'
-                       ,loglevel: 'BAD'
-                       ,archiveFile: 'testArchiveFile.zip'};
-            return Start.handler(argv)
-                .should.be.rejectedWith(/or not one of/);
-
         });
 
     });

--- a/packages/composer-cli/test/network/start.js
+++ b/packages/composer-cli/test/network/start.js
@@ -187,7 +187,7 @@ describe('composer start network CLI unit tests', function () {
             });
         });
 
-        it('Good path, all parms correctly specified, including optional loglevel.', function () {
+        it('Good path, all parms correctly specified, including optional logLevel.', function () {
 
             let argv = {card:'cardname'
                        ,archiveFile: 'testArchiveFile.zip'
@@ -207,7 +207,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(mockAdminConnection.connect);
                 sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
-                sinon.assert.calledWith(mockAdminConnection.start, businessNetworkDefinition, { bootstrapTransactions: [], loglevel: 'DEBUG' });
+                sinon.assert.calledWith(mockAdminConnection.start, businessNetworkDefinition, { bootstrapTransactions: [], logLevel: 'DEBUG' });
             });
         });
 

--- a/packages/composer-cli/test/network/undeploy.js
+++ b/packages/composer-cli/test/network/undeploy.js
@@ -54,17 +54,15 @@ describe('composer undeploy network CLI unit tests', function () {
 
         it('Good path, all parms correctly specified.', function () {
 
-            let argv = {enrollId: 'WebAppAdmin'
-                       ,enrollSecret: 'DJY27pEnl16d'
-                       ,archiveFile: 'testArchiveFile.zip'
-                       ,connectionProfileName: 'someOtherProfile'};
-            let connectionProfileName = argv.connectionProfileName;
+            let argv = {card:'cardname'
+                       ,archiveFile: 'testArchiveFile.zip'};
+
 
             return Undeploy.handler(argv)
             .then ((result) => {
                 argv.thePromise.should.be.a('promise');
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, connectionProfileName, argv.enrollId, argv.enrollSecret);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.undeploy);
 
             });

--- a/packages/composer-cli/test/network/undeploy.js
+++ b/packages/composer-cli/test/network/undeploy.js
@@ -67,6 +67,13 @@ describe('composer undeploy network CLI unit tests', function () {
 
             });
         });
+        it('error path  undeploy method fails', ()=>{
+            let argv = {card:'cardname'};
+            mockAdminConnection.undeploy.rejects(new Error('computer says no'));
 
+
+            return Undeploy.handler(argv).should.eventually.be.rejectedWith(/computer says no/);
+
+        });
     });
 });

--- a/packages/composer-cli/test/network/undeploy.js
+++ b/packages/composer-cli/test/network/undeploy.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const Admin = require('composer-admin');
-
+const IdCard = require('composer-common').IdCard;
 const Undeploy = require('../../lib/cmds/network/undeployCommand.js');
 const CmdUtil = require('../../lib/cmds/utils/cmdutils.js');
 
@@ -33,6 +33,7 @@ let mockAdminConnection;
 describe('composer undeploy network CLI unit tests', function () {
 
     let sandbox;
+    let mockIdCard;
 
     beforeEach(() => {
         sandbox = sinon.sandbox.create();
@@ -41,6 +42,9 @@ describe('composer undeploy network CLI unit tests', function () {
         mockAdminConnection.createProfile.resolves();
         mockAdminConnection.connect.resolves();
         mockAdminConnection.undeploy.resolves();
+        mockIdCard = sinon.createStubInstance(IdCard);
+        mockIdCard.getBusinessNetworkName.returns('penguin-network');
+        mockAdminConnection.getCard.resolves(mockIdCard);
         sandbox.stub(CmdUtil, 'createAdminConnection').returns(mockAdminConnection);
         sandbox.stub(process, 'exit');
 
@@ -69,6 +73,7 @@ describe('composer undeploy network CLI unit tests', function () {
         });
         it('error path  undeploy method fails', ()=>{
             let argv = {card:'cardname'};
+
             mockAdminConnection.undeploy.rejects(new Error('computer says no'));
 
 

--- a/packages/composer-cli/test/network/upgrade.js
+++ b/packages/composer-cli/test/network/upgrade.js
@@ -52,10 +52,8 @@ describe('composer upgrade runtime CLI unit tests', function () {
 
         it('Good path, all parms correctly specified.', function () {
 
-            let argv = {upgradeId: 'PeerAdmin'
-                       ,upgradeSecret: 'Anything'
-                       ,businessNetworkName: 'org-acme-biznet'
-                       ,connectionProfileName: 'testProfile'};
+            let argv = {card:'cardname'
+                       ,businessNetworkName: 'org-acme-biznet'};
 
 
             return InstallCmd.handler(argv)
@@ -63,7 +61,7 @@ describe('composer upgrade runtime CLI unit tests', function () {
                 argv.thePromise.should.be.a('promise');
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
                 sinon.assert.calledOnce(mockAdminConnection.connect);
-                sinon.assert.calledWith(mockAdminConnection.connect, argv.connectionProfileName, argv.upgradeId, argv.upgradeSecret, argv.businessNetworkName);
+                sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.upgrade);
             });
         });

--- a/packages/composer-cli/test/network/upgrade.js
+++ b/packages/composer-cli/test/network/upgrade.js
@@ -65,7 +65,14 @@ describe('composer upgrade runtime CLI unit tests', function () {
                 sinon.assert.calledOnce(mockAdminConnection.upgrade);
             });
         });
+        it('error path  upgrade method fails', ()=>{
+            let argv = {card:'cardname'};
+            mockAdminConnection.upgrade.rejects(new Error('computer says no'));
 
+
+            return InstallCmd.handler(argv).should.eventually.be.rejectedWith(/computer says no/);
+
+        });
     });
 
 });


### PR DESCRIPTION
Within this PR for #2333 

- Updated all the network clis to take a card instead of the collection of the connection profile, network name, enrollid/secret
- Access the card store for these instead - relies on card store semantics for if it doesn't exist etc.
- Remove the old options from the yargs cli specs.
- As we had an update to yargs, was able to go back to using `choices()` for the log level
- Loglevel had some different spellings in the tests so harmonised all of those. 