### PR TITLE
Fix for cancelling a remove when revoking an identity (Issue #2417)

### DIFF
--- a/packages/composer-playground/src/app/identity/identity.component.html
+++ b/packages/composer-playground/src/app/identity/identity.component.html
@@ -27,7 +27,7 @@
                 </div>
                 <div class="actions" *ngIf="cardRef!==currentIdentity">
                     <button class="clear" (click)="setCurrentIdentity(cardRef)">Use now</button>
-                    <button class="clear" (click)="removeIdentity(cardRef); $event.stopPropagation()">Remove</button>
+                    <button class="clear" (click)="openRemoveModal(cardRef); $event.stopPropagation()">Remove</button>
                 </div>
             </div>
         </div>

--- a/packages/composer-playground/src/app/identity/identity.component.spec.ts
+++ b/packages/composer-playground/src/app/identity/identity.component.spec.ts
@@ -538,7 +538,7 @@ describe(`IdentityComponent`, () => {
         }));
     });
 
-    describe('removeIdentity', () => {
+    describe('openRemoveModal', () => {
         it('should open the delete-confirm modal', fakeAsync(() => {
             component['identityCards'] = mockIDCards;
             let loadMock = sinon.stub(component, 'loadAllIdentities');
@@ -548,7 +548,7 @@ describe(`IdentityComponent`, () => {
                 result: Promise.resolve()
             });
 
-            component.removeIdentity('1234');
+            component.openRemoveModal('1234');
             tick();
 
             mockModal.open.should.have.been.called;
@@ -561,7 +561,7 @@ describe(`IdentityComponent`, () => {
                 result: Promise.reject('some error')
             });
 
-            component.removeIdentity('1234');
+            component.openRemoveModal('1234');
             tick();
 
             mockAlertService.busyStatus$.next.should.have.been.called;
@@ -575,38 +575,55 @@ describe(`IdentityComponent`, () => {
                 result: Promise.reject(null)
             });
 
-            component.removeIdentity('1234');
+            component.openRemoveModal('1234');
             tick();
 
             mockAlertService.busyStatus$.next.should.not.have.been.called;
             mockAlertService.errorStatus$.next.should.not.have.been.called;
         }));
 
-        it('should remove the identity from the wallet', fakeAsync(() => {
+        it('should open the delete-confirm modal and handle remove press', fakeAsync(() => {
             component['identityCards'] = mockIDCards;
-            mockIdentityCardService.deleteIdentityCard.returns(Promise.resolve());
+            let mockRemoveIdentity = sinon.stub(component, 'removeIdentity').returns(Promise.resolve());
 
             mockModal.open = sinon.stub().returns({
                 componentInstance: {},
                 result: Promise.resolve(true)
             });
 
-            let mockLoadAllIdentities = sinon.stub(component, 'loadAllIdentities');
-
-            component.removeIdentity('1234');
+            component.openRemoveModal('1234');
 
             tick();
 
             mockAlertService.busyStatus$.next.should.have.been.called;
-            mockIdentityCardService.deleteIdentityCard.should.have.been.calledWith('1234');
-            mockLoadAllIdentities.should.have.been.called;
-
-            mockAlertService.busyStatus$.next.should.have.been.called;
-            mockAlertService.successStatus$.next.should.have.been.called;
-            mockAlertService.errorStatus$.next.should.not.have.been.called;
+            mockRemoveIdentity.should.have.been.calledWith('1234');
         }));
+    });
+    describe('removeIdentity', () => {
+      it('should remove the identity from the wallet', fakeAsync(() => {
+          component['identityCards'] = mockIDCards;
+          mockIdentityCardService.deleteIdentityCard.returns(Promise.resolve());
 
-        it('should handle error when removing from wallet', fakeAsync(() => {
+          mockModal.open = sinon.stub().returns({
+              componentInstance: {},
+              result: Promise.resolve(true)
+          });
+
+          let mockLoadAllIdentities = sinon.stub(component, 'loadAllIdentities');
+
+          component.removeIdentity('1234');
+
+          tick();
+
+          mockAlertService.busyStatus$.next.should.have.been.called;
+          mockIdentityCardService.deleteIdentityCard.should.have.been.calledWith('1234');
+          mockLoadAllIdentities.should.have.been.called;
+
+          mockAlertService.busyStatus$.next.should.have.been.called;
+          mockAlertService.successStatus$.next.should.have.been.called;
+          mockAlertService.errorStatus$.next.should.not.have.been.called;
+      }));
+      it('should handle error when removing from wallet', fakeAsync(() => {
             component['identityCards'] = mockIDCards;
             mockIdentityCardService.deleteIdentityCard.returns(Promise.reject('some error'));
 
@@ -691,31 +708,6 @@ describe(`IdentityComponent`, () => {
 
             mockClientService.revokeIdentity.should.have.been.called;
             mockRemoveIdentity.should.have.been.calledWith('1234');
-            mockLoadAllIdentities.should.have.been.called;
-
-            mockAlertService.busyStatus$.next.should.have.been.called;
-            mockAlertService.successStatus$.next.should.have.been.called;
-        }));
-
-        it('should revoke the identity from the client service not remove from wallet', fakeAsync(() => {
-            component['cardRefs'] = [];
-            component['businessNetworkName'] = 'myNetwork';
-            component['myIdentities'] = ['bob'];
-            mockModal.open = sinon.stub().returns({
-                componentInstance: {},
-                result: Promise.resolve(true)
-            });
-
-            let mockRemoveIdentity = sinon.stub(component, 'removeIdentity').returns(Promise.resolve());
-            let mockLoadAllIdentities = sinon.stub(component, 'loadAllIdentities').returns(Promise.resolve());
-            mockClientService.revokeIdentity.returns(Promise.resolve());
-
-            component.revokeIdentity({name: 'fred', ref: '1234'});
-
-            tick();
-
-            mockClientService.revokeIdentity.should.have.been.called;
-            mockRemoveIdentity.should.not.have.been.called;
             mockLoadAllIdentities.should.have.been.called;
 
             mockAlertService.busyStatus$.next.should.have.been.called;

--- a/packages/composer-playground/src/app/identity/identity.component.ts
+++ b/packages/composer-playground/src/app/identity/identity.component.ts
@@ -182,6 +182,27 @@ export class IdentityComponent implements OnInit {
     }
 
     removeIdentity(cardRef: string): Promise<void> {
+      let userID = this.identityCards.get(cardRef).getUserName();
+      return this.identityCardService.deleteIdentityCard(cardRef)
+          .then(() => {
+              return this.loadAllIdentities();
+          })
+          .then(() => {
+              // Send alert
+              this.alertService.busyStatus$.next(null);
+              this.alertService.successStatus$.next({
+                  title: 'Removal Successful',
+                  text: userID + ' was successfully removed.',
+                  icon: '#icon-bin_icon'
+              });
+          })
+          .catch((error) => {
+              this.alertService.busyStatus$.next(null);
+              this.alertService.errorStatus$.next(error);
+          });
+    }
+
+    openRemoveModal(cardRef: string): Promise<void> {
 
         let userID = this.identityCards.get(cardRef).getUserName();
 
@@ -201,23 +222,7 @@ export class IdentityComponent implements OnInit {
                         title: 'Removing ID',
                         text: 'Removing identity ' + userID + ' from your wallet'
                     });
-
-                    return this.identityCardService.deleteIdentityCard(cardRef)
-                        .then(() => {
-                            return this.loadAllIdentities();
-                        })
-                        .then(() => {
-                            // Send alert
-                            this.alertService.busyStatus$.next(null);
-                            this.alertService.successStatus$.next({
-                                title: 'Removal Successful',
-                                text: userID + ' was successfully removed.',
-                                icon: '#icon-bin_icon'
-                            });
-                        })
-                        .catch((error) => {
-                            this.alertService.errorStatus$.next(error);
-                        });
+                    return this.removeIdentity(cardRef);
                 }
             }, (reason) => {
                 // runs this when user presses 'cancel' button on the modal


### PR DESCRIPTION
#2417 

Fix follows solution outlined in the issue and prevents user cancelling the remove process when revoking by not showing the modal.

### Changes made
- Split remove function from its modal so that button press opens modal which then calls the remove whilst revoking just calls the remove once revoke is performed. 
- Updated tests to test modal and remove separately.