### PR TITLE
change query analyser to return array of parameters for CONTAINS

### DIFF
--- a/packages/composer-common/lib/query/queryanalyzer.js
+++ b/packages/composer-common/lib/query/queryanalyzer.js
@@ -328,7 +328,27 @@ class QueryAnalyzer {
         // Pop the scope name off again.
         parameters.scopes.pop();
 
-        const result = [left, right];
+        // if the left is a string, it is the name of a property
+        // and we infer the type of the right from the model
+        // if the right is a parameter
+        let result = [];
+        if (typeof left === 'string' && (right instanceof Array && right.length > 0)) {
+            if(right[0].type === null) {
+                right[0].type = this.getParameterType(left, parameters);
+            }
+            result = result.concat(right);
+        }
+
+        // if the right is a string, it is the name of a property
+        // and we infer the type of the left from the model
+        // if the left is a parameter
+        if (typeof right === 'string' && (left instanceof Array && left.length > 0)) {
+            if(left[0].type === null) {
+                left[0].type = this.getParameterType(right, parameters);
+            }
+            result = result.concat(left);
+        }
+
         LOG.exit(method, result);
         return result;
     }
@@ -442,6 +462,8 @@ class QueryAnalyzer {
         LOG.entry(method, ast, parameters);
         const result = ast.elements.map((element) => {
             return this.visit(element, parameters);
+        }).filter((element) => {
+            return !(Array.isArray(element) && element.length === 0);
         });
         LOG.exit(method, result);
         return result;

--- a/packages/composer-common/test/query/queryanalyzer.js
+++ b/packages/composer-common/test/query/queryanalyzer.js
@@ -305,7 +305,7 @@ describe('QueryAnalyzer', () => {
             queryAnalyzer = new QueryAnalyzer( mockQuery );
             const result = queryAnalyzer.visit(mockQuery, {});
             result.should.not.be.null;
-            result.length.should.equal(2);
+            result.length.should.equal(0);
         });
 
         it('should process select with a contains and an array value', () => {
@@ -315,7 +315,7 @@ describe('QueryAnalyzer', () => {
             queryAnalyzer = new QueryAnalyzer( mockQuery );
             const result = queryAnalyzer.visit(mockQuery, {});
             result.should.not.be.null;
-            result.length.should.equal(2);
+            result.length.should.equal(0);
         });
 
         it('should process select with a contains and a parameter value', () => {
@@ -325,7 +325,17 @@ describe('QueryAnalyzer', () => {
             queryAnalyzer = new QueryAnalyzer( mockQuery );
             const result = queryAnalyzer.visit(mockQuery, {});
             result.should.not.be.null;
-            result.length.should.equal(2);
+            result.length.should.equal(1);
+        });
+
+        it('should process select with a contains and a reversed parameter value', () => {
+            const ast = parser.parse('SELECT org.acme.TestAsset WHERE (_$inputStringValue CONTAINS stringValues)', { startRule: 'SelectStatement' });
+            const select = new Select(mockQuery, ast);
+            mockQuery.getSelect.returns(select);
+            queryAnalyzer = new QueryAnalyzer( mockQuery );
+            const result = queryAnalyzer.visit(mockQuery, {});
+            result.should.not.be.null;
+            result.length.should.equal(1);
         });
 
         it('should process select with a contains and a nested expression', () => {
@@ -335,7 +345,7 @@ describe('QueryAnalyzer', () => {
             queryAnalyzer = new QueryAnalyzer( mockQuery );
             const result = queryAnalyzer.visit(mockQuery, {});
             result.should.not.be.null;
-            result.length.should.equal(2);
+            result.length.should.equal(0);
         });
 
         it('should process select with a contains and a nested expression with a parameter value', () => {
@@ -345,7 +355,7 @@ describe('QueryAnalyzer', () => {
             queryAnalyzer = new QueryAnalyzer( mockQuery );
             const result = queryAnalyzer.visit(mockQuery, {});
             result.should.not.be.null;
-            result.length.should.equal(2);
+            result.length.should.equal(1);
         });
 
         it('should process select with a contains and a nested expression with a reversed parameter value', () => {
@@ -355,7 +365,7 @@ describe('QueryAnalyzer', () => {
             queryAnalyzer = new QueryAnalyzer( mockQuery );
             const result = queryAnalyzer.visit(mockQuery, {});
             result.should.not.be.null;
-            result.length.should.equal(2);
+            result.length.should.equal(1);
         });
 
         it('should throw for a select with a contains without a property name', () => {


### PR DESCRIPTION
Fix the query analyser to return the correct structure for the CONTAINS operator.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
