### PR TITLE
Make name parameter mandatory for AdminConnection.importCard

### DIFF
--- a/packages/composer-admin/api.txt
+++ b/packages/composer-admin/api.txt
@@ -1,6 +1,6 @@
 class AdminConnection {
    + void constructor(Object,BusinessNetworkCardStore) 
-   + Promise importCard(IdCard,String) 
+   + Promise importCard(String,IdCard) 
    + Promise getCard(String) 
    + Promise exportCard(String) 
    + Promise getAllCards() 

--- a/packages/composer-admin/changelog.txt
+++ b/packages/composer-admin/changelog.txt
@@ -11,12 +11,13 @@
 #
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
-Version 0.15.0 {0cf0932f6245dc1f4c47347bf0988a43} 2017-10-31
+Version 0.15.0 {9c957fda5d03d6e263263ea43e2897d4} 2017-10-31
 - Remove importIdentity, requestIdentity and exportIdentity from AdminConnection public API
 - Remove connect profile functions from AdminConnection public API
 - Add card function to AdminConnection public API
 - Update constructor documentation for cards instead of connection profiles
 - Remove backwards compatible parameters from AdminConnection.connect
+- Make name parameter mandatory on AdminConnection.importCard
 
 Version 0.14.1 {4d2de763c61ba58a8b8a80c83bf9e84a} 2017-10-23
  - Update to have connectWithCard

--- a/packages/composer-admin/lib/adminconnection.js
+++ b/packages/composer-admin/lib/adminconnection.js
@@ -118,15 +118,11 @@ class AdminConnection {
 
     /**
      * Import a business network card.
+     * @param {String} name Name by which this card should be referred
      * @param {IdCard} card The card to import
-     * @param {String} [name] Name by which this card should be referred
-     * @return {Promise} Resolved with the name by which the card is referred as a  String
+     * @return {Promise} Resolved when the card is imported
      */
-    importCard(card, name) {
-        if (!name) {
-            const locationName = card.getBusinessNetworkName() || card.getConnectionProfile().name;
-            name = card.getUserName() + '@' + locationName;
-        }
+    importCard(name, card) {
         let connectionProfileData;
         return this.cardStore.put(name, card)
             .then(() => {
@@ -142,9 +138,6 @@ class AdminConnection {
                 } else {
                     return; // use secret
                 }
-            })
-            .then( ()=>{
-                return name;
             });
     }
 

--- a/packages/composer-cli/lib/cmds/card/lib/import.js
+++ b/packages/composer-cli/lib/cmds/card/lib/import.js
@@ -30,10 +30,12 @@ class Import {
     * @return {Promise} promise when command complete
     */
     static handler(args) {
+        let cardName;
         return Import.readCardFromFile(args.file).then(card => {
+            cardName = args.name || cmdUtil.getDefaultCardName(card);
             const adminConnection = cmdUtil.createAdminConnection();
-            return adminConnection.importCard(card, args.name);
-        }).then((cardName) => {
+            return adminConnection.importCard(cardName, card);
+        }).then(() => {
             console.log('Successfully imported business network card: ' + cardName);
         });
     }

--- a/packages/composer-cli/lib/cmds/utils/cmdutils.js
+++ b/packages/composer-cli/lib/cmds/utils/cmdutils.js
@@ -270,6 +270,16 @@ class CmdUtil {
         let businessNetworkConnection = new BusinessNetworkConnection();
         return businessNetworkConnection;
     }
+
+    /**
+     * Get a default name for a given business network card.
+     * @param {IdCard} card A business network card
+     * @returns {String} A card name
+     */
+    static getDefaultCardName(card) {
+        const locationName = card.getBusinessNetworkName() || card.getConnectionProfile().name;
+        return card.getUserName() + '@' + locationName;
+    }
 }
 
 module.exports = CmdUtil;

--- a/packages/composer-cli/test/card/import.js
+++ b/packages/composer-cli/test/card/import.js
@@ -54,12 +54,10 @@ describe('composer card import CLI', function() {
         const args = {
             file: cardFileName
         };
-        const cardName = 'CARD_NAME';
-        adminConnectionStub.importCard.resolves(cardName);
+        adminConnectionStub.importCard.resolves();
         return ImportCmd.handler(args).then(() => {
             sinon.assert.calledOnce(adminConnectionStub.importCard);
-            sinon.assert.calledWith(adminConnectionStub.importCard, sinon.match.instanceOf(IdCard), sinon.match.falsy);
-            sinon.assert.calledWith(consoleLogSpy, sinon.match(cardName));
+            sinon.assert.calledWith(adminConnectionStub.importCard, sinon.match.string, sinon.match.instanceOf(IdCard));
         });
     });
 
@@ -73,7 +71,7 @@ describe('composer card import CLI', function() {
         adminConnectionStub.importCard.resolves(args.name);
         return ImportCmd.handler(args).then(() => {
             sinon.assert.calledOnce(adminConnectionStub.importCard);
-            sinon.assert.calledWith(adminConnectionStub.importCard, sinon.match.instanceOf(IdCard), cardName);
+            sinon.assert.calledWith(adminConnectionStub.importCard, cardName, sinon.match.instanceOf(IdCard));
             sinon.assert.calledWith(consoleLogSpy, sinon.match(cardName));
         });
     });

--- a/packages/composer-cli/test/utils/cmdutils.js
+++ b/packages/composer-cli/test/utils/cmdutils.js
@@ -17,6 +17,7 @@
 const AdminConnection = require('composer-admin').AdminConnection;
 const BusinessNetworkConnection = require('composer-client').BusinessNetworkConnection;
 const BusinessNetworkDefinition = require('composer-common').BusinessNetworkDefinition;
+const IdCard = require('composer-common').IdCard;
 const CmdUtil = require('../../lib/cmds/utils/cmdutils.js');
 const prompt = require('prompt');
 
@@ -485,6 +486,24 @@ describe('composer transaction cmdutils unit tests', () => {
             CmdUtil.createBusinessNetworkConnection().should.be.an.instanceOf(BusinessNetworkConnection);
         });
 
+    });
+
+    describe('#getDefaultCardName', () => {
+        it('should return name based on card name and business network name for user card', () => {
+            const metadata = { userName: 'conga', businessNetwork: 'penguin-network' };
+            const connectionProfile = { name: 'profile-name' };
+            const card = new IdCard(metadata, connectionProfile);
+            const result = CmdUtil.getDefaultCardName(card);
+            result.should.include(metadata.userName).and.include(metadata.businessNetwork);
+        });
+
+        it('should return name based on card name and connection profile name for PeerAdmin card', () => {
+            const metadata = { userName: 'PeerAdmin', roles: [ 'PeerAdmin', 'ChannelAdmin' ] };
+            const connectionProfile = { name: 'profile-name' };
+            const card = new IdCard(metadata, connectionProfile);
+            const result = CmdUtil.getDefaultCardName(card);
+            result.should.include(metadata.userName).and.include(connectionProfile.name);
+        });
     });
 
 });


### PR DESCRIPTION
Resolves #2587 

Also reverse the order of parameters to better match previous connection profile
API, card store API and Map APIs in general.
No longer returns the card name as this is always specified by the caller.