### PR TITLE
Force garbage collection at regular intervals

### DIFF
--- a/packages/composer-connector-hlfv1/lib/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/lib/hlfconnection.js
@@ -342,13 +342,16 @@ class HLFConnection extends Connection {
             .then(() => {
                 // Update the chaincode source to have the runtime version in it.
                 // Also provide a default poolSize of 8 if not specified in install options.
+                // Also provide a default gcInterval of 5 (seconds) if not specified in install options.
                 const poolSize = installOptions && installOptions.poolSize ? installOptions.poolSize * 1 : 8;
+                const gcInterval = installOptions && installOptions.gcInterval ? installOptions.gcInterval * 1 : 5;
                 let targetFilePath = path.resolve(tempDirectoryPath, 'src', chaincodePath, 'constants.go');
                 let targetFileContents = `
                 package main
                 // The version for this chaincode.
                 const version = "${runtimePackageJSON.version}"
                 const PoolSize = ${poolSize}
+                const GCInterval = ${gcInterval}
                 `;
                 return this.fs.outputFile(targetFilePath, targetFileContents);
 

--- a/packages/composer-runtime-hlfv1/composer.go
+++ b/packages/composer-runtime-hlfv1/composer.go
@@ -42,6 +42,19 @@ func NewComposer() (result *Composer) {
 	result = &Composer{}
 	result.createJavaScript()
 
+	// Create the garbage collection thread.
+	ticker := time.NewTicker(time.Second * GCInterval)
+	go func() {
+		vm := result.VM
+		for range ticker.C {
+			logger.Debug("Garbage collection ticker", result.Index)
+			vm.Lock()
+			vm.Gc(0)
+			vm.Gc(0)
+			vm.Unlock()
+		}
+	}()
+
 	// Create the container and engine objects.
 	result.Container = NewContainer(result.VM, nil)
 	result.Engine = NewEngine(result.VM, result.Container)
@@ -53,7 +66,7 @@ func NewComposer() (result *Composer) {
 func (composer *Composer) createJavaScript() {
 	logger.Debug("Entering Composer.createJavaScript")
 
-	start := time.Now()	
+	start := time.Now()
 	defer func() { logger.Debug("@perf Composer.createJavaScript total duration :", time.Now().Sub(start)) }()
 
 	defer func() { logger.Debug("Exiting Composer.createJavaScript") }()
@@ -128,8 +141,10 @@ func (composer *Composer) createJavaScript() {
 func (composer *Composer) Init(stub shim.ChaincodeStubInterface, function string, arguments []string) (result []byte, err error) {
 	logger.Debug("Entering Composer.Init", &stub, function, arguments)
 
-	start := time.Now()	
-	defer func() { logger.Debug("@perf Composer.Init total duration for [", stub.GetTxID(),"] :", time.Now().Sub(start)) }()
+	start := time.Now()
+	defer func() {
+		logger.Debug("@perf Composer.Init total duration for [", stub.GetTxID(), "] :", time.Now().Sub(start))
+	}()
 
 	defer func() { logger.Debug("Exiting Composer.Init", string(result), err) }()
 
@@ -166,8 +181,10 @@ func (composer *Composer) Init(stub shim.ChaincodeStubInterface, function string
 func (composer *Composer) Invoke(stub shim.ChaincodeStubInterface, function string, arguments []string) (result []byte, err error) {
 	logger.Debug("Entering Composer.Invoke", &stub, function, arguments)
 
-	start := time.Now()	
-	defer func() { logger.Debug("@perf Composer.Invoke total duration for [", stub.GetTxID(),"] :", time.Now().Sub(start)) }()
+	start := time.Now()
+	defer func() {
+		logger.Debug("@perf Composer.Invoke total duration for [", stub.GetTxID(), "] :", time.Now().Sub(start))
+	}()
 
 	defer func() { logger.Debug("Exiting Composer.Invoke", string(result), err) }()
 

--- a/packages/composer-runtime-hlfv1/constants.go
+++ b/packages/composer-runtime-hlfv1/constants.go
@@ -14,8 +14,11 @@
 
 package main
 
-// The version of this chaincode and the default pool size. 
-// version is replaced with the npm package version, PoolSize is
-// also replaced with a default value during the deployment process.
+// The version of this chaincode, the default pool size, and the
+// default garbage collection interval. All three values are
+// replaced as part of the deployment process; version is replaced
+// with the npm package version, and PoolSize/GCInterval are
+// replaced with defaults or user specified overrides.
 const version = "development"
 const PoolSize = 8
+const GCInterval = 5


### PR DESCRIPTION
High memory usage and leak from Composer runtime #2758

Force Duktape to perform garbage collections at regular intervals to keep memory utilisation low. Set the default garbage collection interval to 5 seconds, but allow users to override it by specifying `-o gcInterval=30` (an example for setting it to 30 seconds).

Possible/likely performance degradation owing to garbage collection pauses, but the memory saving for a reasonable BNA file this is well worthwhile. Anybody that objects to the performance degradation can override the garbage collection interval as per the instructions above.