### PR TITLE
Add BusinessNetworkCardStore.getDefaultCardName static function

### DIFF
--- a/packages/composer-cli/lib/cmds/utils/cmdutils.js
+++ b/packages/composer-cli/lib/cmds/utils/cmdutils.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const AdminConnection = require('composer-admin').AdminConnection;
+const BusinessNetworkCardStore = require('composer-common').BusinessNetworkCardStore;
 const BusinessNetworkConnection = require('composer-client').BusinessNetworkConnection;
 const fs = require('fs');
 const Logger = require('composer-common').Logger;
@@ -277,8 +278,7 @@ class CmdUtil {
      * @returns {String} A card name
      */
     static getDefaultCardName(card) {
-        const locationName = card.getBusinessNetworkName() || card.getConnectionProfile().name;
-        return card.getUserName() + '@' + locationName;
+        return BusinessNetworkCardStore.getDefaultCardName(card);
     }
 }
 

--- a/packages/composer-cli/test/utils/cmdutils.js
+++ b/packages/composer-cli/test/utils/cmdutils.js
@@ -489,20 +489,20 @@ describe('composer transaction cmdutils unit tests', () => {
     });
 
     describe('#getDefaultCardName', () => {
-        it('should return name based on card name and business network name for user card', () => {
+        it('should return name for user card', () => {
             const metadata = { userName: 'conga', businessNetwork: 'penguin-network' };
             const connectionProfile = { name: 'profile-name' };
             const card = new IdCard(metadata, connectionProfile);
             const result = CmdUtil.getDefaultCardName(card);
-            result.should.include(metadata.userName).and.include(metadata.businessNetwork);
+            result.should.be.a('String').that.is.not.empty;
         });
 
-        it('should return name based on card name and connection profile name for PeerAdmin card', () => {
+        it('should return name for PeerAdmin card', () => {
             const metadata = { userName: 'PeerAdmin', roles: [ 'PeerAdmin', 'ChannelAdmin' ] };
             const connectionProfile = { name: 'profile-name' };
             const card = new IdCard(metadata, connectionProfile);
             const result = CmdUtil.getDefaultCardName(card);
-            result.should.include(metadata.userName).and.include(connectionProfile.name);
+            result.should.be.a('String').that.is.not.empty;
         });
     });
 

--- a/packages/composer-common/api.txt
+++ b/packages/composer-common/api.txt
@@ -29,6 +29,13 @@ class BusinessNetworkMetadata {
    + string getVersion() 
    + string getIdentifier() 
 }
+class BusinessNetworkCardStore {
+   + String getDefaultCardName(IdCard) 
+   + Promise get(String) 
+   + Promise put(String,IdCard) 
+   + Promise getAll() 
+   + Promise delete(String) 
+}
 class Factory {
    + void constructor(ModelManager) 
    + Resource newResource(string,string,string,Object,boolean,string,boolean,boolean) throws TypeNotFoundException
@@ -46,6 +53,20 @@ class FileWallet extends Wallet {
    + Promise add(string,string) 
    + Promise update(string,string) 
    + Promise remove(string) 
+}
+class IdCard {
+   + String getUserName() 
+   + String getDescription() 
+   + String getBusinessNetworkName() 
+   + Object getConnectionProfile() 
+   + Object getCredentials() 
+   + void setCredentials(Object) 
+   + Object getEnrollmentCredentials() 
+   + String[] getRoles() 
+   + Promise fromArchive() 
+   + Promise toArchive(Object,String) 
+   + Promise fromDirectory(String,undefined) 
+   + Promise toDirectory(String,undefined) 
 }
 class IllegalModelException extends BaseFileException {
    + void constructor(String,ModelFile,Object,String,String,String,String) 

--- a/packages/composer-common/changelog.txt
+++ b/packages/composer-common/changelog.txt
@@ -11,6 +11,9 @@
 #
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
+Version 0.15.0 {bc4416a38d5d8d9d53dd4f5cbe3992aa} 2017-11-08
+- Add IdCard and BusinessNetworkCardStore to public API
+
 Version 0.14.0  {06b9fe19f8d0de36b494e9a3d3e0776f} 2017-10-16
 - Added allowEmptyId option to Factory.newResource Factory.newEvent and Factory.newTransaction
 

--- a/packages/composer-common/lib/cardstore/businessnetworkcardstore.js
+++ b/packages/composer-common/lib/cardstore/businessnetworkcardstore.js
@@ -17,17 +17,26 @@
 /**
  * Manages persistence of business network cards.
  *
- * @private
  * @abstract
  * @class
  * @memberof module:composer-common
  */
 class BusinessNetworkCardStore {
     /**
+     * Get a default name for a given business network card.
+     * @param {IdCard} card A business network card
+     * @returns {String} A card name
+     */
+    static getDefaultCardName(card) {
+        const locationName = card.getBusinessNetworkName() || card.getConnectionProfile().name;
+        return card.getUserName() + '@' + locationName;
+    }
+
+    /**
      * Gets a card from the store.
      * @abstract
      * @param {String} cardName The name of the card to get
-     * @return {Promise} A promise that is resolved with a {@link IdCard}.
+     * @return {Promise} A promise that is resolved with an IdCard.
      */
     get(cardName) {
         return Promise.reject(new Error('Abstract function called'));
@@ -48,8 +57,8 @@ class BusinessNetworkCardStore {
     /**
      * Gets all cards from the store.
      * @abstract
-     * @return {Promise} A promise that is resolved with a {@link Map} where
-     * the keys are identity card names and the values are {@link IdCard} objects.
+     * @return {Promise} A promise that is resolved with a Map where
+     * the keys are identity card names and the values are IdCard objects.
      */
     getAll() {
         return Promise.reject(new Error('Abstract function called'));

--- a/packages/composer-common/lib/idcard.js
+++ b/packages/composer-common/lib/idcard.js
@@ -42,8 +42,7 @@ const newErrorWithCause = (message, cause) => {
  * An ID card. Encapsulates credentials and other information required to connect to a specific business network
  * as a specific user.
  * <p>
- * Instances of this class should be created using {@link IdCard#fromArchive}.
- * @private
+ * Instances of this class should be created using IdCard.fromArchive or IdCard.fromDirectory.
  * @class
  * @memberof module:composer-common
  */
@@ -53,7 +52,7 @@ class IdCard {
      * Create the IdCard.
      * <p>
      * <strong>Note: Only to be called by framework code. Applications should
-     * retrieve instances from {@link IdCard#fromArchive}</strong>
+     * retrieve instances from IdCard.fromArchive or IdCard.fromDirectory</strong>
      * @private
      * @param {Object} metadata - metadata associated with the card.
      * @param {Object} connectionProfile - connection profile associated with the card.
@@ -298,7 +297,7 @@ class IdCard {
      * @param {String} cardDirectory directory containing card data.
      * @param {*} [fs] Node file system API implementation to use for reading card data.
      * Defaults to the Node implementation.
-     * @return {Promise} Promise that resolves to an {@link IdCard}.
+     * @return {Promise} Promise that resolves to an IdCard.
      */
     static fromDirectory(cardDirectory, fs) {
         const method = 'fromDirectory';

--- a/packages/composer-common/test/cardstore/businessnetworkcardstore.js
+++ b/packages/composer-common/test/cardstore/businessnetworkcardstore.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const BusinessNetworkCardStore = require('../../lib/cardstore/businessnetworkcardstore');
+const IdCard = require('../../lib/idcard');
 
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
@@ -22,6 +23,24 @@ chai.use(chaiAsPromised);
 chai.should();
 
 describe('BusinessNetworkCardStore', function() {
+    describe('#getDefaultCardName', function() {
+        it('should return name based on card name and business network name for user card', () => {
+            const metadata = { userName: 'conga', businessNetwork: 'penguin-network' };
+            const connectionProfile = { name: 'profile-name' };
+            const card = new IdCard(metadata, connectionProfile);
+            const result = BusinessNetworkCardStore.getDefaultCardName(card);
+            result.should.include(metadata.userName).and.include(metadata.businessNetwork);
+        });
+
+        it('should return name based on card name and connection profile name for PeerAdmin card', () => {
+            const metadata = { userName: 'PeerAdmin', roles: [ 'PeerAdmin', 'ChannelAdmin' ] };
+            const connectionProfile = { name: 'profile-name' };
+            const card = new IdCard(metadata, connectionProfile);
+            const result = BusinessNetworkCardStore.getDefaultCardName(card);
+            result.should.include(metadata.userName).and.include(connectionProfile.name);
+        });
+    });
+
     describe('#get', function() {
         it('should throw as abstract method', function() {
             const store = new BusinessNetworkCardStore();


### PR DESCRIPTION
Resolves #2621 

Common code for default naming of cards in a card store, for use by both the CLI
and Playground to ensure consistent default naming behaviour.