### PR TITLE
ACL Rules: return immediately if simple boolean condition specified in operation

### DIFF
--- a/packages/composer-runtime/lib/accesscontroller.js
+++ b/packages/composer-runtime/lib/accesscontroller.js
@@ -379,6 +379,13 @@ class AccessController {
         const method = 'matchPredicate';
         LOG.entry(method, resource, participant, transaction, aclRule);
 
+        // shortcut evaluation if simple boolean predicate
+        if (aclRule.getPredicate().getExpression() === 'true') {
+            return Promise.resolve(true);
+        } else if (aclRule.getPredicate().getExpression() === 'false') {
+            return Promise.resolve(false);
+        }
+
         // We want to permit access to related assets and participants, so prepare the resources.
         const compiledAclBundle = this.context.getCompiledAclBundle();
         const resolver = this.context.getResolver();


### PR DESCRIPTION
closes #2768

 - within matchPredicate, check if the condition passed in is true/false and return a Promise.resolve(true/false), otherwise continue with original code execution
- new tests to check that ACL rules are not executed for the true/false cases
- updating of old tests to retain ACL rule execution

Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>