### PR TITLE
remove restriction for grpc version

### DIFF
--- a/packages/composer-connector-hlfv1/package.json
+++ b/packages/composer-connector-hlfv1/package.json
@@ -45,7 +45,7 @@
     "fabric-ca-client": "1.0.2",
     "fabric-client": "1.0.2",
     "fs-extra": "1.0.0",
-    "grpc": ">=1.3.5 <1.7.0",
+    "grpc": ">=1.3.5 <2.0.0",
     "semver": "5.3.0",
     "temp": "0.8.3",
     "thenify-all": "1.6.0",


### PR DESCRIPTION
we pinned to grpc 1.6.6 because 1.7.0 release was broken for our docker images.
They have fixed this in 1.7.1 so we should revert back as there could be a fix to the
TLS problem we currently have
closes #2572

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
