### PR TITLE
find host ip using ifconfig on mac

### DIFF
--- a/packages/composer-tests-functional/scripts/run-fv-tests.sh
+++ b/packages/composer-tests-functional/scripts/run-fv-tests.sh
@@ -80,7 +80,11 @@ for FVTEST in $(echo ${FVTEST} | tr "," " "); do
         cd ../composer-common
         npm publish --registry http://localhost:4873
         cd ../composer-runtime-hlfv1
-        GATEWAY="$(docker inspect hlfv1_default | grep Gateway | cut -d \" -f4)"
+        if [ `uname` = "Darwin" ]; then
+            GATEWAY="$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p')"
+        else
+            GATEWAY="$(docker inspect hlfv1_default | grep Gateway | cut -d \" -f4)"
+        fi
         echo registry=http://${GATEWAY}:4873 > .npmrc
         cd "${DIR}"
     fi

--- a/packages/composer-tests-integration/scripts/run-integration-tests.sh
+++ b/packages/composer-tests-integration/scripts/run-integration-tests.sh
@@ -66,7 +66,11 @@ for INTEST in $(echo ${INTEST} | tr "," " "); do
         ARCH=$ARCH docker-compose -f ${DOCKER_FILE} up -d
         cd ${DIR}
         cd ../composer-runtime-hlfv1
-        GATEWAY="$(docker inspect hlfv1_default | grep Gateway | cut -d \" -f4)"
+        if [ `uname` = "Darwin" ]; then
+            GATEWAY="$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p')"
+        else
+            GATEWAY="$(docker inspect hlfv1_default | grep Gateway | cut -d \" -f4)"
+        fi
         echo registry=http://${GATEWAY}:4873 > .npmrc
     fi
 


### PR DESCRIPTION
Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>

<!--- Provide a general summary of the pull request in the Title above -->
Looking up the host ip address using docker inspect is not working on Mac OSX which causes the integration and functional tests to fail locally.
This PR resolves this by extracting the IP from the output of ifconfig (for mac platform only)

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
