### PR TITLE
Do not write updated card to card store on export

### DIFF
--- a/packages/composer-admin/lib/adminconnection.js
+++ b/packages/composer-admin/lib/adminconnection.js
@@ -177,10 +177,7 @@ class AdminConnection {
                             if (result){
                                 //{ certificate: String, privateKey: String }
                                 card.setCredentials(result);
-                                // put back the card, so that it has the ceritificates sotre
-                                return this.cardStore.put(cardName,card);
                             }
-                        }).then(()=>{
                             return card;
                         });
                 }

--- a/packages/composer-admin/test/adminconnection.js
+++ b/packages/composer-admin/test/adminconnection.js
@@ -64,6 +64,9 @@ class StubCardStore extends BusinessNetworkCardStore {
      */
     put(cardName, card) {
         return Promise.resolve().then(() => {
+            if (this.cards.has(cardName)) {
+                throw new Error('Card already exists: ' + cardName);
+            }
             this.cards.set(cardName, card);
         });
     }
@@ -1053,8 +1056,9 @@ describe('AdminConnection', () => {
         describe('#exportCard', ()=> {
 
             it('Card exists, but no credentials, call to export identity is correct executed',()=>{
+                const credentials = { certificate: 'String', privateKey: 'String' };
                 mockConnectionManager.exportIdentity = sinon.stub();
-                mockConnectionManager.exportIdentity.resolves({ certificate: 'String', privateKey: 'String' });
+                mockConnectionManager.exportIdentity.resolves(credentials);
                 adminConnection.connection = mockConnection;
                 adminConnection.securityContext = mockSecurityContext;
 
@@ -1066,8 +1070,7 @@ describe('AdminConnection', () => {
                 }).then((result) => {
                     result.should.be.instanceOf(IdCard);
                     result.getUserName().should.equal('user');
-                    sinon.assert.calledOnce(mockConnectionManager.exportIdentity);
-                    sinon.assert.calledWith(userCard.setCredentials,{ certificate: 'String', privateKey: 'String' });
+                    result.getCredentials().should.equal(credentials);
                 });
 
             });


### PR DESCRIPTION
Resolves #2645 

The certificates still need to be added to the exported card but don't
need to be included in the card store copy as they still live in the
client store.