### PR TITLE
Move to use travis providers to control the branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,14 @@ after_failure: |
     tail -n +1 -- /home/travis/.npm/_logs/*-debug.log
 deploy:
     - provider: script
-	    script: ./.travis/deploy.sh
-	    skip_cleanup: true
-	    on:
-	        branch: master
+      script: ./.travis/deploy.sh
+      skip_cleanup: true
+      on:
+            branch: master
     - provider: script
-        script: ./.travis/deploy.sh
-        skip_cleanup: true
-        on:
+      script: ./.travis/deploy.sh
+      skip_cleanup: true
+      on:
             branch: v0.16.x
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,16 @@ script: ./.travis/script.sh
 after_failure: |
     tail -n +1 -- /home/travis/.npm/_logs/*-debug.log
 deploy:
-    provider: script
-    script: ./.travis/deploy.sh
-    skip_cleanup: true
-    on:
-        all_branches: true
+    - provider: script
+	    script: ./.travis/deploy.sh
+	    skip_cleanup: true
+	    on:
+	        branch: master
+    - provider: script
+        script: ./.travis/deploy.sh
+        skip_cleanup: true
+        on:
+            branch: v0.16.x
 cache:
   directories:
     - node_modules

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -40,9 +40,9 @@ if [[ "${TRAVIS_REPO_SLUG}" != hyperledger* ]]; then
     exit 0
 fi
 
-# Check that if this is not a tagged build, then we only deploy master.
-if [ "${TRAVIS_TAG}" = "" -a "${TRAVIS_BRANCH}" != "master" ]; then
-    echo Not executing as not building a tag and not building from master
+# Check that if this is not a tagged build (branch control in .travis.yml deploy providers)
+if [ "${TRAVIS_TAG}" = "" ]; then
+    echo Not executing as not building a tag
     exit 0
 fi
 


### PR DESCRIPTION
v0.16.x wasn't deploying the modules

- Move to use two travis deploy providers and lock them to the v0.16.x and the master branches
- Remove branch check from the deploy.sh script.

resolves #2976 

