### PR TITLE
convert identity bind to use cards

### DIFF
--- a/packages/composer-cli/lib/cmds/identity/bindCommand.js
+++ b/packages/composer-cli/lib/cmds/identity/bindCommand.js
@@ -19,10 +19,7 @@ const Bind = require ('./lib/bind.js');
 module.exports.command = 'bind [options]';
 module.exports.describe = 'Bind an existing identity to a participant in a participant registry';
 module.exports.builder = {
-    connectionProfileName: {alias: 'p', required: true, describe: 'The connection profile name', type: 'string' },
-    businessNetworkName: {alias: 'n', required: true, describe: 'The business network name', type: 'string' },
-    enrollId: { alias: 'i', required: true, describe: 'The enrollment ID of the user', type: 'string' },
-    enrollSecret: { alias: 's', required: false, describe: 'The enrollment secret of the user', type: 'string' },
+    card: {alias: 'c', required: true, describe: 'Name of the network card to use', type: 'string'},
     participantId: { alias: 'a', required: true, describe: 'The particpant to issue the new identity to', type: 'string' },
     certificateFile: { alias: 'c', required: true, describe: 'File containing the certificate', type: 'string' }
 };

--- a/packages/composer-cli/lib/cmds/identity/lib/bind.js
+++ b/packages/composer-cli/lib/cmds/identity/lib/bind.js
@@ -33,13 +33,10 @@ class Bind {
     */
     static handler(argv) {
         let businessNetworkConnection;
-        let enrollId;
-        let enrollSecret;
-        let connectionProfileName = argv.connectionProfileName;
-        let businessNetworkName;
         let participantId = argv.participantId;
         let certificateFile = argv.certificateFile;
         let certificate;
+        let cardName;
 
         try {
             certificate = fs.readFileSync(certificateFile).toString();
@@ -47,36 +44,16 @@ class Bind {
             return Promise.reject(new Error('Unable to read certificate file ' + certificateFile + '. ' + error.message));
         }
 
-        return (() => {
-            if (!argv.enrollSecret) {
-                return cmdUtil.prompt({
-                    name: 'enrollmentSecret',
-                    description: 'What is the enrollment secret of the user?',
-                    required: true,
-                    hidden: true,
-                    replace: '*'
-                })
-                .then((result) => {
-                    argv.enrollSecret = result.enrollmentSecret;
-                });
-            } else {
-                return Promise.resolve();
-            }
-        })()
-        .then(() => {
-            enrollId = argv.enrollId;
-            enrollSecret = argv.enrollSecret;
-            businessNetworkName = argv.businessNetworkName;
-            businessNetworkConnection = cmdUtil.createBusinessNetworkConnection();
-            return businessNetworkConnection.connectWithDetails(connectionProfileName, businessNetworkName, enrollId, enrollSecret);
-        })
-        .then(() => {
-            return businessNetworkConnection.bindIdentity(participantId, certificate);
-        })
-        .then((result) => {
-            console.log(`An identity was bound to the participant '${participantId}'`);
-            console.log('The participant can now connect to the business network using the identity');
-        });
+        cardName = argv.card;
+        businessNetworkConnection = cmdUtil.createBusinessNetworkConnection();
+        return businessNetworkConnection.connect(cardName)
+            .then(() => {
+                return businessNetworkConnection.bindIdentity(participantId, certificate);
+            })
+            .then((result) => {
+                console.log(`An identity was bound to the participant '${participantId}'`);
+                console.log('The participant can now connect to the business network using the identity');
+            });
     }
 
 }

--- a/packages/composer-cli/test/identity/bind.js
+++ b/packages/composer-cli/test/identity/bind.js
@@ -38,9 +38,11 @@ describe('composer identity bind CLI unit tests', () => {
     beforeEach(() => {
         sandbox = sinon.sandbox.create();
         mockBusinessNetworkConnection = sinon.createStubInstance(BusinessNetworkConnection);
-        mockBusinessNetworkConnection.connect.withArgs('cardName').resolves(
-            { userSecret: 'suchsecret'
-            });
+        mockBusinessNetworkConnection.connect.withArgs('cardName').resolves();
+        mockBusinessNetworkConnection.bindIdentity.withArgs('org.doge.Doge#DOGE_1', pem, sinon.match.object).resolves({
+            userID: 'dogeid1',
+            userSecret: 'suchsecret'
+        });
         sandbox.stub(fs, 'readFileSync').withArgs('admin.pem').returns(pem);
         sandbox.stub(CmdUtil, 'createBusinessNetworkConnection').returns(mockBusinessNetworkConnection);
         sandbox.stub(process, 'exit');
@@ -51,22 +53,6 @@ describe('composer identity bind CLI unit tests', () => {
     });
 
     it('should bind an existing identity using the specified profile', () => {
-        let argv = {
-            card:'cardName',
-            participantId: 'org.doge.Doge#DOGE_1',
-            certificateFile: 'admin.pem'
-        };
-        return Bind.handler(argv)
-            .then((res) => {
-                argv.thePromise.should.be.a('promise');
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'cardName');
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.bindIdentity);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.bindIdentity, 'org.doge.Doge#DOGE_1', pem);
-            });
-    });
-
-    it('should prompt for the enrollment secret if not specified', () => {
         let argv = {
             card:'cardName',
             participantId: 'org.doge.Doge#DOGE_1',

--- a/packages/composer-cli/test/identity/bind.js
+++ b/packages/composer-cli/test/identity/bind.js
@@ -27,10 +27,6 @@ chai.use(require('chai-as-promised'));
 
 const fs = require('fs');
 
-const BUSINESS_NETWORK_NAME = 'net.biz.TestNetwork-0.0.1';
-const ENROLL_ID = 'SuccessKid';
-const ENROLL_SECRET = 'SuccessKidWin';
-
 describe('composer identity bind CLI unit tests', () => {
 
     const pem = '-----BEGIN CERTIFICATE-----\nMIIB8TCCAZegAwIBAgIUKhzgF0nmP1Zl6uubdgq6wFohMC8wCgYIKoZIzj0EAwIw\nczELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDVNh\nbiBGcmFuY2lzY28xGTAXBgNVBAoTEG9yZzEuZXhhbXBsZS5jb20xHDAaBgNVBAMT\nE2NhLm9yZzEuZXhhbXBsZS5jb20wHhcNMTcwNzEyMjIzNzAwWhcNMTgwNzEyMjIz\nNzAwWjAQMQ4wDAYDVQQDEwVhZG1pbjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IA\nBPnG/X+v7R2ljdtRoreLnub9vlvU9BmF7LTuklTC0iHJr96ecQRkx6OCE8nDK09G\n5P6LvL95PUxlhDDdlStqASGjbDBqMA4GA1UdDwEB/wQEAwIHgDAMBgNVHRMBAf8E\nAjAAMB0GA1UdDgQWBBQl3QT+2qX5eTM2zaJ+MjU4vF+NQDArBgNVHSMEJDAigCAZ\nq2WruwSAfa0S5MCpqqZknnCGjjq9AhejItieR+GmrjAKBggqhkjOPQQDAgNIADBF\nAiEAok4RzwsOX7lSkUmGK+yfr9reJxvtyCHxQ68YC7blAQECIB3T3H0iwX+2MZaX\nmJucq33qkeHpFiq1focn3o6WAx/x\n-----END CERTIFICATE-----\n';
@@ -38,14 +34,13 @@ describe('composer identity bind CLI unit tests', () => {
     let sandbox;
     let mockBusinessNetworkConnection;
 
+
     beforeEach(() => {
         sandbox = sinon.sandbox.create();
         mockBusinessNetworkConnection = sinon.createStubInstance(BusinessNetworkConnection);
-        mockBusinessNetworkConnection.connect.resolves();
-        mockBusinessNetworkConnection.bindIdentity.withArgs('org.doge.Doge#DOGE_1', pem, sinon.match.object).resolves({
-            userID: 'dogeid1',
-            userSecret: 'suchsecret'
-        });
+        mockBusinessNetworkConnection.connect.withArgs('cardName').resolves(
+            { userSecret: 'suchsecret'
+            });
         sandbox.stub(fs, 'readFileSync').withArgs('admin.pem').returns(pem);
         sandbox.stub(CmdUtil, 'createBusinessNetworkConnection').returns(mockBusinessNetworkConnection);
         sandbox.stub(process, 'exit');
@@ -57,37 +52,31 @@ describe('composer identity bind CLI unit tests', () => {
 
     it('should bind an existing identity using the specified profile', () => {
         let argv = {
-            connectionProfileName: 'someOtherProfile',
-            businessNetworkName: BUSINESS_NETWORK_NAME,
-            enrollId: ENROLL_ID,
-            enrollSecret: ENROLL_SECRET,
+            card:'cardName',
             participantId: 'org.doge.Doge#DOGE_1',
             certificateFile: 'admin.pem'
         };
         return Bind.handler(argv)
             .then((res) => {
                 argv.thePromise.should.be.a('promise');
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.connectWithDetails);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connectWithDetails, 'someOtherProfile', argv.businessNetworkName, argv.enrollId, argv.enrollSecret);
+                sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
+                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'cardName');
                 sinon.assert.calledOnce(mockBusinessNetworkConnection.bindIdentity);
                 sinon.assert.calledWith(mockBusinessNetworkConnection.bindIdentity, 'org.doge.Doge#DOGE_1', pem);
             });
     });
 
     it('should prompt for the enrollment secret if not specified', () => {
-        sandbox.stub(CmdUtil, 'prompt').resolves(ENROLL_SECRET);
         let argv = {
-            connectionProfileName: 'someOtherProfile',
-            businessNetworkName: BUSINESS_NETWORK_NAME,
-            enrollId: ENROLL_ID,
+            card:'cardName',
             participantId: 'org.doge.Doge#DOGE_1',
             certificateFile: 'admin.pem'
         };
         return Bind.handler(argv)
             .then((res) => {
                 argv.thePromise.should.be.a('promise');
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.connectWithDetails);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connectWithDetails, 'someOtherProfile', argv.businessNetworkName, argv.enrollId, argv.enrollSecret);
+                sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
+                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'cardName');
                 sinon.assert.calledOnce(mockBusinessNetworkConnection.bindIdentity);
                 sinon.assert.calledWith(mockBusinessNetworkConnection.bindIdentity, 'org.doge.Doge#DOGE_1', pem);
             });
@@ -96,10 +85,7 @@ describe('composer identity bind CLI unit tests', () => {
     it('should error when the certificate file cannot be read', () => {
         fs.readFileSync.withArgs('admin.pem').throws(new Error('such error'));
         let argv = {
-            connectionProfileName: 'someOtherProfile',
-            businessNetworkName: BUSINESS_NETWORK_NAME,
-            enrollId: ENROLL_ID,
-            enrollSecret: ENROLL_SECRET,
+            card:'cardName',
             participantId: 'org.doge.Doge#DOGE_1',
             certificateFile: 'admin.pem'
         };
@@ -110,10 +96,7 @@ describe('composer identity bind CLI unit tests', () => {
     it('should error when the existing identity cannot be bound', () => {
         mockBusinessNetworkConnection.bindIdentity.withArgs('org.doge.Doge#DOGE_1', pem).rejects(new Error('such error'));
         let argv = {
-            connectionProfileName: 'someOtherProfile',
-            businessNetworkName: BUSINESS_NETWORK_NAME,
-            enrollId: ENROLL_ID,
-            enrollSecret: ENROLL_SECRET,
+            card:'cardName',
             participantId: 'org.doge.Doge#DOGE_1',
             certificateFile: 'admin.pem'
         };


### PR DESCRIPTION
Add in a --card option to replace the collection of the connection profile, enroll secret, ,enroll id.

left the code structure as is, but removed the enroll secret etc specific parts. 