### PR TITLE
Issue2485 Filter returned objects to remove model-invalid instances

### DIFF
--- a/packages/composer-runtime/lib/registry.js
+++ b/packages/composer-runtime/lib/registry.js
@@ -67,19 +67,22 @@ class Registry extends EventEmitter {
     getAll() {
         return this.dataCollection.getAll()
             .then((objects) => {
-                return objects.map((object) => {
-                    object = Registry.removeInternalProperties(object);
-                    return this.serializer.fromJSON(object);
-                }).reduce((promise, resource) => {
-                    return promise.then((resources) => {
-                        return this.accessController.check(resource, 'READ')
+                return objects.reduce((promiseChain, resource) => {
+                    return promiseChain.then((newResources) => {
+                        let object = Registry.removeInternalProperties(resource);
+                        try {
+                            let resourceToCheckAccess = this.serializer.fromJSON(object);
+                            return this.accessController.check(resourceToCheckAccess, 'READ')
                             .then(() => {
-                                resources.push(resource);
-                                return resources;
-                            })
-                            .catch((error) => {
-                                return resources;
+                                newResources.push(resourceToCheckAccess);
+                                return newResources;
+                            }).catch((e) => {
+                                return newResources;
                             });
+                        } catch (err) {
+                            return newResources;
+                        }
+
                     });
                 }, Promise.resolve([]));
             });

--- a/packages/composer-runtime/test/registry.js
+++ b/packages/composer-runtime/test/registry.js
@@ -116,7 +116,7 @@ describe('Registry', () => {
                 });
         });
 
-        it('should not throw or leak information about resources that cannot be accessed', () => {
+        it('should not throw or leak information about resources that cannot be accessed due to ACL rules', () => {
             mockAccessController.check.withArgs(mockResource2, 'READ').rejects(new AccessException(mockResource2, 'READ', mockParticipant));
             return registry.getAll()
                 .then((resources) => {
@@ -127,6 +127,24 @@ describe('Registry', () => {
                     resources.should.deep.equal([mockResource1]);
                 });
         });
+
+        it('should not throw or leak information about existing resources that cannot be accessed due to not being valid in the model', () => {
+            let err = new Error('serializer error');
+            let ARGS = {
+                $class: 'org.doge.Doge',
+                assetId: 'doge2'
+            };
+            mockSerializer.fromJSON.withArgs(ARGS).throws(err);
+
+            return registry.getAll()
+                .then((resources) => {
+                    sinon.assert.calledOnce(mockAccessController.check);
+                    sinon.assert.calledWith(mockAccessController.check, mockResource1, 'READ');
+                    resources.should.all.be.an.instanceOf(Resource);
+                    resources.should.deep.equal([mockResource1]);
+                });
+        });
+
 
         it('should return errors from the data service', () => {
             mockDataCollection.getAll.rejects();


### PR DESCRIPTION
Filter objects returned by getAll to remove model-invalid objects.

Signed-off-by: Sam Smith <smithsj@uk.ibm.com>

