### PR TITLE
Use fixed version of go-duktape

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "packages/composer-runtime-hlfv1/vendor/gopkg.in/olebedev/go-duktape.v3"]
 	path = packages/composer-runtime-hlfv1/vendor/gopkg.in/olebedev/go-duktape.v3
-	url = https://gopkg.in/olebedev/go-duktape.v3.git
+	url = https://gopkg.in/sstone1/go-duktape.v3.git
+	branch = v3

--- a/.travis/before-install.sh
+++ b/.travis/before-install.sh
@@ -4,6 +4,17 @@
 set -ev
 set -o pipefail
 
+# Grab the parent (root) directory.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+# Ensure we're using the correct fork of go-duktape.
+pushd "${DIR}/packages/composer-runtime-hlfv1/vendor/gopkg.in/olebedev/go-duktape.v3"
+if ! git remote -v | grep sstone1 > /dev/null; then
+    echo Using the wrong version of go-duktape: refusing to run the build
+    exit 1
+fi
+popd
+
 # Remove the MongoDB repo as their GPG key has expired.
 sudo rm /etc/apt/sources.list.d/mongodb-3.2.list
 # Remove Riak https://github.com/travis-ci/travis-ci/issues/8607
@@ -14,9 +25,6 @@ sudo rm -vf /etc/apt/sources.list.d/*riak*
 
 pip install --user linkchecker requests==2.9.2
 linkchecker --version
-
-# Grab the parent (root) directory.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 npm install -g lerna@2 @alrra/travis-scripts asciify gnomon
 

--- a/.travis/before-install.sh
+++ b/.travis/before-install.sh
@@ -48,57 +48,6 @@ echo "->- Build cfg being used"
 cat ${DIR}/build.cfg
 echo "-<-"
 
-
-######
-# checking the changes that are in this file
-echo "Travis commit range $TRAVIS_COMMIT_RANGE"
-echo "Travis commit $TRAVIS_COMMIT"
-echo "Travis event type $TRAVIS_EVENT_TYPE"
-
-
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-  echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
-elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
-  echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
-elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
-  echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
-else
-  echo -e 'WARN: Should not be here => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']  Pull Request ['$TRAVIS_PULL_REQUEST']'
-fi
-
-
-cd $TRAVIS_BUILD_DIR
-touch changefiles.log
-git diff --name-only $(echo $TRAVIS_COMMIT_RANGE | sed 's/\.//')
-
-if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-    git show --pretty=format: --name-only "$TRAVIS_COMMIT_RANGE"|sort|uniq  >> changedfiles.log  || echo Fail
-elif [ -n "$TRAVIS_PULL_REQUEST" ]; then
-    git diff --name-only "$TRAVIS_COMMIT" "$TRAVIS_BRANCH"  >> changedfiles.log   || echo Fail
-fi
-
-RESULT=$(cat changedfiles.log | sed '/^\s*$/d' | awk '!/composer-website/ { print "MORE" }')
-if [ "${RESULT}" == "" ] && [ "$TRAVIS_TAG" == "" ];
-then
-
-    # Check of the task current executing
-    if [ "${FC_TASK}" != "docs" ]; then
-#        echo "ABORT_BUILD=true" > ${DIR}/build.cfg
-#        echo "ABORT_CODE=0" >> ${DIR}/build.cfg
-        echo 'Docs only build'
-#        exit 0
-    fi
-
-else
-  echo "More than docs changes"
-fi
-rm changedfiles.log
-cd - > /dev/null
-######
-
-
-
-
 # Check of the task current executing
 if [ "${FC_TASK}" = "docs" ]; then
   echo Doing Docs - no requirement for installations of other software


### PR DESCRIPTION
High memory usage and leak from Composer runtime #2758 

Use fixed `go-duktape` that fixes:
- Duktape stack leak caused by a bug in the setTimeout code in `go-duktape`.
- Duktape memory leak caused by context tracking code in `go-duktape`, that we are exacerbating by regularly binding new Go functions to JavaScript.

Ensure the build uses the right version of `go-duktape` by adding a check for the correct Git submodule remote URL - whenever we change this, it tends to result in people undoing the change due to merge failures.

Finally, remove broken git diff code that blows up my personal Travis builds - it does nothing useful anyway.