### PR TITLE
Improve super type declaration and instanceOf lookup

### DIFF
--- a/packages/composer-common/lib/introspect/classdeclaration.js
+++ b/packages/composer-common/lib/introspect/classdeclaration.js
@@ -78,6 +78,7 @@ class ClassDeclaration extends Decorated {
         this.name = this.ast.id.name;
         this.properties = [];
         this.superType = null;
+        this.superTypeDeclaration = null;
         this.idField = null;
         this.abstract = false;
 
@@ -160,19 +161,17 @@ class ClassDeclaration extends Decorated {
                 classDecl = this.getModelFile().getType(this.superType);
             }
 
-            if(classDecl===null) {
+            if(!classDecl) {
                 throw new IllegalModelException('Could not find super type ' + this.superType, this.modelFile, this.ast.location);
             }
 
             // Prevent extending declaration with different type of declaration
-            const supertypeDeclaration = this.getModelFile().getType(this.superType);
-            if (supertypeDeclaration) {
-                if (this.constructor.name !== supertypeDeclaration.constructor.name) {
-                    let typeName = this.getSystemType();
-                    let superTypeName = supertypeDeclaration.getSystemType();
-                    throw new IllegalModelException(`${typeName} (${this.getName()}) cannot extend ${superTypeName} (${supertypeDeclaration.getName()})`, this.modelFile, this.ast.location);
-                }
+            if (this.constructor.name !== classDecl.constructor.name) {
+                let typeName = this.getSystemType();
+                let superTypeName = classDecl.getSystemType();
+                throw new IllegalModelException(`${typeName} (${this.getName()}) cannot extend ${superTypeName} (${classDecl.getName()})`, this.modelFile, this.ast.location);
             }
+            this.superTypeDeclaration = classDecl;
         }
 
         if(this.idField) {
@@ -431,16 +430,7 @@ class ClassDeclaration extends Decorated {
      * @return {ClassDeclaration} the super type declaration, or null if there is no super type.
      */
     getSuperTypeDeclaration() {
-        if (!this.superType) {
-            return null;
-        }
-
-        const supertypeDeclaration = this.getModelFile().getType(this.superType);
-        if (!supertypeDeclaration) {
-            throw new Error('Could not find super type: ' + this.superType);
-        }
-
-        return supertypeDeclaration;
+        return this.superTypeDeclaration;
     }
 
     /**

--- a/packages/composer-common/lib/model/typed.js
+++ b/packages/composer-common/lib/model/typed.js
@@ -164,9 +164,20 @@ class Typed {
      * qualified type name, false otherwise.
      */
     instanceOf(fqt) {
+        // Check to see if this is an exact instance of the specified type.
         const classDeclaration = this.getClassDeclaration();
-        return classDeclaration.getFullyQualifiedName() === fqt ||
-            classDeclaration.getAllSuperTypeDeclarations().some(declaration => declaration.getFullyQualifiedName() === fqt);
+        if (classDeclaration.getFullyQualifiedName() === fqt) {
+            return true;
+        }
+        // Now walk the class hierachy looking to see if it's an instance of the specified type.
+        let superTypeDeclaration = classDeclaration.getSuperTypeDeclaration();
+        while (superTypeDeclaration) {
+            if (superTypeDeclaration.getFullyQualifiedName() === fqt) {
+                return true;
+            }
+            superTypeDeclaration = superTypeDeclaration.getSuperTypeDeclaration();
+        }
+        return false;
     }
 
     /**

--- a/packages/composer-common/test/codegen/loopbackvisitor.js
+++ b/packages/composer-common/test/codegen/loopbackvisitor.js
@@ -544,6 +544,7 @@ describe('LoopbackVisitor', () => {
                     transaction MyTransaction{
                     }
                     `);
+                    modelFile.validate();
                     const schemas = modelFile.accept(visitor, { fileWriter: mockFileWriter });
                     schemas.should.deep.equal([{
                         acls: [],
@@ -601,6 +602,7 @@ describe('LoopbackVisitor', () => {
 
                     }
                     `);
+                    modelFile.validate();
                     const schemas = modelFile.accept(visitor, { fileWriter: mockFileWriter });
                     schemas.should.deep.equal([{
                         acls: [],
@@ -699,6 +701,7 @@ describe('LoopbackVisitor', () => {
                         o String theValue
                     }
                     `);
+                    modelFile.validate();
                     const schemas = modelFile.accept(visitor, { fileWriter: mockFileWriter });
                     schemas.should.deep.equal([{
                         acls: [],

--- a/packages/composer-common/test/introspect/assetdeclaration.js
+++ b/packages/composer-common/test/introspect/assetdeclaration.js
@@ -16,7 +16,6 @@
 
 const IllegalModelException = require('../../lib/introspect/illegalmodelexception');
 const AssetDeclaration = require('../../lib/introspect/assetdeclaration');
-const ClassDeclaration = require('../../lib/introspect/classdeclaration');
 const ModelFile = require('../../lib/introspect/modelfile');
 const ModelManager = require('../../lib/modelmanager');
 const fs = require('fs');
@@ -37,7 +36,7 @@ describe('AssetDeclaration', () => {
         mockSystemAsset = sinon.createStubInstance(AssetDeclaration);
         mockSystemAsset.getFullyQualifiedName.returns('org.hyperledger.composer.system.Asset');
         mockModelManager.getSystemTypes.returns([mockSystemAsset]);
-        mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+        mockClassDeclaration = sinon.createStubInstance(AssetDeclaration);
         mockModelManager.getType.returns(mockClassDeclaration);
         mockClassDeclaration.getProperties.returns([]);
     });
@@ -140,22 +139,6 @@ describe('AssetDeclaration', () => {
                 err.message.should.match(/Asset is a reserved type name./);
             }
         });
-    });
-
-    describe('#getSuperType', () => {
-
-        it('should return the fully qualified super type', () => {
-            let asset = loadLastAssetDeclaration('test/data/parser/assetdeclaration.json.cto');
-            asset.getSuperType().should.equal('com.hyperledger.testing.BaseAsset');
-        });
-
-        it('should throw when the super type is missing', () => {
-            let asset = loadAssetDeclaration('test/data/parser/assetdeclaration.missingsuper.cto');
-            (() => {
-                asset.getSuperType();
-            }).should.throw(/Could not find super type/);
-        });
-
     });
 
     describe('#getProperty', () => {

--- a/packages/composer-common/test/introspect/participantdeclaration.js
+++ b/packages/composer-common/test/introspect/participantdeclaration.js
@@ -15,7 +15,6 @@
 'use strict';
 
 const ParticipantDeclaration = require('../../lib/introspect/participantdeclaration');
-const ClassDeclaration = require('../../lib/introspect/classdeclaration');
 const ModelFile = require('../../lib/introspect/modelfile');
 const ModelManager = require('../../lib/modelmanager');
 const fs = require('fs');
@@ -25,29 +24,15 @@ const sinon = require('sinon');
 
 describe('ParticipantDeclaration', () => {
 
-    let mockModelManager;
-    let mockClassDeclaration;
-    let mockSystemParticipant;
-    let sandbox;
+    let modelManager;
 
     beforeEach(() => {
-        sandbox = sinon.sandbox.create();
-        mockModelManager =  sinon.createStubInstance(ModelManager);
-        mockSystemParticipant = sinon.createStubInstance(ParticipantDeclaration);
-        mockSystemParticipant.getFullyQualifiedName.returns('org.hyperledger.composer.system.Participant');
-        mockModelManager.getSystemTypes.returns([mockSystemParticipant]);
-        mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
-        mockModelManager.getType.returns(mockClassDeclaration);
-        mockClassDeclaration.getProperties.returns([]);
-    });
-
-    afterEach(() => {
-        sandbox.restore();
+        modelManager = new ModelManager();
     });
 
     let loadParticipantDeclaration = (modelFileName) => {
         let modelDefinitions = fs.readFileSync(modelFileName, 'utf8');
-        let modelFile = new ModelFile(mockModelManager, modelDefinitions);
+        let modelFile = new ModelFile(modelManager, modelDefinitions);
         let assets = modelFile.getParticipantDeclarations();
         assets.should.have.lengthOf(1);
 

--- a/packages/composer-runtime/lib/accesscontroller.js
+++ b/packages/composer-runtime/lib/accesscontroller.js
@@ -159,16 +159,16 @@ class AccessController {
         const method = 'matchRule';
         LOG.entry(method, resource, access, participant, transaction, aclRule);
 
-        // Is the ACL rule relevant to the specified noun?
-        if (!this.matchNoun(resource, aclRule)) {
-            LOG.debug(method, 'Noun does not match');
+        // Is the ACL rule relevant to the specified verb?
+        if (!this.matchVerb(access, aclRule)) {
+            LOG.debug(method, 'Verb does not match');
             LOG.exit(method, false);
             return false;
         }
 
-        // Is the ACL rule relevant to the specified verb?
-        if (!this.matchVerb(access, aclRule)) {
-            LOG.debug(method, 'Verb does not match');
+        // Is the ACL rule relevant to the specified noun?
+        if (!this.matchNoun(resource, aclRule)) {
+            LOG.debug(method, 'Noun does not match');
             LOG.exit(method, false);
             return false;
         }


### PR DESCRIPTION
ACL rule execution is inefficient #2576 

Super type declaration lookup is not cached, which means we look it up every time we execute an ACL rule. This also slows down the `instanceOf` check, so lets improve those things.