### PR TITLE
Correctly create card with no credentials in 'composer card create'

### DIFF
--- a/packages/composer-admin/lib/adminconnection.js
+++ b/packages/composer-admin/lib/adminconnection.js
@@ -163,7 +163,7 @@ class AdminConnection {
                 card=result;
                 let credentials = card.getCredentials();
                 //anything set? if so don't go and get the credentials again
-                if (Object.keys(credentials).length!==0){
+                if (credentials.certificate || credentials.privateKey) {
                     return card;
                 } else {
                     // check to make sure the credentials are present and if not then extract them.
@@ -179,11 +179,6 @@ class AdminConnection {
                                 card.setCredentials(result);
                                 // put back the card, so that it has the ceritificates sotre
                                 return this.cardStore.put(cardName,card);
-                            } else {
-                                if(!card.getEnrollmentCredentials()){
-                                    // no secret either!
-                                    throw new Error(`Card ${cardName} has no credentials or secret so is invalid`);
-                                }
                             }
                         }).then(()=>{
                             return card;

--- a/packages/composer-admin/test/adminconnection.js
+++ b/packages/composer-admin/test/adminconnection.js
@@ -1088,7 +1088,7 @@ describe('AdminConnection', () => {
 
             });
 
-            it('Card exists, but with no credentials or secret',()=>{
+            it('should still export a card with no secret or credentials',()=>{
                 mockConnectionManager.exportIdentity = sinon.stub();
                 adminConnection.connection = mockConnection;
                 adminConnection.securityContext = mockSecurityContext;
@@ -1096,7 +1096,10 @@ describe('AdminConnection', () => {
 
                 return cardStore.put(cardName, userCard).then(() => {
                     return adminConnection.exportCard(cardName);
-                }).should.eventually.be.rejectedWith(/no credentials or secret so is invalid/);
+                }).then((result) => {
+                    result.should.be.instanceOf(IdCard);
+                    result.getUserName().should.equal('user');
+                });
 
             });
 

--- a/packages/composer-cli/lib/cmds/card/lib/create.js
+++ b/packages/composer-cli/lib/cmds/card/lib/create.js
@@ -76,14 +76,16 @@ class Create {
 
         // certificates & privateKey
         // YARGS command spec logic will have enforced the correct set of options
-        let newCredentials = {certificate: '', privateKey: ''};
-        if (argv.certificate){
-            newCredentials.certificate = this.readFile(path.resolve(argv.certificate));
+        if (argv.certificate || argv.privateKey) {
+            const newCredentials = { };
+            if (argv.certificate){
+                newCredentials.certificate = this.readFile(path.resolve(argv.certificate));
+            }
+            if (argv.privateKey){
+                newCredentials.privateKey =  this.readFile(path.resolve(argv.privateKey));
+            }
+            idCard.setCredentials(newCredentials);
         }
-        if (argv.privateKey){
-            newCredentials.privateKey =  this.readFile(path.resolve(argv.privateKey));
-        }
-        idCard.setCredentials(newCredentials);
 
         // handle the filename
         // Default is userName@businessNetworkName.card if the card includes a business network name;


### PR DESCRIPTION
Resolves #2630 

Also don't fail export if a card that exists in the system doesn't look valid. It's
already in the system. It's too late to complain now.