### PR TITLE
Removed unnecessary line height for header link CSS (Issue 2933)

### DIFF
--- a/packages/composer-playground/src/assets/styles/elements/_header.scss
+++ b/packages/composer-playground/src/assets/styles/elements/_header.scss
@@ -208,7 +208,6 @@
         a {
           margin-left: 1rem;
           margin-right: 1rem;
-          line-height: 63px;
           vertical-align: middle;
           color: $white;
           text-decoration: none;


### PR DESCRIPTION
Removed line height for header links to allow for the header to change height in future.

#2933 