### PR TITLE
Fix import of business network cards, upgrade Swagger UI

### DIFF
--- a/packages/composer-rest-server/package.json
+++ b/packages/composer-rest-server/package.json
@@ -49,7 +49,7 @@
     "lodash": "4.17.4",
     "loopback": "3.4.0",
     "loopback-boot": "2.25.0",
-    "loopback-component-explorer": "4.1.1",
+    "loopback-component-explorer": "5.2.0",
     "loopback-component-passport": "3.2.0",
     "loopback-connector-composer": "0.15.0",
     "passport-local": "1.0.0",


### PR DESCRIPTION
As a user, I can import existing identities into my REST server wallet #2072 

Upgrade to latest LoopBack explorer for latest Swagger UI:
- Needed to support configuration of Swagger tags, so we can change the API category "Card" to "Wallet" in the UI
- Needed to properly support formData parameters to allow file upload in the UI.

Fix the import of business network cards so that certificates/private keys are imported into the wallet, broke with the latest business network card changes.