### PR TITLE
Issue business network cards from the REST server

### DIFF
--- a/packages/composer-client/lib/businessnetworkconnection.js
+++ b/packages/composer-client/lib/businessnetworkconnection.js
@@ -82,6 +82,7 @@ class BusinessNetworkConnection extends EventEmitter {
         this.securityContext = null;
         this.businessNetwork = null;
         this.dynamicQueryFile = null;
+        this.card = null;
     }
 
     /**
@@ -443,23 +444,31 @@ class BusinessNetworkConnection extends EventEmitter {
         const method = 'connectWithCard';
         LOG.entry(method,cardName);
 
-        let card;
-
         return this.cardStore.get(cardName)
             .then((retrievedCard)=>{
-                card = retrievedCard;
+                this.card = retrievedCard;
                 if (!additionalConnectOptions) {
                     additionalConnectOptions = {};
                 }
                 additionalConnectOptions.cardName = cardName;
-                return this.connectionProfileManager.connectWithData(card.getConnectionProfile(), card.getBusinessNetworkName(), additionalConnectOptions);
+                return this.connectionProfileManager.connectWithData(this.card.getConnectionProfile(), this.card.getBusinessNetworkName(), additionalConnectOptions);
             })
             .then((connection) => {
                 LOG.exit(method);
-                return this._connectionLogin(connection,card.getUserName(),card.getEnrollmentCredentials().secret);
+                return this._connectionLogin(connection,this.card.getUserName(),this.card.getEnrollmentCredentials().secret);
 
             });
 
+    }
+
+    /**
+     * Get the business network card used by this connection, if a business network card was used.
+     * @return {IdCard} The business network card used by this connection, or null if a business
+     * network card was not used.
+     * @private
+     */
+    getCard() {
+        return this.card;
     }
 
     /**
@@ -569,6 +578,7 @@ class BusinessNetworkConnection extends EventEmitter {
                 this.securityContext = null;
                 this.businessNetwork = null;
                 this.dynamicQueryFile = null;
+                this.card = null;
                 LOG.exit(method);
             });
     }

--- a/packages/composer-client/test/businessnetworkconnection.js
+++ b/packages/composer-client/test/businessnetworkconnection.js
@@ -234,11 +234,12 @@ describe('BusinessNetworkConnection', () => {
         const userName = 'FredBloggs';
         const enrollmentSecret = 'password';
         const keyValStore = '/conga/conga/conga';
+        let mockIdCard;
 
         beforeEach(() => {
             sandbox.stub(businessNetworkConnection.connectionProfileManager, 'connectWithData').resolves(mockConnection);
             let mockCardStore = sinon.createStubInstance(CardStore);
-            let mockIdCard = sinon.createStubInstance(IdCard);
+            mockIdCard = sinon.createStubInstance(IdCard);
             mockCardStore.get.resolves(mockIdCard);
             mockIdCard.getEnrollmentCredentials.returns({secret: enrollmentSecret});
             mockIdCard.getUserName.returns(userName);
@@ -271,6 +272,7 @@ describe('BusinessNetworkConnection', () => {
             return businessNetworkConnection.connect('cardName', { some: 'other', options: true })
                 .then((result)=>{
                     sinon.assert.calledWith(mockConnection.login, userName, enrollmentSecret);
+                    businessNetworkConnection.getCard().should.equal(mockIdCard);
                 });
         });
 
@@ -282,6 +284,7 @@ describe('BusinessNetworkConnection', () => {
                         sinon.match.any,
                         sinon.match.any,
                         sinon.match.has('cardName', cardName));
+                    businessNetworkConnection.getCard().should.equal(mockIdCard);
                 });
         });
 
@@ -293,6 +296,7 @@ describe('BusinessNetworkConnection', () => {
                         sinon.match.any,
                         sinon.match.any,
                         sinon.match.has('cardName', cardName));
+                    businessNetworkConnection.getCard().should.equal(mockIdCard);
                 });
         });
 

--- a/packages/composer-rest-server/public/lib/loadSwaggerUI.js
+++ b/packages/composer-rest-server/public/lib/loadSwaggerUI.js
@@ -25,6 +25,8 @@ $(function() {
   function fixupOperation(op) {
     if (op.nickname === 'Card_exportCard') {
       op.produces = [ 'application/octet-stream' ];
+    } else if (op.nickname === 'System_issueIdentity') {
+      op.produces = [ 'application/octet-stream' ];
     }
   }
 
@@ -134,3 +136,4 @@ $(function() {
     }
   }
 });
+


### PR DESCRIPTION
As a user, I can import existing identities into my REST server wallet #2072

Update the LoopBack connector and REST server such that the issue identity API generates a new business network card. This is instead of an enrolment ID and secret pair, which is very difficult to use for a REST client as they would have to _somehow_ package it up into a business network card themselves.