### PR TITLE
Undo all of the CLI changes for network admins

### DIFF
--- a/packages/composer-admin/lib/adminconnection.js
+++ b/packages/composer-admin/lib/adminconnection.js
@@ -549,7 +549,7 @@ class AdminConnection {
      * });
      * @param {BusinessNetworkDefinition} businessNetworkDefinition - The business network to start
      * @param {Object} [startOptions] connector specific start options
-     *                  NetworkAdmins:   [ { name, certificate } , { name, enrollmentSecret  }]
+     *                  networkAdmins:   [ { userName, certificate } , { userName, enrollmentSecret  }]
      *
      * @return {Promise} A promise that will be fufilled when the business network has been
      * deployed - with a MAP of cards key is name

--- a/packages/composer-cli/lib/cmds/archive/createCommand.js
+++ b/packages/composer-cli/lib/cmds/archive/createCommand.js
@@ -45,9 +45,6 @@ module.exports.builder = function (yargs){
     // enforce singletons
     yargs.check(checkFn);
 
-    // grouping for the card options - moves them away from the standard --version etc.
-    yargs.group(['archiveFile','sourceType','sourceName'],'Archive options');
-
     return yargs;
 };
 

--- a/packages/composer-cli/lib/cmds/card/createCommand.js
+++ b/packages/composer-cli/lib/cmds/card/createCommand.js
@@ -46,9 +46,6 @@ module.exports.builder = function (yargs) {
     // enforce the option after these options
     yargs.requiresArg(['file','businessNetworkName','connectionProfileFile','user','enrollSecret','certificate','privateKey','roles']);
 
-    // grouping for the card options - moves them away from the standard --version etc.
-    yargs.group(['f','n','p','u','s','c','k','r'],'Card options');
-
     yargs.implies('certificate','privateKey');
     yargs.implies('privateKey','certificate');
 

--- a/packages/composer-cli/lib/cmds/card/deleteCommand.js
+++ b/packages/composer-cli/lib/cmds/card/deleteCommand.js
@@ -23,7 +23,6 @@ module.exports.builder = (yargs) => {
         name: { alias: 'n', required: true, describe: 'The name of the card to delete', type: 'string' }
     });
 
-    yargs.group(['n'],'Card options');
     yargs.requiresArg(['n']);
 
     return yargs;

--- a/packages/composer-cli/lib/cmds/identity/issueCommand.js
+++ b/packages/composer-cli/lib/cmds/identity/issueCommand.js
@@ -28,9 +28,6 @@ module.exports.builder =function (yargs) {
         'file': {alias: 'f', required: false, describe: 'The card file name for the new identity', type: 'string' }
     });
 
-    yargs.group(['c','f'],'Business Network Cards');
-    yargs.group(['u','a','x'],'Identity Options');
-
     return yargs;
 };
 

--- a/packages/composer-cli/lib/cmds/network/deployCommand.js
+++ b/packages/composer-cli/lib/cmds/network/deployCommand.js
@@ -26,7 +26,7 @@ module.exports.builder = function (yargs) {
         optionsFile: { alias: 'O', required: false, describe: 'A file containing options that are specific to connection', type: 'string' },
         networkAdmin: { alias: 'A', required: true, description: 'The identity name of the business network administrator', type: 'string' },
         networkAdminCertificateFile: { alias: 'C', required: false, description: 'The certificate of the business network administrator', type: 'string' },
-        networkAdminSecret: { alias: 'S', required: false, description: 'The enrollment secret for the business network administrator', type: 'string' },
+        networkAdminEnrollSecret: { alias: 'S', required: false, description: 'The enrollment secret for the business network administrator', type: 'string' },
         card: { alias: 'c', required: true, description: 'The cardname to use to deploy the network', type:'string'},
         file: { alias: 'f', required: false, description: 'File name of the card to be created', type: 'string'}
     });
@@ -36,9 +36,6 @@ module.exports.builder = function (yargs) {
 
     // Mark the options that conflict
     yargs.conflicts('C','S');
-
-    // group the options
-    yargs.group(['loglevel','file','archiveFile','networkAdmin','networkAdminCertificateFile','networkAdminEnrollSecret','card'],'Deploy Options');
 
     return yargs;
 };

--- a/packages/composer-cli/lib/cmds/network/lib/start.js
+++ b/packages/composer-cli/lib/cmds/network/lib/start.js
@@ -77,7 +77,7 @@ class Start {
             // grab the network admins
             // what we want is an array of the following
             // {userName, certificate, secret, file}
-            startOptions.networkAdmins = networkAdmins = Start.createNetworkAdmins(argv);
+            startOptions.networkAdmins = networkAdmins = cmdUtil.parseNetworkAdmins(argv);
             cmdUtil.log(chalk.bold.blue('Processing these Network Admins: '));
             startOptions.networkAdmins.forEach((e)=>{
                 cmdUtil.log(chalk.blue('\tuserName: ')+e.userName);
@@ -149,68 +149,6 @@ class Start {
             throw new Error('Archive file '+archiveFile+' does not exist.');
         }
         return archiveFileContents;
-    }
-
-    /** Parse the argv structure to get an array of Network Admins
-     * @param {array} argv standard YARGS structure
-     * @return {array} simple objects with details of the network admins to create
-     */
-    static createNetworkAdmins(argv){
-        let networkAdmins;
-        if (typeof argv.networkAdmin.id === 'object'){
-
-            networkAdmins = Object.keys(argv.networkAdmin.id).map((index)=>{
-                let admin={};
-                admin.userName = argv.networkAdmin.id[index];
-                if (argv.networkAdmin.cert && argv.networkAdmin.cert[index]){
-                    admin.certificate = argv.networkAdmin.cert[index];
-                }
-
-                if (!admin.certificate && argv.networkAdmin.secret) {
-                    admin.secret = argv.networkAdmin.secret[index];
-                } else {
-                    throw new Error('Need to have certificate or secret');
-                }
-
-                if (argv.networkAdmin.file && argv.networkAdmin.file[index]){
-                    admin.file = argv.networkAdmin.file[index];
-                }
-                return admin;
-            });
-
-        } else if (typeof argv.networkAdmin === 'object') {
-            let admin={};
-            admin.userName = argv.networkAdmin.id;
-            if (argv.networkAdmin.certificate){
-                admin.certificate = argv.networkAdmin.certificate;
-            } else if (argv.networkAdmin.secret){
-                admin.enrollmentSecret  = argv.networkAdmin.secret;
-            } else {
-                throw new Error('Need to have certificate or secret');
-            }
-
-            if (argv.networkAdmin.file){
-                admin.file = argv.networkAdmin.file;
-            }
-            networkAdmins = [ admin ];
-        } else {
-            // old school
-            let admin={};
-            admin.userName = argv.networkAdmin;
-            if (argv.networkAdminCertificateFile){
-                admin.certificate = argv.networkAdminCertificateFile;
-            } else if (argv.networkAdminSecret){
-                admin.enrollmentSecret  = argv.networkAdminSecret;
-            } else {
-                throw new Error('Need to have certificate or secret');
-            }
-
-            if (argv.file){
-                admin.file = argv.file;
-            }
-            networkAdmins = [ admin ];
-        }
-        return networkAdmins;
     }
 }
 module.exports = Start;

--- a/packages/composer-cli/lib/cmds/network/startCommand.js
+++ b/packages/composer-cli/lib/cmds/network/startCommand.js
@@ -26,7 +26,7 @@ module.exports.builder = function (yargs) {
         optionsFile: { alias: 'O', required: false, describe: 'A file containing options that are specific to connection', type: 'string' },
         networkAdmin: { alias: 'A', required: true, description: 'The identity name of the business network administrator', type: 'string' },
         networkAdminCertificateFile: { alias: 'C', required: false, description: 'The certificate of the business network administrator', type: 'string' },
-        networkAdminSecret: { alias: 'S', required: false, description: 'The enrollment secret for the business network administrator', type: 'string', default: undefined },
+        networkAdminEnrollSecret: { alias: 'S', required: false, description: 'The enrollment secret for the business network administrator', type: 'string', default: undefined },
         card: { alias: 'c', required: true, description: 'The cardname to use to start the network', type:'string'},
         file: { alias: 'f', required: false, description: 'File name of the card to be created', type: 'string'}
     });

--- a/packages/composer-cli/lib/cmds/participant/addCommand.js
+++ b/packages/composer-cli/lib/cmds/participant/addCommand.js
@@ -41,8 +41,6 @@ module.exports.builder = (yargs) =>{
 
     yargs.check(checkFn);
 
-    yargs.group(['card','data'],'Participant options');
-
     return yargs;
 };
 

--- a/packages/composer-cli/lib/cmds/utils/cmdutils.js
+++ b/packages/composer-cli/lib/cmds/utils/cmdutils.js
@@ -18,10 +18,7 @@ const AdminConnection = require('composer-admin').AdminConnection;
 const BusinessNetworkCardStore = require('composer-common').BusinessNetworkCardStore;
 const BusinessNetworkConnection = require('composer-client').BusinessNetworkConnection;
 const fs = require('fs');
-const Logger = require('composer-common').Logger;
 const prompt = require('prompt');
-
-const LOG = Logger.getLog('CmdUtil');
 
 /**
  * Internal Utility Class
@@ -114,7 +111,7 @@ class CmdUtil {
             const certificateFile = networkAdminCertificateFiles[index];
             const certificate = fs.readFileSync(certificateFile, { encoding: 'utf8' });
             return {
-                name: networkAdmin,
+                userName: networkAdmin,
                 certificate
             };
 
@@ -134,10 +131,10 @@ class CmdUtil {
         return networkAdmins.map((networkAdmin, index) => {
 
             // Grab the secret for the network admin.
-            const secret = networkAdminEnrollSecrets[index];
+            const enrollmentSecret = networkAdminEnrollSecrets[index];
             return {
-                name: networkAdmin,
-                secret
+                userName: networkAdmin,
+                enrollmentSecret
             };
 
         });
@@ -155,6 +152,7 @@ class CmdUtil {
         const networkAdmins = CmdUtil.arrayify(argv.networkAdmin);
         const networkAdminCertificateFiles = CmdUtil.arrayify(argv.networkAdminCertificateFile);
         const networkAdminEnrollSecrets = CmdUtil.arrayify(argv.networkAdminEnrollSecret);
+        const files = CmdUtil.arrayify(argv.file);
 
         // It's valid not to specify any network administrators.
         if (networkAdmins.length === 0) {
@@ -167,85 +165,32 @@ class CmdUtil {
         }
 
         // Check that enough certificate files have been specified.
+        let result;
         if (networkAdmins.length === networkAdminCertificateFiles.length) {
-            return CmdUtil.parseNetworkAdminsWithCertificateFiles(networkAdmins, networkAdminCertificateFiles);
+            result = CmdUtil.parseNetworkAdminsWithCertificateFiles(networkAdmins, networkAdminCertificateFiles);
         }
 
         // Check that enough enrollment secrets have been specified.
-        if (networkAdmins.length === networkAdminEnrollSecrets.length) {
-            return CmdUtil.parseNetworkAdminsWithEnrollSecrets(networkAdmins, networkAdminEnrollSecrets);
+        else if (networkAdmins.length === networkAdminEnrollSecrets.length) {
+            result = CmdUtil.parseNetworkAdminsWithEnrollSecrets(networkAdmins, networkAdminEnrollSecrets);
         }
 
         // Not enough certificate files or enrollment secrets!
-        throw new Error('You must specify certificate files or enrollment secrets for all network administrators');
+        else {
+            console.log(JSON.stringify(argv, null, 4));
+            throw new Error('You must specify certificate files or enrollment secrets for all network administrators');
+        }
 
-    }
-
-    /**
-     * Build the bootstrap transactions for any business network administrators specified on the command line.
-     * @param {BusinessNetworkDefinition} businessNetworkDefinitinon The business network definition.
-     * @param {Object} argv The command line arguments as parsed by yargs.
-     * @return {Object[]} The bootstrap transactions.
-     */
-    static buildBootstrapTransactions(businessNetworkDefinitinon, argv) {
-        const method = 'buildBootstrapTransactions';
-        LOG.entry(method, businessNetworkDefinitinon, argv);
-
-        // Grab the useful things from the business network definition.
-        const factory = businessNetworkDefinitinon.getFactory();
-        const serializer = businessNetworkDefinitinon.getSerializer();
-
-        // Parse the network administrators.
-        const networkAdmins = CmdUtil.parseNetworkAdmins(argv);
-
-        // Convert the network administrators into add participant transactions.
-        const addParticipantTransactions = networkAdmins.map((networkAdmin) => {
-            const participant = factory.newResource('org.hyperledger.composer.system', 'NetworkAdmin', networkAdmin.name);
-            const targetRegistry = factory.newRelationship('org.hyperledger.composer.system', 'ParticipantRegistry', participant.getFullyQualifiedType());
-            const addParticipantTransaction = factory.newTransaction('org.hyperledger.composer.system', 'AddParticipant');
-            Object.assign(addParticipantTransaction, {
-                resources: [ participant ],
-                targetRegistry
+        // If any files specified, check we have enough, and merge them into the result.
+        if (files.length && files.length !== result.length) {
+            throw new Error('If you specify a network administrators card file name, you must specify one for all network administrators');
+        } else if (files.length) {
+            files.forEach((file, index) => {
+                result[index].file = file;
             });
-            LOG.debug(method, 'Created bootstrap transaction to add participant', addParticipantTransaction);
-            return addParticipantTransaction;
-        });
+        }
+        return result;
 
-        // Convert the network administrators into issue or bind identity transactions.
-        const identityTransactions = networkAdmins.map((networkAdmin) => {
-
-            // Handle a certificate which requires a bind identity transaction.
-            let identityTransaction;
-            if (networkAdmin.certificate) {
-                identityTransaction = factory.newTransaction('org.hyperledger.composer.system', 'BindIdentity');
-                Object.assign(identityTransaction, {
-                    participant: factory.newRelationship('org.hyperledger.composer.system', 'NetworkAdmin', networkAdmin.name),
-                    certificate: networkAdmin.certificate
-                });
-                LOG.debug(method, 'Created bootstrap transaction to bind identity', identityTransaction);
-            }
-
-            // Handle an enrollment secret which requires an issue identity transactiom.
-            if (networkAdmin.secret) {
-                identityTransaction = factory.newTransaction('org.hyperledger.composer.system', 'IssueIdentity');
-                Object.assign(identityTransaction, {
-                    participant: factory.newRelationship('org.hyperledger.composer.system', 'NetworkAdmin', networkAdmin.name),
-                    identityName: networkAdmin.name
-                });
-                LOG.debug(method, 'Created bootstrap transaction to issue identity', identityTransaction);
-            }
-            return identityTransaction;
-
-        });
-
-        // Serialize all of the transactions into a single array.
-        const transactions = addParticipantTransactions.concat(identityTransactions);
-        const json = transactions.map((transaction) => {
-            return serializer.toJSON(transaction);
-        });
-
-        LOG.exit(method, json);
-        return json;
     }
 
     /**

--- a/packages/composer-cli/test/archive/archive.js
+++ b/packages/composer-cli/test/archive/archive.js
@@ -35,7 +35,6 @@ describe('composer archive cmd launcher unit tests', function () {
         sandbox = sinon.sandbox.create();
         sandbox.stub(yargs, 'check').returns(yargs);
         sandbox.stub(yargs, 'conflicts').returns(yargs);
-        sandbox.stub(yargs, 'group').returns(yargs);
         sandbox.stub(yargs, 'options').returns(yargs);
         sandbox.stub(yargs, 'usage').returns(yargs);
         sandbox.stub(yargs, 'requiresArg').returns(yargs);
@@ -74,7 +73,6 @@ describe('composer archive cmd launcher unit tests', function () {
             sinon.assert.calledOnce(yargs.options);
             sinon.assert.calledOnce(yargs.requiresArg);
             sinon.assert.calledOnce(yargs.check);
-            sinon.assert.calledOnce(yargs.group);
         });
 
 

--- a/packages/composer-cli/test/card/card.js
+++ b/packages/composer-cli/test/card/card.js
@@ -35,7 +35,6 @@ describe('composer participant cmd launcher unit tests', function () {
 
         sandbox.stub(yargs, 'check').returns(yargs);
         sandbox.stub(yargs, 'conflicts').returns(yargs);
-        sandbox.stub(yargs, 'group').returns(yargs);
         sandbox.stub(yargs, 'options').returns(yargs);
         sandbox.stub(yargs, 'requiresArg').returns(yargs);
         sandbox.stub(yargs, 'demandCommand').returns(yargs);
@@ -64,14 +63,12 @@ describe('composer participant cmd launcher unit tests', function () {
         it('should drive the yargs builder fn correctly',()=>{
             cardCommand.builder(yargs);
             sinon.assert.calledOnce(yargs.options);
-            sinon.assert.calledOnce(yargs.group);
             sinon.assert.calledOnce(yargs.check);
         });
 
         it('should drive the yargs builder fn correctly',()=>{
             deleteCommand.builder(yargs);
             sinon.assert.calledOnce(yargs.options);
-            sinon.assert.calledOnce(yargs.group);
             sinon.assert.calledOnce(yargs.requiresArg);
         });
     });

--- a/packages/composer-cli/test/identity/identity.js
+++ b/packages/composer-cli/test/identity/identity.js
@@ -33,7 +33,6 @@ describe('composer identity cmd launcher unit tests', function () {
         sandbox = sinon.sandbox.create();
         sandbox.stub(yargs, 'usage').returns(yargs);
         sandbox.stub(yargs, 'conflicts').returns(yargs);
-        sandbox.stub(yargs, 'group').returns(yargs);
         sandbox.stub(yargs, 'options').returns(yargs);
         sandbox.stub(yargs, 'requiresArg').returns(yargs);
         sandbox.stub(yargs, 'demandCommand').returns(yargs);
@@ -63,7 +62,6 @@ describe('composer identity cmd launcher unit tests', function () {
         it('should drive the yargs builder fn correctly',()=>{
             issueCommand.builder(yargs);
             sinon.assert.calledOnce(yargs.options);
-            sinon.assert.calledTwice(yargs.group);
         });
 
     });

--- a/packages/composer-cli/test/network/deploy.js
+++ b/packages/composer-cli/test/network/deploy.js
@@ -82,7 +82,7 @@ describe('composer deploy network CLI unit tests', function () {
                         ,archiveFile: 'testArchiveFile.zip'
                        ,optionsFile: '/path/to/options.json'
                        ,networkAdmin: 'admin'
-                       ,networkAdminSecret:'true'
+                       ,networkAdminEnrollSecret:'true'
                        ,file:'default'
             };
 
@@ -133,7 +133,7 @@ describe('composer deploy network CLI unit tests', function () {
                         ,archiveFile: 'testArchiveFile.zip'
                         ,option: 'endorsementPolicyFile=/path/to/some/file.json'
                         ,networkAdmin: 'admin'
-                        ,networkAdminSecret:'secret-secret'};
+                        ,networkAdminEnrollSecret:'secret-secret'};
 
             sandbox.stub(Deploy, 'getArchiveFileContents');
             sandbox.stub(Start, 'getArchiveFileContents');
@@ -167,7 +167,7 @@ describe('composer deploy network CLI unit tests', function () {
             let argv = {card:'cardname'
                         ,archiveFile: 'testArchiveFile.zip'
                         ,networkAdmin: 'admin'
-                        ,networkAdminSecret:'secret-secret'
+                        ,networkAdminEnrollSecret:'secret-secret'
                         ,option: 'endorsementPolicy=' + VALID_ENDORSEMENT_POLICY_STRING};
 
             sandbox.stub(Deploy, 'getArchiveFileContents');
@@ -196,7 +196,7 @@ describe('composer deploy network CLI unit tests', function () {
             let argv = {card:'cardname'
                         ,archiveFile: 'testArchiveFile.zip'
                         ,networkAdmin: 'admin'
-                        ,networkAdminSecret:'secret-secret'
+                        ,networkAdminEnrollSecret:'secret-secret'
                         ,file:'writetothisfile'};
 
 
@@ -225,7 +225,7 @@ describe('composer deploy network CLI unit tests', function () {
                        ,archiveFile: 'testArchiveFile.zip'
                        ,loglevel: 'DEBUG'
                        ,networkAdmin: 'admin'
-                       ,networkAdminSecret:'secret-secret'};
+                       ,networkAdminEnrollSecret:'secret-secret'};
 
             sandbox.stub(Deploy, 'getArchiveFileContents');
             sandbox.stub(Start, 'getArchiveFileContents');
@@ -291,7 +291,7 @@ describe('composer deploy network CLI unit tests', function () {
 
             let argv = {card:'cardname'
                         ,networkAdmin: 'admin1'
-                        ,networkAdminSecret: 'secret-secret'};
+                        ,networkAdminEnrollSecret: 'secret-secret'};
 
             sandbox.stub(Deploy, 'getArchiveFileContents');
             sandbox.stub(Start, 'getArchiveFileContents');
@@ -318,7 +318,7 @@ describe('composer deploy network CLI unit tests', function () {
 
             let argv = {card:'cardname'
                         ,networkAdmin: 'admin1'
-                        ,networkAdminSecret: 'secret-secret'
+                        ,networkAdminEnrollSecret: 'secret-secret'
                         ,optionsFile: '/path/to/options.json'};
 
             sandbox.stub(Deploy, 'getArchiveFileContents');
@@ -393,7 +393,7 @@ describe('composer deploy network CLI unit tests', function () {
 
             let argv = {card:'cardname'
                             ,networkAdmin: 'admin1'
-                            ,networkAdminSecret: 'secret-secret'
+                            ,networkAdminEnrollSecret: 'secret-secret'
                             ,archiveFile: 'testArchiveFile.zip'};
 
             sandbox.stub(Deploy, 'getArchiveFileContents').withArgs(argv.archiveFile).throws(new Error('failure'));
@@ -407,7 +407,7 @@ describe('composer deploy network CLI unit tests', function () {
 
             let argv = {card:'cardname'
                                         ,networkAdmin: 'admin1'
-                                        ,networkAdminSecret: 'secret-secret'
+                                        ,networkAdminEnrollSecret: 'secret-secret'
                                         ,archiveFile: 'testArchiveFile.zip'};
 
             sandbox.stub(Deploy, 'getArchiveFileContents');

--- a/packages/composer-cli/test/network/network.js
+++ b/packages/composer-cli/test/network/network.js
@@ -34,7 +34,6 @@ describe('composer network cmd launcher unit tests', function () {
         sandbox = sinon.sandbox.create();
         sandbox.stub(yargs, 'usage').returns(yargs);
         sandbox.stub(yargs, 'conflicts').returns(yargs);
-        sandbox.stub(yargs, 'group').returns(yargs);
         sandbox.stub(yargs, 'options').returns(yargs);
         sandbox.stub(yargs, 'requiresArg').returns(yargs);
         sandbox.stub(yargs, 'demandCommand').returns(yargs);
@@ -74,7 +73,6 @@ describe('composer network cmd launcher unit tests', function () {
             sinon.assert.calledOnce(yargs.options);
             sinon.assert.calledOnce(yargs.requiresArg);
             sinon.assert.calledOnce(yargs.conflicts);
-            sinon.assert.calledOnce(yargs.group);
         });
     });
 });

--- a/packages/composer-cli/test/network/start.js
+++ b/packages/composer-cli/test/network/start.js
@@ -79,7 +79,7 @@ describe('composer start network CLI unit tests', function () {
                         ,archiveFile: 'testArchiveFile.zip'
                        ,optionsFile: '/path/to/options.json'
                        ,networkAdmin: 'admin'
-                       ,networkAdminSecret:'true'};
+                       ,networkAdminEnrollSecret:'true'};
             sandbox.stub(Start, 'getArchiveFileContents');
             const optionsObject = {
                 endorsementPolicy: {
@@ -121,7 +121,7 @@ describe('composer start network CLI unit tests', function () {
             let argv = {card:'cardname'
                        ,option: 'endorsementPolicyFile=/path/to/some/file.json'
                        ,networkAdmin: 'admin'
-                       ,networkAdminSecret:'true'};
+                       ,networkAdminEnrollSecret:'true'};
             sandbox.stub(Start, 'getArchiveFileContents');
 
             Start.getArchiveFileContents.withArgs(argv.archiveFile).returns(testBusinessNetworkArchive);
@@ -150,7 +150,7 @@ describe('composer start network CLI unit tests', function () {
                        ,archiveFile: 'testArchiveFile.zip'
                        ,option: 'endorsementPolicy=' + VALID_ENDORSEMENT_POLICY_STRING
                        ,networkAdmin: 'admin'
-                       ,networkAdminSecret:'true'};
+                       ,networkAdminEnrollSecret:'true'};
 
             sandbox.stub(Start, 'getArchiveFileContents');
 
@@ -179,7 +179,7 @@ describe('composer start network CLI unit tests', function () {
             let argv = {card:'cardname'
                        ,archiveFile: 'testArchiveFile.zip'
                        ,networkAdmin: 'admin'
-                       ,networkAdminSecret:'true'};
+                       ,networkAdminEnrollSecret:'true'};
 
             sandbox.stub(Start, 'getArchiveFileContents');
 
@@ -230,7 +230,7 @@ describe('composer start network CLI unit tests', function () {
             let argv = {card:'cardname'
                                    ,archiveFile: 'testArchiveFile.zip'
                                    ,networkAdmin: 'admin'
-                                   ,networkAdminSecret:'true'
+                                   ,networkAdminEnrollSecret:'true'
                                 ,file:'mycardfile'};
 
             sandbox.stub(Start, 'getArchiveFileContents');
@@ -258,7 +258,7 @@ describe('composer start network CLI unit tests', function () {
                        ,archiveFile: 'testArchiveFile.zip'
                        ,loglevel: 'DEBUG'
                        ,networkAdmin: 'admin'
-                       ,networkAdminSecret:'true'};
+                       ,networkAdminEnrollSecret:'true'};
 
             sandbox.stub(Start, 'getArchiveFileContents');
 
@@ -283,7 +283,7 @@ describe('composer start network CLI unit tests', function () {
             let argv = {card:'cardname'
                        ,archiveFile: 'testArchiveFile.zip'
                        ,networkAdmin: 'admin'
-                       ,networkAdminSecret:'true'};
+                       ,networkAdminEnrollSecret:'true'};
 
             sandbox.stub(Start, 'getArchiveFileContents');
 
@@ -318,7 +318,7 @@ describe('composer start network CLI unit tests', function () {
             let argv = {card:'cardname'
                         ,archiveFile: 'testArchiveFile.zip'
                         ,networkAdmin: 'admin1'
-                        ,networkAdminSecret: true};
+                        ,networkAdminEnrollSecret: true};
 
             sandbox.stub(Start, 'getArchiveFileContents');
 
@@ -344,7 +344,7 @@ describe('composer start network CLI unit tests', function () {
                         ,archiveFile: 'testArchiveFile.zip'
 
                         ,networkAdmin: 'admin1'
-                        ,networkAdminSecret: true
+                        ,networkAdminEnrollSecret: true
                         ,optionsFile: '/path/to/options.json'};
 
 
@@ -386,7 +386,7 @@ describe('composer start network CLI unit tests', function () {
             let argv = {card:'cardname'
                 ,archiveFile: 'testArchiveFile.zip'
                 ,networkAdmin: 'admin1'
-                ,networkAdminSecret: true
+                ,networkAdminEnrollSecret: true
                 ,optionsFile: '/path/to/options.json'};
 
             sandbox.stub(Start, 'getArchiveFileContents');
@@ -404,7 +404,7 @@ describe('composer start network CLI unit tests', function () {
             ,archiveFile: 'testArchiveFile.zip'
 
             ,networkAdmin: 'admin1'
-            ,networkAdminSecret: true
+            ,networkAdminEnrollSecret: true
             ,optionsFile: '/path/to/options.json'};
 
             sandbox.stub(Start, 'getArchiveFileContents');
@@ -422,8 +422,9 @@ describe('composer start network CLI unit tests', function () {
 
             let argv = {card:'cardname'
                                     ,archiveFile: 'testArchiveFile.zip'
-                                    , 'networkAdmin': { id: 'admin1',secret: 'true', file: 'mycard'}
-            };
+                                    ,networkAdmin: 'admin1'
+                                    ,networkAdminEnrollSecret: true
+                                    ,file: 'mycard'};
 
             sandbox.stub(Start, 'getArchiveFileContents');
 

--- a/packages/composer-tests-integration/features/cli.feature
+++ b/packages/composer-tests-integration/features/cli.feature
@@ -52,6 +52,6 @@ Feature: Cli steps
             | ../tmp/basic-sample-network.bna |
         When I run the following CLI command
             """
-            composer network start --card TestPeerAdmin@org1 --networkAdmin admin --networkAdminSecret adminpw --archiveFile ./tmp/basic-sample-network.bna --file networkadmin
+            composer network start --card TestPeerAdmin@org1 --networkAdmin admin --networkAdminEnrollSecret adminpw --archiveFile ./tmp/basic-sample-network.bna --file networkadmin
             """
         Then The stdout information should include text matching /Command succeeded/


### PR DESCRIPTION
Undo all of the CLI changes that have been introduced for network admins:

- New magic `networkAdmin.*` options are not documented ANYWHERE, even in the command line help available with `-h`, and the documented options do NOT work.
- Code for those options mixes up `cert` and `certificate` and I'm pretty sure it's broken with regards to the list of options that _should_ work as per #2753.
- Documentation, including the developer tutorial, has not been updated to reflect the renamed `--networkAdminSecret` flag.
- Random `yarg.groups` have snuck in for SOME of the commands, but not ALL.