### PR TITLE
Add quiet option to 'composer card list'

### DIFF
--- a/packages/composer-cli/cli.js
+++ b/packages/composer-cli/cli.js
@@ -38,7 +38,9 @@ let results = yargs
 if (typeof(results.thePromise) !== 'undefined'){
     results.thePromise.then( () => {
 
-        console.log(chalk.green('\nCommand succeeded\n'));
+        if (!results.quiet) {
+            console.log(chalk.green('\nCommand succeeded\n'));
+        }
         process.exit(0);
     }).catch((error) => {
         console.log(error+chalk.red('\nCommand failed\n'));

--- a/packages/composer-cli/lib/cmds/card/lib/list.js
+++ b/packages/composer-cli/lib/cmds/card/lib/list.js
@@ -34,9 +34,23 @@ class List {
             return this.showCardDetails(args.name);
         } else {
             return cmdUtil.createAdminConnection().getAllCards().then(cardMap => {
-                this.showtable(cardMap);
+                if (args.quiet) {
+                    this.showNames(cardMap);
+                } else {
+                    this.showtable(cardMap);
+                }
             });
         }
+    }
+
+    /** Show the name of each card
+      * @param {Map} cardMap Map of the cards currently held
+      */
+    static showNames(cardMap){
+        const cardNames = Array.from(cardMap.keys());
+        cardNames.forEach(function(card){
+            cmdUtil.log(card);
+        });
     }
 
     /** Show summary table

--- a/packages/composer-cli/lib/cmds/card/listCommand.js
+++ b/packages/composer-cli/lib/cmds/card/listCommand.js
@@ -19,7 +19,8 @@ const List = require ('./lib/list.js');
 module.exports.command = 'list';
 module.exports.describe = 'List all business network cards';
 module.exports.builder = {
-    name: {alias: 'n', required: false, describe: 'The name used to identify the card', type: 'string' }
+    name: {alias: 'n', required: false, describe: 'The name used to identify the card', type: 'string' },
+    quiet: { alias: 'q', required: false, describe: 'Only display the card name', type: 'boolean' }
 };
 
 module.exports.handler = (argv) => {

--- a/packages/composer-cli/test/card/list.js
+++ b/packages/composer-cli/test/card/list.js
@@ -66,6 +66,25 @@ describe('composer card list CLI', function() {
         });
     });
 
+    it('should succeed for some cards when using the "quiet" flag', function() {
+        const cardName1 = 'BlueCard';
+        const cardName2a= 'GreenCard=a';
+        const cardName2b = 'GreenCard=b';
+        let testCard1 = new IdCard({ userName: 'conga1' }, { name: 'blue-profileName' });
+
+        let testCard2a = new IdCard({ userName: 'conga2' }, { name: 'green-profileName' });
+        let testCard2b = new IdCard({ userName: 'conga3' }, { name: 'green-profileName' });
+        const cardMap = new Map([[cardName1, testCard1],[cardName2a, testCard2a],[cardName2b, testCard2b]]);
+
+        adminConnectionStub.getAllCards.resolves(cardMap);
+        const args = {'quiet': true};
+        return ListCmd.handler(args).then(() => {
+            sinon.assert.calledWith(consoleLogSpy, cardName1);
+            sinon.assert.calledWith(consoleLogSpy, cardName2a);
+            sinon.assert.calledWith(consoleLogSpy, cardName2b);
+        });
+    });
+
     describe('should handle the information for one card',()=>{
         it('show card details for one card',()=>{
             let x;


### PR DESCRIPTION
Add quiet option for command `card list`. When this flag is passed the command will return all the card's names, one for each line.

It fixes #3026

Some thoughts:

- When `--quiet` is passed alongside `-n` then quiet is ignored, since the output would be the same as the input `-n`. So, `composer card list -n card@name -q` is the same as  `composer card list -n card@name`. I have not added any information about this since it seems obvious and it would just pollute the help instructions..

- "Command succeeded" now is not printed if the argument `--quiet` is provided.  "Command failed" is still printed in all situations in case of error.