### PR TITLE
Cache class declaration in resources

### DIFF
--- a/packages/composer-common/lib/factory.js
+++ b/packages/composer-common/lib/factory.js
@@ -113,10 +113,10 @@ class Factory {
 
         let newObj = null;
         if(options.disableValidation) {
-            newObj = new Resource(this.modelManager, ns, type, id);
+            newObj = new Resource(this.modelManager, classDecl, ns, type, id);
         }
         else {
-            newObj = new ValidatedResource(this.modelManager, ns, type, id, new ResourceValidator());
+            newObj = new ValidatedResource(this.modelManager, classDecl, ns, type, id, new ResourceValidator());
         }
         newObj.assignFieldDefaults();
         this.initializeNewObject(newObj, classDecl, options);
@@ -162,10 +162,10 @@ class Factory {
         let newObj = null;
         options = options || {};
         if(options.disableValidation) {
-            newObj = new Concept(this.modelManager,ns,type);
+            newObj = new Concept(this.modelManager, classDecl, ns, type);
         }
         else {
-            newObj = new ValidatedConcept(this.modelManager,ns,type, new ResourceValidator());
+            newObj = new ValidatedConcept(this.modelManager, classDecl, ns, type, new ResourceValidator());
         }
         newObj.assignFieldDefaults();
         this.initializeNewObject(newObj, classDecl, options);
@@ -190,9 +190,8 @@ class Factory {
     newRelationship(ns, type, id) {
         // Load the type declaration to force an error if it doesn't exist
         const fqn = ModelUtil.getFullyQualifiedName(ns, type);
-        this.modelManager.getType(fqn);
-
-        return new Relationship(this.modelManager, ns, type, id);
+        const classDecl = this.modelManager.getType(fqn);
+        return new Relationship(this.modelManager, classDecl, ns, type, id);
     }
 
     /**

--- a/packages/composer-common/lib/introspect/classdeclaration.js
+++ b/packages/composer-common/lib/introspect/classdeclaration.js
@@ -15,12 +15,13 @@
 'use strict';
 
 const Decorated = require('./decorated');
-const Field = require('./field');
 const EnumValueDeclaration = require('./enumvaluedeclaration');
-const RelationshipDeclaration = require('./relationshipdeclaration');
-const IllegalModelException = require('./illegalmodelexception');
+const Field = require('./field');
 const Globalize = require('../globalize');
+const IllegalModelException = require('./illegalmodelexception');
 const Introspector = require('./introspector');
+const ModelUtil = require('../modelutil');
+const RelationshipDeclaration = require('./relationshipdeclaration');
 
 /**
  * ClassDeclaration defines the structure (model/schema) of composite data.
@@ -52,6 +53,7 @@ class ClassDeclaration extends Decorated {
         }
         this.modelFile = modelFile;
         this.process();
+        this.fqn = ModelUtil.getFullyQualifiedName(modelFile.getNamespace(), this.name);
     }
 
     /**
@@ -349,7 +351,7 @@ class ClassDeclaration extends Decorated {
      * @return {string} the fully-qualified name of this class
      */
     getFullyQualifiedName() {
-        return this.getNamespace() + '.' + this.name;
+        return this.fqn;
     }
 
     /**

--- a/packages/composer-common/lib/model/concept.js
+++ b/packages/composer-common/lib/model/concept.js
@@ -44,12 +44,13 @@ class Concept extends Typed {
      * </p>
      *
      * @param {ModelManager} modelManager - The ModelManager for this instance
+     * @param {ClassDeclaration} classDeclaration - The class declaration for this instance.
      * @param {string} ns - The namespace this instance.
      * @param {string} type - The type this instance.
      * @private
      */
-    constructor(modelManager, ns, type) {
-        super(modelManager, ns, type);
+    constructor(modelManager, classDeclaration, ns, type) {
+        super(modelManager, classDeclaration, ns, type);
     }
 
 

--- a/packages/composer-common/lib/model/identifiable.js
+++ b/packages/composer-common/lib/model/identifiable.js
@@ -34,13 +34,14 @@ class Identifiable extends Typed {
      * </p>
      *
      * @param {ModelManager} modelManager - The ModelManager for this instance
+     * @param {ClassDeclaration} classDeclaration - The class declaration for this instance.
      * @param {string} ns - The namespace this instance.
      * @param {string} type - The type this instance.
      * @param {string} id - The identifier of this instance.
      * @private
      */
-    constructor(modelManager, ns, type, id) {
-        super(modelManager, ns, type);
+    constructor(modelManager, classDeclaration, ns, type, id) {
+        super(modelManager, classDeclaration, ns, type);
         this.$identifier = id;
     }
 

--- a/packages/composer-common/lib/model/relationship.js
+++ b/packages/composer-common/lib/model/relationship.js
@@ -15,8 +15,8 @@
 'use strict';
 
 const Identifiable = require('./identifiable');
+const ModelUtil = require('../modelutil');
 const ResourceId = require('./resourceid');
-const Globalize = require('../globalize');
 
 /**
  * A Relationship is a typed pointer to an instance. I.e the relationship
@@ -37,13 +37,14 @@ class Relationship extends Identifiable {
      * </p>
      *
      * @param {ModelManager} modelManager - The ModelManager for this instance
+     * @param {ClassDeclaration} classDeclaration - The class declaration for this instance.
      * @param {string} ns - The namespace this instance.
      * @param {string} type - The type this instance.
      * @param {string} id - The identifier of this instance.
      * @private
      */
-    constructor(modelManager, ns, type, id) {
-        super(modelManager, ns, type, id);
+    constructor(modelManager, classDeclaration, ns, type, id) {
+        super(modelManager, classDeclaration, ns, type, id);
         // we use this metatag to identify the instance as a relationship
         this.$class = 'Relationship';
     }
@@ -75,26 +76,9 @@ class Relationship extends Identifiable {
      */
     static fromURI(modelManager, uriAsString, defaultNamespace, defaultType) {
         const resourceId = ResourceId.fromURI(uriAsString, defaultNamespace, defaultType);
-
-        let modelFile = modelManager.getModelFile(resourceId.namespace);
-        if (!modelFile) {
-            let formatter = Globalize.messageFormatter('factory-newrelationship-notregisteredwithmm');
-
-            throw new Error(formatter({
-                namespace: resourceId.namespace
-            }));
-        }
-
-        if (!modelFile.isDefined(resourceId.type)) {
-            let formatter = Globalize.messageFormatter('factory-newinstance-typenotdeclaredinns');
-
-            throw new Error(formatter({
-                namespace: resourceId.namespace,
-                type: resourceId.type
-            }));
-        }
-
-        let relationship = new Relationship(modelManager, resourceId.namespace, resourceId.type, resourceId.id);
+        let fqt = ModelUtil.getFullyQualifiedName(resourceId.namespace, resourceId.type);
+        let classDeclaration = modelManager.getType(fqt);
+        let relationship = new Relationship(modelManager, classDeclaration, resourceId.namespace, resourceId.type, resourceId.id);
         return relationship;
     }
 }

--- a/packages/composer-common/lib/model/resource.js
+++ b/packages/composer-common/lib/model/resource.js
@@ -44,13 +44,14 @@ class Resource extends Identifiable {
      * </p>
      *
      * @param {ModelManager} modelManager - The ModelManager for this instance
+     * @param {ClassDeclaration} classDeclaration - The class declaration for this instance.
      * @param {string} ns - The namespace this instance.
      * @param {string} type - The type this instance.
      * @param {string} id - The identifier of this instance.
      * @private
      */
-    constructor(modelManager, ns, type, id) {
-        super(modelManager, ns, type, id);
+    constructor(modelManager, classDeclaration, ns, type, id) {
+        super(modelManager, classDeclaration, ns, type, id);
     }
 
     /**

--- a/packages/composer-common/lib/model/typed.js
+++ b/packages/composer-common/lib/model/typed.js
@@ -15,7 +15,6 @@
 'use strict';
 
 const Field = require('../introspect/field');
-const ModelUtil = require('../modelutil');
 
 /**
  * Object is an instance with a namespace and a type.
@@ -34,12 +33,14 @@ class Typed {
      * </p>
      *
      * @param {ModelManager} modelManager - The ModelManager for this instance
+     * @param {ClassDeclaration} classDeclaration - The class declaration for this instance.
      * @param {string} ns - The namespace this instance.
      * @param {string} type - The type this instance.
      * @private
      */
-    constructor(modelManager, ns, type) {
+    constructor(modelManager, classDeclaration, ns, type) {
         this.$modelManager = modelManager;
+        this.$classDeclaration = classDeclaration;
         this.$namespace = ns;
         this.$type = type;
     }
@@ -77,7 +78,7 @@ class Typed {
      * @return {string} The fully-qualified type name of this object
      */
     getFullyQualifiedType() {
-        return ModelUtil.getFullyQualifiedName(this.$namespace, this.$type);
+        return this.$classDeclaration.getFullyQualifiedName();
     }
 
     /**
@@ -92,25 +93,10 @@ class Typed {
      * Returns the class declaration for this instance object.
      *
      * @return {ClassDeclaration} - the class declaration for this instance
-     * @throws {Error} - if the class or namespace for the instance is not declared
      * @private
      */
     getClassDeclaration() {
-        // do we have a model file?
-        let modelFile = this.getModelManager().getModelFile(this.getNamespace());
-
-        if (!modelFile) {
-            throw new Error('No model for namespace ' + this.getNamespace() + ' is registered with the ModelManager');
-        }
-
-        // do we have a class?
-        let classDeclaration = modelFile.getType(this.getType());
-
-        if (!classDeclaration) {
-            throw new Error('The namespace ' + this.getNamespace() + ' does not contain the type ' + this.getType());
-        }
-
-        return classDeclaration;
+        return this.$classDeclaration;
     }
 
     /**

--- a/packages/composer-common/lib/model/validatedconcept.js
+++ b/packages/composer-common/lib/model/validatedconcept.js
@@ -44,13 +44,14 @@ class ValidatedConcept extends Concept {
      * </p>
      *
      * @param {ModelManager} modelManager - The ModelManager for this instance
+     * @param {ClassDeclaration} classDeclaration - The class declaration for this instance.
      * @param {string} ns - The namespace this instance.
      * @param {string} type - The type this instance.
      * @param {ResourceValidator} resourceValidator - The validator to use for this instance
      * @private
      */
-    constructor(modelManager, ns, type, resourceValidator) {
-        super(modelManager, ns, type);
+    constructor(modelManager, classDeclaration, ns, type, resourceValidator) {
+        super(modelManager, classDeclaration, ns, type);
         this.$validator = resourceValidator;
     }
 

--- a/packages/composer-common/lib/model/validatedresource.js
+++ b/packages/composer-common/lib/model/validatedresource.js
@@ -36,14 +36,15 @@ class ValidatedResource extends Resource {
      * retrieve instances from {@link Factory}</strong>
      * </p>
      * @param {ModelManager} modelManager - The ModelManager for this instance
+     * @param {ClassDeclaration} classDeclaration - The class declaration for this instance.
      * @param {string} ns - The namespace this instance.
      * @param {string} type - The type this instance.
      * @param {string} id - The identifier of this instance.
      * @param {ResourceValidator} resourceValidator - The validator to use for this instance
      * @private
      */
-    constructor(modelManager, ns, type, id,resourceValidator) {
-        super(modelManager, ns, type, id);
+    constructor(modelManager, classDeclaration, ns, type, id, resourceValidator) {
+        super(modelManager, classDeclaration, ns, type, id);
         this.$validator = resourceValidator;
     }
 

--- a/packages/composer-common/test/introspect/classdeclaration.js
+++ b/packages/composer-common/test/introspect/classdeclaration.js
@@ -30,16 +30,12 @@ const sinon = require('sinon');
 
 describe('ClassDeclaration', () => {
 
-    let mockModelManager;
-    let mockModelFile;
-    let mockSystemAsset;
+    let modelManager;
+    let modelFile;
 
     beforeEach(() => {
-        mockModelManager = sinon.createStubInstance(ModelManager);
-        mockSystemAsset = sinon.createStubInstance(AssetDeclaration);
-        mockSystemAsset.getFullyQualifiedName.returns('org.hyperledger.composer.system.Asset');
-        mockModelManager.getSystemTypes.returns([mockSystemAsset]);
-        mockModelFile = sinon.createStubInstance(ModelFile);
+        modelManager = new ModelManager();
+        modelFile = new ModelFile(modelManager, 'namespace com.hyperledger.testing', 'org.acme.cto');
     });
 
     /**
@@ -59,7 +55,7 @@ describe('ClassDeclaration', () => {
     };
 
     const loadModelFile = (modelFileName) => {
-        return loadModelFiles([modelFileName], mockModelManager)[0];
+        return loadModelFiles([modelFileName], modelManager)[0];
     };
 
     const loadLastDeclaration = (modelFileName, type) => {
@@ -78,13 +74,13 @@ describe('ClassDeclaration', () => {
 
         it('should throw if ast not specified', () => {
             (() => {
-                new ClassDeclaration(mockModelFile, null);
+                new ClassDeclaration(modelFile, null);
             }).should.throw(/required/);
         });
 
         it('should throw if ast contains invalid type', () => {
             (() => {
-                new ClassDeclaration(mockModelFile, {
+                new ClassDeclaration(modelFile, {
                     id: {
                         name: 'suchName'
                     },
@@ -155,7 +151,7 @@ describe('ClassDeclaration', () => {
     describe('#accept', () => {
 
         it('should call the visitor', () => {
-            let clz = new ClassDeclaration(mockModelFile, {
+            let clz = new ClassDeclaration(modelFile, {
                 id: {
                     name: 'suchName'
                 },
@@ -177,7 +173,7 @@ describe('ClassDeclaration', () => {
     describe('#getModelFile', () => {
 
         it('should return the model file', () => {
-            let clz = new ClassDeclaration(mockModelFile, {
+            let clz = new ClassDeclaration(modelFile, {
                 id: {
                     name: 'suchName'
                 },
@@ -186,7 +182,7 @@ describe('ClassDeclaration', () => {
                     ]
                 }
             });
-            clz.getModelFile().should.equal(mockModelFile);
+            clz.getModelFile().should.equal(modelFile);
         });
 
     });
@@ -194,7 +190,7 @@ describe('ClassDeclaration', () => {
     describe('#getName', () => {
 
         it('should return the class name', () => {
-            let clz = new ClassDeclaration(mockModelFile, {
+            let clz = new ClassDeclaration(modelFile, {
                 id: {
                     name: 'suchName'
                 },
@@ -204,7 +200,7 @@ describe('ClassDeclaration', () => {
                 }
             });
             clz.getName().should.equal('suchName');
-            clz.toString().should.equal('ClassDeclaration {id=undefined.suchName enum=false abstract=false}');
+            clz.toString().should.equal('ClassDeclaration {id=com.hyperledger.testing.suchName enum=false abstract=false}');
         });
 
     });
@@ -212,8 +208,7 @@ describe('ClassDeclaration', () => {
     describe('#getFullyQualifiedName', () => {
 
         it('should return the fully qualified name if function is in a namespace', () => {
-            mockModelFile.getNamespace.returns('com.hyperledger.testing');
-            let clz = new ClassDeclaration(mockModelFile, {
+            let clz = new ClassDeclaration(modelFile, {
                 id: {
                     name: 'suchName'
                 },

--- a/packages/composer-common/test/introspect/modelfile.js
+++ b/packages/composer-common/test/introspect/modelfile.js
@@ -28,7 +28,9 @@ const parser = require('../../lib/introspect/parser');
 const fs = require('fs');
 const path = require('path');
 
-const should = require('chai').should();
+const chai = require('chai');
+const should = chai.should();
+chai.use(require('chai-things'));
 const sinon = require('sinon');
 
 describe('ModelFile', () => {
@@ -452,6 +454,33 @@ describe('ModelFile', () => {
             }).should.throw(/DontExist/);
         });
 
+
+    });
+
+    describe('#isDefined', () => {
+
+        let modelManager;
+        let modelFile;
+
+        before(() => {
+            modelManager = new ModelManager();
+            modelFile = modelManager.addModelFile(`namespace org.acme
+            asset MyAsset identified by assetId {
+                o String assetId
+            }`);
+        });
+
+        it('should return true for a primitive type', () => {
+            modelFile.isDefined('String').should.be.true;
+        });
+
+        it('should return true for a local type', () => {
+            modelFile.isDefined('MyAsset').should.be.true;
+        });
+
+        it('should return false for a local type that does not exist', () => {
+            modelFile.isDefined('NoAsset').should.be.false;
+        });
 
     });
 

--- a/packages/composer-common/test/model/concept.js
+++ b/packages/composer-common/test/model/concept.js
@@ -19,7 +19,6 @@ const Concept = require('../../lib/model/concept');
 const Serializer = require('../../lib/serializer');
 const Factory = require('../../lib/factory');
 
-const sinon = require('sinon');
 const fs = require('fs');
 
 const chai = require('chai');
@@ -39,6 +38,7 @@ describe('Concept', function () {
   `;
 
     let modelManager = null;
+    let classDecl = null;
 
     before(function () {
         modelManager = new ModelManager();
@@ -46,6 +46,7 @@ describe('Concept', function () {
 
     beforeEach(function () {
         modelManager.addModelFile(levelOneModel);
+        classDecl = modelManager.getType('org.acme.l1.Person');
     });
 
     afterEach(function () {
@@ -53,28 +54,15 @@ describe('Concept', function () {
     });
 
     describe('#getClassDeclaration', function() {
-        it('should throw with no ModelFile', function () {
-            const resource = new Concept(modelManager, 'org.acme.l1', 'Person' );
-            const stub = sinon.stub(modelManager, 'getModelFile', function(){return null;});
-            (function () {
-                resource.getClassDeclaration();
-            }).should.throw(/No model for namespace org.acme.l1 is registered with the ModelManager/);
-            stub.restore();
-        });
-        it('should throw with no type', function () {
-            const resource = new Concept(modelManager, 'org.acme.l1', 'Person' );
-            const modelFile = modelManager.getModelFile('org.acme.l1');
-            const stub = sinon.stub(modelFile, 'getType', function(type){return null;});
-            (function () {
-                resource.getClassDeclaration();
-            }).should.throw(/The namespace org.acme.l1 does not contain the type Person/);
-            stub.restore();
+        it('should return the class declaraction', function () {
+            const resource = new Concept(modelManager, classDecl, 'org.acme.l1', 'Person' );
+            resource.getClassDeclaration().should.equal(classDecl);
         });
     });
 
     describe('#toJSON', () => {
         it('should throw if toJSON is called', function () {
-            const resource = new Concept(modelManager, 'org.acme.l1', 'Person');
+            const resource = new Concept(modelManager, classDecl, 'org.acme.l1', 'Person');
             (function () {
                 resource.toJSON();
             }).should.throw(/Use Serializer.toJSON to convert resource instances to JSON objects./);
@@ -145,7 +133,7 @@ describe('Concept', function () {
 
     describe('#isConcept', () => {
         it('should be true', () => {
-            const resource = new Concept(modelManager, 'org.acme.l1', 'Person');
+            const resource = new Concept(modelManager, classDecl, 'org.acme.l1', 'Person');
             resource.isConcept().should.be.true;
         });
     });

--- a/packages/composer-common/test/model/identifiable.js
+++ b/packages/composer-common/test/model/identifiable.js
@@ -21,11 +21,17 @@ const chai = require('chai');
 chai.should();
 chai.use(require('chai-things'));
 
-describe    ('Identifiable', function () {
+describe('Identifiable', function () {
 
     let modelManager;
+    let classDecl;
     before(function () {
         modelManager = new ModelManager();
+        modelManager.addModelFile(`namespace com.composer
+        participant Farmer identified by farmerId {
+            o String farmerId
+        }`);
+        classDecl = modelManager.getType('com.composer.Farmer');
     });
 
     beforeEach(function () {
@@ -36,18 +42,14 @@ describe    ('Identifiable', function () {
 
     describe('#toString', function() {
         it('should be able to call toString', function () {
-            const id = new Identifiable(modelManager, 'org.acme', 'Type', '123' );
-            id.toString().should.equal('Identifiable {id=org.acme.Type#123}');
+            const id = new Identifiable(modelManager, classDecl, 'com.composer', 'Farmer', '123' );
+            id.toString().should.equal('Identifiable {id=com.composer.Farmer#123}');
         });
     });
 
     describe('#setIdentifier', () => {
         it('should be able to set identifier', function () {
-            modelManager.addModelFile(`namespace com.composer
-            participant Farmer identified by farmerId {
-                o String farmerId
-            }`);
-            let id = new Identifiable(modelManager, 'com.composer', 'Farmer', '123' );
+            let id = new Identifiable(modelManager, modelManager.getType('com.composer.Farmer'), 'com.composer', 'Farmer', '123' );
             id.setIdentifier('321');
             id.getIdentifier().should.equal('321');
         });
@@ -55,7 +57,7 @@ describe    ('Identifiable', function () {
 
     describe('#accept', () => {
         it('should be able to accept visitor', function () {
-            const id = new Identifiable(modelManager, 'org.acme', 'Type', '123' );
+            const id = new Identifiable(modelManager, classDecl, 'com.composer', 'Farmer', '123' );
             const visitor = {visit: function(obj,parameters){}};
             const spy = sinon.spy(visitor, 'visit');
             id.accept(visitor, {});
@@ -65,7 +67,7 @@ describe    ('Identifiable', function () {
 
     describe('#toJSON', () => {
         it('should throw is toJSON is called', function () {
-            const id = new Identifiable(modelManager, 'org.acme', 'Type', '123' );
+            const id = new Identifiable(modelManager, classDecl, 'com.composer', 'Farmer', '123' );
             (function () {
                 id.toJSON();
             }).should.throw(/Use Serializer.toJSON to convert resource instances to JSON objects./);
@@ -74,14 +76,14 @@ describe    ('Identifiable', function () {
 
     describe('#isRelationship', () => {
         it('should be false', () => {
-            const id = new Identifiable(modelManager, 'org.acme', 'Type', '123' );
+            const id = new Identifiable(modelManager, classDecl, 'com.composer', 'Farmer', '123' );
             id.isRelationship().should.be.false;
         });
     });
 
     describe('#isResource', () => {
         it('should be false', () => {
-            const id = new Identifiable(modelManager, 'org.acme', 'Type', '123' );
+            const id = new Identifiable(modelManager, classDecl, 'com.composer', 'Farmer', '123' );
             id.isResource().should.be.false;
         });
     });

--- a/packages/composer-common/test/model/resource.js
+++ b/packages/composer-common/test/model/resource.js
@@ -16,7 +16,6 @@
 
 const ModelManager = require('../../lib/modelmanager');
 const Resource = require('../../lib/model/resource');
-const sinon = require('sinon');
 
 const chai = require('chai');
 chai.should();
@@ -35,6 +34,7 @@ describe('Resource', function () {
   `;
 
     let modelManager = null;
+    let classDecl = null;
 
     before(function () {
         modelManager = new ModelManager();
@@ -42,6 +42,7 @@ describe('Resource', function () {
 
     beforeEach(function () {
         modelManager.addModelFile(levelOneModel);
+        classDecl = modelManager.getType('org.acme.l1.Person');
     });
 
     afterEach(function () {
@@ -49,22 +50,9 @@ describe('Resource', function () {
     });
 
     describe('#getClassDeclaration', function() {
-        it('should throw with no ModelFile', function () {
-            const resource = new Resource(modelManager, 'org.acme.l1', 'Person', '123' );
-            const stub = sinon.stub(modelManager, 'getModelFile', function(){return null;});
-            (function () {
-                resource.getClassDeclaration();
-            }).should.throw(/No model for namespace org.acme.l1 is registered with the ModelManager/);
-            stub.restore();
-        });
-        it('should throw with no type', function () {
-            const resource = new Resource(modelManager, 'org.acme.l1', 'Person', '123' );
-            const modelFile = modelManager.getModelFile('org.acme.l1');
-            const stub = sinon.stub(modelFile, 'getType', function(type){return null;});
-            (function () {
-                resource.getClassDeclaration();
-            }).should.throw(/The namespace org.acme.l1 does not contain the type Person/);
-            stub.restore();
+        it('should return the class declaraction', function () {
+            const resource = new Resource(modelManager, classDecl, 'org.acme.l1', 'Person', '123' );
+            resource.getClassDeclaration().should.equal(classDecl);
         });
     });
 

--- a/packages/composer-common/test/model/typed.js
+++ b/packages/composer-common/test/model/typed.js
@@ -22,6 +22,9 @@ require('chai').should();
 describe('Typed', () => {
 
     let modelManager;
+    let baseAssetClassDecl;
+    let baseAsset2ClassDecl;
+    let asset2ClassDecl;
 
     beforeEach(() => {
         modelManager = new ModelManager();
@@ -31,6 +34,8 @@ describe('Typed', () => {
         }
         abstract asset BaseAsset2 extends BaseAsset {
         }`);
+        baseAssetClassDecl = modelManager.getType('org.acme.base.BaseAsset');
+        baseAsset2ClassDecl = modelManager.getType('org.acme.base.BaseAsset2');
         modelManager.addModelFile(`
         namespace org.acme.ext
         import org.acme.base.BaseAsset2
@@ -39,27 +44,28 @@ describe('Typed', () => {
         }
         asset Asset2 extends MyAsset {
         }`);
+        asset2ClassDecl = modelManager.getType('org.acme.ext.Asset2');
     });
 
     describe('#instanceOf', () => {
 
         it('should return true for a matching type', () => {
-            let typed = new Typed(modelManager, 'org.acme.base', 'BaseAsset');
+            let typed = new Typed(modelManager, baseAssetClassDecl, 'org.acme.base', 'BaseAsset');
             typed.instanceOf('org.acme.base.BaseAsset').should.be.true;
         });
 
         it('should return true for a matching super type', () => {
-            let typed = new Typed(modelManager, 'org.acme.base', 'BaseAsset2');
+            let typed = new Typed(modelManager, baseAsset2ClassDecl, 'org.acme.base', 'BaseAsset2');
             typed.instanceOf('org.acme.base.BaseAsset').should.be.true;
         });
 
         it('should return false for a non-matching sub type', () => {
-            let typed = new Typed(modelManager, 'org.acme.base', 'BaseAsset');
+            let typed = new Typed(modelManager, baseAssetClassDecl, 'org.acme.base', 'BaseAsset');
             typed.instanceOf('org.acme.base.BaseAsset2').should.be.false;
         });
 
         it('should return true for a matching nested super type', () => {
-            let typed = new Typed(modelManager, 'org.acme.ext', 'Asset2');
+            let typed = new Typed(modelManager, asset2ClassDecl, 'org.acme.ext', 'Asset2');
             typed.instanceOf('org.acme.base.BaseAsset').should.be.true;
         });
 
@@ -86,7 +92,8 @@ describe('Typed', () => {
                     o String assetId
                     o ${defaultValueType} value default=${JSON.stringify(defaultValue)}
                 }`);
-                const typed = new Typed(modelManager, 'org.acme.defaults', 'DefaultAsset');
+                const classDecl = modelManager.getType('org.acme.defaults.DefaultAsset');
+                const typed = new Typed(modelManager, classDecl, 'org.acme.defaults', 'DefaultAsset');
                 typed.assignFieldDefaults();
                 if (typed.value instanceof Date) {
                     typed.value.toISOString().should.equal(defaultValue);

--- a/packages/composer-common/test/model/validatedconcept.js
+++ b/packages/composer-common/test/model/validatedconcept.js
@@ -22,7 +22,7 @@ const chai = require('chai');
 chai.should();
 chai.use(require('chai-things'));
 
-describe('Validatedoncept', function () {
+describe('ValidatedConcept', function () {
 
     const levelOneModel = `namespace org.acme.l1
   concept Person {
@@ -36,6 +36,7 @@ describe('Validatedoncept', function () {
   `;
 
     let modelManager = null;
+    let classDecl = null;
     let mockResourceValidator;
 
     before(function () {
@@ -44,6 +45,7 @@ describe('Validatedoncept', function () {
 
     beforeEach(function () {
         modelManager.addModelFile(levelOneModel);
+        classDecl = modelManager.getType('org.acme.l1.Person');
         mockResourceValidator = sinon.createStubInstance(ResourceValidator);
         mockResourceValidator.visit.returns(null);
 
@@ -54,49 +56,45 @@ describe('Validatedoncept', function () {
     });
 
     describe('#getClassDeclaration', function() {
-        it('should throw with no ModelFile', function () {
-            const resource = new ValidatedConcept(modelManager, 'org.acme.l1', 'Person' ,mockResourceValidator);
-            const stub = sinon.stub(modelManager, 'getModelFile', function(){return null;});
-            (function () {
-                resource.getClassDeclaration();
-            }).should.throw(/No model for namespace org.acme.l1 is registered with the ModelManager/);
-            stub.restore();
+        it('should return the class declaraction', function () {
+            const resource = new ValidatedConcept(modelManager, classDecl, 'org.acme.l1', 'Person' ,mockResourceValidator);
+            resource.getClassDeclaration().should.equal(classDecl);
         });
     });
 
     describe('#setPropertyValue', () => {
         it (' should accept valid property - value', function (){
-            const resource = new ValidatedConcept(modelManager, 'org.acme.l1', 'Person' ,mockResourceValidator);
+            const resource = new ValidatedConcept(modelManager, classDecl, 'org.acme.l1', 'Person' ,mockResourceValidator);
             resource.setPropertyValue('name','Fred Bloggs');
         });
         it (' should throw error for invalid property name', function (){
-            const resource = new ValidatedConcept(modelManager, 'org.acme.l1', 'Person' ,mockResourceValidator);
+            const resource = new ValidatedConcept(modelManager, classDecl, 'org.acme.l1', 'Person' ,mockResourceValidator);
             ( () => {
                 resource.setPropertyValue('namenamename','Fred Bloggs');
             }).should.throw(/Trying to set field namenamename which is not declared in the model/);
         });
         it (' should throw error for array', function (){
-            const resource = new ValidatedConcept(modelManager, 'org.acme.l1', 'Person' ,mockResourceValidator);
+            const resource = new ValidatedConcept(modelManager, classDecl, 'org.acme.l1', 'Person' ,mockResourceValidator);
             ( () => {
                 resource.addArrayValue('name',['Fred','Bloggs']);
             }).should.throw(/Trying to add array item name which is not declared as an array in the model/);
         });
         it (' correct path for adding an array', function (){
-            const resource = new ValidatedConcept(modelManager, 'org.acme.l1', 'Person' ,mockResourceValidator);
+            const resource = new ValidatedConcept(modelManager, classDecl, 'org.acme.l1', 'Person' ,mockResourceValidator);
             resource.addArrayValue('arrayName',['Fred','Bloggs']);
         });
         it (' should throw error for invalid property name', function (){
-            const resource = new ValidatedConcept(modelManager, 'org.acme.l1', 'Person' ,mockResourceValidator);
+            const resource = new ValidatedConcept(modelManager, classDecl, 'org.acme.l1', 'Person' ,mockResourceValidator);
             (()=>{
                 resource.addArrayValue('invalid','Fred');
             }).should.throw(/Trying to set field invalid which is not declared in the model/);
         });
         it (' validate', function (){
-            const resource = new ValidatedConcept(modelManager, 'org.acme.l1', 'Person' ,mockResourceValidator);
+            const resource = new ValidatedConcept(modelManager, classDecl, 'org.acme.l1', 'Person' ,mockResourceValidator);
             resource.validate();
         });
         it (' add two elements separately to an array property', function (){
-            const resource = new ValidatedConcept(modelManager, 'org.acme.l1', 'Person' ,mockResourceValidator);
+            const resource = new ValidatedConcept(modelManager, classDecl, 'org.acme.l1', 'Person' ,mockResourceValidator);
             resource.addArrayValue('arrayName','Fred');
             resource.addArrayValue('arrayName','Bloggs');
         });

--- a/packages/composer-common/test/modelutil.js
+++ b/packages/composer-common/test/modelutil.js
@@ -14,7 +14,6 @@
 
 'use strict';
 
-const ClassDeclaration = require('../lib/introspect/classdeclaration');
 const ModelFile = require('../lib/introspect/modelfile');
 const Property = require('../lib/introspect/property');
 const Typed = require('../lib/model/identifiable');
@@ -109,22 +108,18 @@ describe('ModelUtil', function () {
 
     describe('#isMatchingType', () => {
 
-        let mockModelManager;
-        let mockModelFile;
-        let mockClassDeclaration;
+        let modelManager;
+        let classDecl;
         let type;
 
         beforeEach(() => {
-            mockModelManager = sinon.createStubInstance(ModelManager);
-            mockModelFile = sinon.createStubInstance(ModelFile);
-            mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
-
-            mockModelManager.getModelFile.returns(mockModelFile);
-            mockModelFile.getType.returns(mockClassDeclaration);
-            mockClassDeclaration.getFullyQualifiedName.returns('org.acme.baz.Foo');
-            mockClassDeclaration.getAllSuperTypeDeclarations.returns([]);
-
-            type = new Typed(mockModelManager, 'org.acme.baz', 'Foo' );
+            modelManager = new ModelManager();
+            modelManager.addModelFile(`namespace org.acme.baz
+            asset Foo identified by fooId {
+                o String fooId
+            }`);
+            classDecl = modelManager.getType('org.acme.baz.Foo');
+            type = new Typed(modelManager, classDecl, 'org.acme.baz', 'Foo' );
         });
 
         it('should return true for an exact match', () => {

--- a/packages/composer-runtime/lib/callbackrelationship.js
+++ b/packages/composer-runtime/lib/callbackrelationship.js
@@ -41,7 +41,7 @@ class CallbackRelationship extends Relationship {
      * @param {relationshipCallback} callback The callback to call when a property is accessed.
      */
     constructor(relationship, callback) {
-        super(relationship.getModelManager(), relationship.getNamespace(), relationship.getType(), relationship.getIdentifier());
+        super(relationship.getModelManager(), relationship.getClassDeclaration(), relationship.getNamespace(), relationship.getType(), relationship.getIdentifier());
         const method = 'constructor';
         LOG.entry(method, relationship, callback);
         const classDeclaration = this.getClassDeclaration();

--- a/packages/composer-runtime/lib/invalidrelationship.js
+++ b/packages/composer-runtime/lib/invalidrelationship.js
@@ -34,7 +34,7 @@ class InvalidRelationship extends Relationship {
      * @param {Error} error The error to throw when the relationship is accessed.
      */
     constructor(relationship, error) {
-        super(relationship.getModelManager(), relationship.getNamespace(), relationship.getType(), relationship.getIdentifier());
+        super(relationship.getModelManager(), relationship.getClassDeclaration(), relationship.getNamespace(), relationship.getType(), relationship.getIdentifier());
         const method = 'constructor';
         LOG.entry(method, relationship, error);
         const classDeclaration = this.getClassDeclaration();

--- a/packages/composer-runtime/test/callbackrelationship.js
+++ b/packages/composer-runtime/test/callbackrelationship.js
@@ -25,6 +25,7 @@ const sinon = require('sinon');
 describe('CallbackRelationship', () => {
 
     let modelManager;
+    let classDecl;
     let factory;
     let relationship;
     let cb;
@@ -51,9 +52,10 @@ describe('CallbackRelationship', () => {
             --> SampleParticipant owner
             --> SampleParticipant[] owners
         }`);
+        classDecl = modelManager.getType('org.acme.sample.SampleAsset');
         factory = new Factory(modelManager);
         cb = sinon.stub();
-        relationship = new CallbackRelationship(new Relationship(modelManager, 'org.acme.sample', 'SampleAsset', 'ASSET_1'), cb);
+        relationship = new CallbackRelationship(new Relationship(modelManager, classDecl, 'org.acme.sample', 'SampleAsset', 'ASSET_1'), cb);
     });
 
     describe('#constructor', () => {

--- a/packages/composer-runtime/test/invalidrelationship.js
+++ b/packages/composer-runtime/test/invalidrelationship.js
@@ -23,6 +23,7 @@ require('chai').should();
 describe('InvalidRelationship', () => {
 
     let modelManager;
+    let classDecl;
     let relationship;
 
     beforeEach(() => {
@@ -47,7 +48,8 @@ describe('InvalidRelationship', () => {
             --> SampleParticipant owner
             --> SampleParticipant[] owners
         }`);
-        relationship = new InvalidRelationship(new Relationship(modelManager, 'org.acme.sample', 'SampleAsset', 'ASSET_1'), new Error('such error'));
+        classDecl = modelManager.getType('org.acme.sample.SampleAsset');
+        relationship = new InvalidRelationship(new Relationship(modelManager, classDecl, 'org.acme.sample', 'SampleAsset', 'ASSET_1'), new Error('such error'));
     });
 
     describe('#constructor', () => {


### PR DESCRIPTION
ACL rule execution is inefficient #2576 

Class declaration look up for a given `Typed` object is expensive and pointless; the class declaration is always held in memory by the model manager, and we have to look it up before we can create the `Typed` object anyway. Let's pass it in and store a reference to it!