### PR TITLE
Replace playground link with a variable

### DIFF
--- a/packages/composer-website/jekylldocs/_data/links.yml
+++ b/packages/composer-website/jekylldocs/_data/links.yml
@@ -1,0 +1,3 @@
+
+playground:
+  https://composer-playground.mybluemix.net

--- a/packages/composer-website/jekylldocs/index.html
+++ b/packages/composer-website/jekylldocs/index.html
@@ -9,7 +9,7 @@ title: Hyperledger Composer - Create business networks and blockchain applicatio
         <h1>Build Blockchain applications and business networks your way</h1>
         <div class="buttoncontainer">
           <button class="secondary" onclick="window.location.href='{{site.baseurl}}/installing/installing-index.html'" title="View the installation options">Install {{site.data.conrefs.composer_full}}</button>
-          <button class="primary" ga-on="click" ga-event-category="Outbound Link" ga-event-action="click" ga-event-label="http://composer-playground.mybluemix.net/" onclick="window.location.href='https://composer-playground.mybluemix.net'" title="Try the Composer Web Playground">Try it online</button>
+          <button class="primary" ga-on="click" ga-event-category="Outbound Link" ga-event-action="click" ga-event-label={{site.data.links.playground}} onclick="window.location.href='{{site.data.links.playground}}'" title="Try the Composer Web Playground">Try it online</button>
         </div>
         <div class="readmore">
         or learn more about a typical <a href='{{site.baseurl}}/introduction/introduction.html' title="Hyperledger Composer Introduction">{{site.data.conrefs.composer_short}} architecture...</a>

--- a/packages/composer-website/jekylldocs/installing/getting-started-with-playground.md
+++ b/packages/composer-website/jekylldocs/installing/getting-started-with-playground.md
@@ -24,7 +24,7 @@ Before beginning, you will need:
 
 ## Access the online Playground
 
-The Online Playground can be accessed here: <a href="https://composer-playground.mybluemix.net" target="blank">composer-playground.mybluemix.net</a>
+The Online Playground can be accessed here: <a href={{site.data.links.playground}}" target="blank">{{site.data.links.playground}}</a>
 
 ## Start with a Playground Tutorial
 

--- a/packages/composer-website/jekylldocs/tutorials/playground-tutorial.md
+++ b/packages/composer-website/jekylldocs/tutorials/playground-tutorial.md
@@ -14,7 +14,7 @@ In this step by step tutorial we'll walk through setting up a business network, 
 
 ## Step One: Open the {{site.data.conrefs.composer_full}} Playground
 
-Open <a href="http://composer-playground.mybluemix.net" target="blank">{{site.data.conrefs.composer_short}} Playground</a>. You should see the **My Business Network** screen. The **My Business Network** page shows you a summary of the business networks you can connect to, and the identities you can use to connect to them. Don't worry about this too much for the time being, as we're going to create our own network.
+Open <a href={{site.data.links.playground}} target="blank">{{site.data.conrefs.composer_short}} Playground</a>. You should see the **My Business Network** screen. The **My Business Network** page shows you a summary of the business networks you can connect to, and the identities you can use to connect to them. Don't worry about this too much for the time being, as we're going to create our own network.
 
 ## Step Two: Creating a new business network
 


### PR DESCRIPTION
Closes #2852 - allows us to swap the URL of the version of Playground we point at (e.g. for 0.16 and 0.17 streams) via a config file.

Signed-off-by: E. P. Moffatt <edmoffat@uk.ibm.com>

