### PR TITLE
Make IdCard.constructor public

### DIFF
--- a/packages/composer-common/api.txt
+++ b/packages/composer-common/api.txt
@@ -56,6 +56,7 @@ class FileWallet extends Wallet {
    + Promise remove(string) 
 }
 class IdCard {
+   + void constructor(Object,Object) 
    + String getUserName() 
    + String getDescription() 
    + String getBusinessNetworkName() 

--- a/packages/composer-common/changelog.txt
+++ b/packages/composer-common/changelog.txt
@@ -11,8 +11,9 @@
 #
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
-Version 0.15.1 {6a730f0048593bd942b567da27ebadfc} 2017-11-14
+Version 0.15.1 {015d225161956eb66be1636cef324c8a} 2017-11-14
 - Add in has to the Card Store
+- Make IdCard constructor public
 
 Version 0.15.0 {bc4416a38d5d8d9d53dd4f5cbe3992aa} 2017-11-08
 - Add IdCard and BusinessNetworkCardStore to public API

--- a/packages/composer-common/lib/idcard.js
+++ b/packages/composer-common/lib/idcard.js
@@ -42,7 +42,7 @@ const newErrorWithCause = (message, cause) => {
  * An ID card. Encapsulates credentials and other information required to connect to a specific business network
  * as a specific user.
  * <p>
- * Instances of this class should be created using IdCard.fromArchive or IdCard.fromDirectory.
+ * Instances of this class can be created using IdCard.fromArchive or IdCard.fromDirectory.
  * @class
  * @memberof module:composer-common
  */
@@ -50,10 +50,6 @@ class IdCard {
 
     /**
      * Create the IdCard.
-     * <p>
-     * <strong>Note: Only to be called by framework code. Applications should
-     * retrieve instances from IdCard.fromArchive or IdCard.fromDirectory</strong>
-     * @private
      * @param {Object} metadata - metadata associated with the card.
      * @param {Object} connectionProfile - connection profile associated with the card.
      */


### PR DESCRIPTION
Contributes to #2523 

Required so it can be used by end-user tests of their business networks.