### PR TITLE
reduce parsing and getters

### DIFF
--- a/packages/composer-runtime/lib/identitymanager.js
+++ b/packages/composer-runtime/lib/identitymanager.js
@@ -73,41 +73,41 @@ class IdentityManager extends TransactionHandler {
                 // Check to see if the identity exists.
                 identityRegistry = identityRegistry_;
                 identifier = this.identityService.getIdentifier();
-                identityName = this.identityService.getName();
-                return identityRegistry.exists(identifier);
-
+                return identityRegistry.get(identifier)
+                .catch(() => {
+                    return null;
+                });
             })
-            .then((exists) => {
+            .then((identity) => {
 
                 // If it doesn't exist, then try again with the temporary identifier, which is hash(name, issuer).
-                if (!exists) {
+                if (!identity) {
                     const sha256 = createHash('sha256');
                     const name = this.identityService.getName();
                     const issuer = this.identityService.getIssuer();
                     sha256.update(name, 'utf8');
                     sha256.update(issuer, 'utf8');
                     identifier = sha256.digest('hex');
-                    return identityRegistry.exists(identifier);
+                    return identityRegistry.get(identifier)
+                    .catch(() => {
+                        return null;
+                    });
                 } else {
-                    return exists;
+                    return identity;
                 }
-
             })
-            .then((exists) => {
+            .then((identity) => {
 
                 // If it still doesn't exist, throw!
-                if (!exists) {
-                    const error = new Error('The current identity has not been registered: '+identityName);
-                    error.identityName=identityName;
+                if (!identity) {
+                    identityName = this.identityService.getName();
+                    const error = new Error('The current identity has not been registered: ' + identityName);
+                    error.identityName = identityName;
                     LOG.error(method, error);
                     throw error;
                 }
 
-                // Get the identity.
-                return identityRegistry.get(identifier);
-
-            })
-            .then((identity) => {
+                // Return the identity.
                 LOG.exit(method, identity);
                 return identity;
             });

--- a/packages/composer-runtime/test/identitymanager.js
+++ b/packages/composer-runtime/test/identitymanager.js
@@ -77,7 +77,6 @@ describe('IdentityManager', () => {
         it('should look up an identity using the identifier', () => {
             mockIdentityService.getIdentifier.returns('7d85a9672abea0dfa45705eed99a536b8470d192e2a17e50c1fb86cb4bccae63');
             let identity = factory.newResource('org.hyperledger.composer.system', 'Identity', '7d85a9672abea0dfa45705eed99a536b8470d192e2a17e50c1fb86cb4bccae63');
-            mockIdentityRegistry.exists.withArgs('7d85a9672abea0dfa45705eed99a536b8470d192e2a17e50c1fb86cb4bccae63').resolves(true);
             mockIdentityRegistry.get.withArgs('7d85a9672abea0dfa45705eed99a536b8470d192e2a17e50c1fb86cb4bccae63').resolves(identity);
             return identityManager.getIdentity()
                 .should.eventually.be.equal(identity);
@@ -85,11 +84,10 @@ describe('IdentityManager', () => {
 
         it('should look up an issued identity using the name and issuer', () => {
             mockIdentityService.getIdentifier.returns('7d85a9672abea0dfa45705eed99a536b8470d192e2a17e50c1fb86cb4bccae63');
-            mockIdentityRegistry.exists.withArgs('7d85a9672abea0dfa45705eed99a536b8470d192e2a17e50c1fb86cb4bccae63').resolves(false);
+            mockIdentityRegistry.get.withArgs('7d85a9672abea0dfa45705eed99a536b8470d192e2a17e50c1fb86cb4bccae63').rejects();
             mockIdentityService.getName.returns('admin');
             mockIdentityService.getIssuer.returns('26341f1fc63f30886c54abeba3aca520601126ae2a57869d1ec1a3f854ebc417');
             let identity = factory.newResource('org.hyperledger.composer.system', 'Identity', '9f8b1a1e7280d40f4f14577ee4329473c60f04db3ea0f40c91f9684558c6ab50');
-            mockIdentityRegistry.exists.withArgs('9f8b1a1e7280d40f4f14577ee4329473c60f04db3ea0f40c91f9684558c6ab50').resolves(true);
             mockIdentityRegistry.get.withArgs('9f8b1a1e7280d40f4f14577ee4329473c60f04db3ea0f40c91f9684558c6ab50').resolves(identity);
             return identityManager.getIdentity()
                 .should.eventually.be.equal(identity);
@@ -97,10 +95,10 @@ describe('IdentityManager', () => {
 
         it('should throw for an identity that does not exist', () => {
             mockIdentityService.getIdentifier.returns('7d85a9672abea0dfa45705eed99a536b8470d192e2a17e50c1fb86cb4bccae63');
-            mockIdentityRegistry.exists.withArgs('7d85a9672abea0dfa45705eed99a536b8470d192e2a17e50c1fb86cb4bccae63').resolves(false);
+            mockIdentityRegistry.get.withArgs('7d85a9672abea0dfa45705eed99a536b8470d192e2a17e50c1fb86cb4bccae63').rejects();
             mockIdentityService.getName.returns('admin');
             mockIdentityService.getIssuer.returns('26341f1fc63f30886c54abeba3aca520601126ae2a57869d1ec1a3f854ebc417');
-            mockIdentityRegistry.exists.withArgs('9f8b1a1e7280d40f4f14577ee4329473c60f04db3ea0f40c91f9684558c6ab50').resolves(false);
+            mockIdentityRegistry.get.withArgs('9f8b1a1e7280d40f4f14577ee4329473c60f04db3ea0f40c91f9684558c6ab50').rejects();
             return identityManager.getIdentity()
                 .should.be.rejectedWith(/The current identity has not been registered/);
         });


### PR DESCRIPTION
Contributes to #2576

- engine.queries was serialising and deserialising the same thing, we can  pass the original instead
- identitymanager was also inefficient, we can speed it up by doing a get and dealing with an exception if it is thrown due to not being there
- no test fixes for engine.queries required, test fixes for identitymanager due to the change in `.get()`

Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>
