### PR TITLE
Added missing sample --networkAdminEnrollSecret (-S) on bnd-deploy.md

### DIFF
--- a/packages/composer-website/jekylldocs/business-network/bnd-deploy.md
+++ b/packages/composer-website/jekylldocs/business-network/bnd-deploy.md
@@ -18,7 +18,7 @@ For example:
 
     composer network deploy -p connectionProfileName -a <BusinessNetworkDefinition>.bna
     -i <Your EnrollmentID> -s <Your EnrollmentSecret>
-    -A admin -S
+    -A admin -S adminpw
 
 To update the business network definition for an already deployed business network use the [`composer network update`](../reference/composer.network.update.html) CLI command.
 
@@ -64,7 +64,7 @@ You can use additional options to the [`composer network deploy`](../reference/c
 
 If the business network administrator has an enrollment ID and enrollment secret, you can use the `-A` (business network administrator) and `-S` (business network administrator uses enrollment secret) flags. For example, the following command will create a business network administrator for the existing `admin` enrollment ID:
 
-    composer network deploy -p hlfv1 -a my-network.bna -i PeerAdmin -s randomString -A admin -S
+    composer network deploy -p hlfv1 -a my-network.bna -i PeerAdmin -s randomString -A admin -S adminpw
 
 If the business network administrator already has a certificate, you can use the `-A` (business network administrator) and `-C` (business network administrator certificate file) flags. For example, the following command will create a business network administrator for the specified certificate file:
 


### PR DESCRIPTION
Looking through the breaking changes for 0.14.0 and found that there was a missing --networkAdminEnrollSecret in the documentation. Just updating the sample code so that it will work when you run it. Issue reference : #2502