### PR TITLE
Do not collect JavaScript tokens in HLFv1 runtime

### DIFF
--- a/packages/composer-common/lib/codegen/javascriptparser.js
+++ b/packages/composer-common/lib/codegen/javascriptparser.js
@@ -41,13 +41,18 @@ class JavaScriptParser {
         let comments = [];
         this.tokens = [];
 
+        // If the magic flag is set, don't collect tokens. They eat up a lot of
+        // memory and this is problematic for the HLFv1 runtime (the only place
+        // that this flag is set).
+        let noTokens = !!global.composerJavaScriptParserNoTokens;
+
         let options =  {
             // collect ranges for each node
             ranges: true,
             // collect comments in Esprima's format
             onComment: comments,
             // collect token ranges
-            onToken: this.tokens,
+            onToken: noTokens ? null : this.tokens,
             // collect token locations
             locations: true,
             // locations: true,

--- a/packages/composer-common/test/codegen/javascriptparser.js
+++ b/packages/composer-common/test/codegen/javascriptparser.js
@@ -263,12 +263,24 @@ describe('JavascriptParser', () => {
     });
 
     describe('#getTokens', () => {
+        afterEach(() => {
+            delete global.composerJavaScriptParserNoTokens;
+        });
+
         it('should return all of the tokens', () => {
             const contents = 'eval(true)';
             const parser = new JavascriptParser(contents);
             const tokens = parser.getTokens();
             tokens.should.have.lengthOf(5);
             tokens.should.all.have.property('loc');
+        });
+
+        it('should return no tokens if token collection is disabled', () => {
+            global.composerJavaScriptParserNoTokens = true;
+            const contents = 'eval(true)';
+            const parser = new JavascriptParser(contents);
+            const tokens = parser.getTokens();
+            tokens.should.have.lengthOf(0);
         });
     });
 

--- a/packages/composer-runtime-hlfv1/composer.go
+++ b/packages/composer-runtime-hlfv1/composer.go
@@ -117,6 +117,10 @@ func (composer *Composer) createJavaScript() {
 		panic(err)
 	}
 
+	// Set the magic flag which stops us holding onto many tokens.
+	vm.PushBoolean(true)
+	vm.PutGlobalString("composerJavaScriptParserNoTokens")
+
 }
 
 // Init is called by the Hyperledger Fabric when the chaincode is deployed.


### PR DESCRIPTION
High memory usage and leak from Composer runtime #2758

Stop collecting and storing tokens for any JavaScript files that are loaded as part of a business network definition in the HLFv1 runtime. This saves a significant amount of memory for a BNA that contains a lot of JavaScript code.