### PR TITLE
update fv-test package name to prevent publishing

### DIFF
--- a/packages/composer-tests-functional/package.json
+++ b/packages/composer-tests-functional/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "composer-systests",
+  "name": "composer-tests-functional",
   "version": "0.15.2",
   "private": true,
-  "description": "System tests and automation for Hyperledger Composer",
+  "description": "Functional verification tests for Hyperledger Composer",
   "engines": {
     "node": ">=8",
     "npm": ">=5"


### PR DESCRIPTION
closes #2756 

Update of package information name within composer-tests-functional, so that it is correctly skipped in the travis deploy.sh (line 91 in that file)

Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>
