### PR TITLE
Give LoopBack all abstract types without exposing their remote methods (v0.17.x)

### DIFF
--- a/packages/composer-common/lib/codegen/fromcto/loopback/loopbackvisitor.js
+++ b/packages/composer-common/lib/codegen/fromcto/loopback/loopbackvisitor.js
@@ -134,9 +134,6 @@ class LoopbackVisitor {
             .concat(modelFile.getConceptDeclarations())
             .concat(modelFile.getParticipantDeclarations())
             .concat(modelFile.getTransactionDeclarations())
-            .filter((declaration) => {
-                return !declaration.isAbstract();
-            })
             .forEach((declaration) => {
                 parameters.first = true;
                 jsonSchemas.push(declaration.accept(this, parameters));
@@ -347,9 +344,12 @@ class LoopbackVisitor {
 
         // Add information from the class declaration into the composer section.
         if (jsonSchema.options && jsonSchema.options.composer) {
-            jsonSchema.options.composer.namespace = classDeclaration.getNamespace();
-            jsonSchema.options.composer.name = classDeclaration.getName();
-            jsonSchema.options.composer.fqn = classDeclaration.getFullyQualifiedName();
+            Object.assign(jsonSchema.options.composer, {
+                namespace: classDeclaration.getNamespace(),
+                name: classDeclaration.getName(),
+                fqn: classDeclaration.getFullyQualifiedName(),
+                abstract: classDeclaration.isAbstract()
+            });
         }
 
         // Set the required properties into the schema.

--- a/packages/composer-common/test/codegen/loopbackvisitor.js
+++ b/packages/composer-common/test/codegen/loopbackvisitor.js
@@ -75,6 +75,7 @@ describe('LoopbackVisitor', () => {
                         expectedFiles = [
                             'org.acme.base.SimpleAsset.json',
                             'org.acme.base.BaseAsset.json',
+                            'org.acme.base.AbstractAsset.json',
                             'org.acme.base.DerivedAsset.json',
                             'org.acme.base.DerivedDerivedAsset.json',
                             'org.acme.base.MyBasicTransaction.json',
@@ -87,6 +88,7 @@ describe('LoopbackVisitor', () => {
                         expectedTypes = [
                             'org_acme_base_SimpleAsset',
                             'org_acme_base_BaseAsset',
+                            'org_acme_base_AbstractAsset',
                             'org_acme_base_DerivedAsset',
                             'org_acme_base_DerivedDerivedAsset',
                             'org_acme_base_MyBasicTransaction',
@@ -100,6 +102,7 @@ describe('LoopbackVisitor', () => {
                         expectedFiles = [
                             'SimpleAsset.json',
                             'BaseAsset.json',
+                            'AbstractAsset.json',
                             'DerivedAsset.json',
                             'DerivedDerivedAsset.json',
                             'MyBasicTransaction.json',
@@ -111,6 +114,7 @@ describe('LoopbackVisitor', () => {
                         expectedTypes = [
                             'SimpleAsset',
                             'BaseAsset',
+                            'AbstractAsset',
                             'DerivedAsset',
                             'DerivedDerivedAsset',
                             'MyBasicTransaction',
@@ -145,6 +149,8 @@ describe('LoopbackVisitor', () => {
                         expectedFiles = [
                             'org.acme.base.SimpleAsset.json',
                             'org.acme.base.BaseAsset.json',
+                            'org.acme.base.AbstractAsset.json',
+                            'org.acme.base.Address.json',
                             'org.acme.base.DerivedAsset.json',
                             'org.acme.base.DerivedDerivedAsset.json',
                             'org.acme.base.MyBasicTransaction.json',
@@ -158,6 +164,8 @@ describe('LoopbackVisitor', () => {
                         expectedFiles = [
                             'SimpleAsset.json',
                             'BaseAsset.json',
+                            'AbstractAsset.json',
+                            'Address.json',
                             'DerivedAsset.json',
                             'DerivedDerivedAsset.json',
                             'MyBasicTransaction.json',
@@ -197,7 +205,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'asset',
                                 namespace: 'org.acme',
                                 name: 'MyAsset',
-                                fqn: 'org.acme.MyAsset'
+                                fqn: 'org.acme.MyAsset',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -244,7 +253,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'asset',
                                 namespace: 'org.acme',
                                 name: 'MyBaseAsset',
-                                fqn: 'org.acme.MyBaseAsset'
+                                fqn: 'org.acme.MyBaseAsset',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -277,7 +287,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'asset',
                                 namespace: 'org.acme',
                                 name: 'MyAsset',
-                                fqn: 'org.acme.MyAsset'
+                                fqn: 'org.acme.MyAsset',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -305,7 +316,7 @@ describe('LoopbackVisitor', () => {
                     }]);
                 });
 
-                it('should generate one schema for an asset that extends an abstract asset', () => {
+                it('should generate two schemas for an asset that extends an abstract asset', () => {
                     const modelFile = new ModelFile(modelManager, `
                     namespace org.acme
                     abstract asset MyBaseAsset identified by assetId {
@@ -319,6 +330,40 @@ describe('LoopbackVisitor', () => {
                     schemas.should.deep.equal([{
                         acls: [],
                         base: 'PersistedModel',
+                        description: 'An asset named MyBaseAsset',
+                        idInjection: false,
+                        methods: [],
+                        name: namespaces ? 'org_acme_MyBaseAsset' : 'MyBaseAsset',
+                        options: {
+                            composer: {
+                                type: 'asset',
+                                namespace: 'org.acme',
+                                name: 'MyBaseAsset',
+                                fqn: 'org.acme.MyBaseAsset',
+                                abstract: true
+                            },
+                            validateUpsert: true
+                        },
+                        plural: namespaces ? 'org.acme.MyBaseAsset' : 'MyBaseAsset',
+                        properties: {
+                            $class: {
+                                default: 'org.acme.MyBaseAsset',
+                                description: 'The class identifier for this type',
+                                required: false,
+                                type: 'string'
+                            },
+                            assetId: {
+                                description: 'The instance identifier for this type',
+                                id: true,
+                                required: true,
+                                type: 'string'
+                            }
+                        },
+                        relations: {},
+                        validations: []
+                    }, {
+                        acls: [],
+                        base: 'PersistedModel',
                         description: 'An asset named MyAsset',
                         idInjection: false,
                         methods: [],
@@ -328,7 +373,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'asset',
                                 namespace: 'org.acme',
                                 name: 'MyAsset',
-                                fqn: 'org.acme.MyAsset'
+                                fqn: 'org.acme.MyAsset',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -376,7 +422,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'participant',
                                 namespace: 'org.acme',
                                 name: 'MyParticipant',
-                                fqn: 'org.acme.MyParticipant'
+                                fqn: 'org.acme.MyParticipant',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -423,7 +470,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'participant',
                                 namespace: 'org.acme',
                                 name: 'MyBaseParticipant',
-                                fqn: 'org.acme.MyBaseParticipant'
+                                fqn: 'org.acme.MyBaseParticipant',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -456,7 +504,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'participant',
                                 namespace: 'org.acme',
                                 name: 'MyParticipant',
-                                fqn: 'org.acme.MyParticipant'
+                                fqn: 'org.acme.MyParticipant',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -484,7 +533,7 @@ describe('LoopbackVisitor', () => {
                     }]);
                 });
 
-                it('should generate one schema for a participant that extends an abstract participant', () => {
+                it('should generate two schemas for a participant that extends an abstract participant', () => {
                     const modelFile = new ModelFile(modelManager, `
                     namespace org.acme
                     abstract participant MyBaseParticipant identified by participantId {
@@ -498,6 +547,40 @@ describe('LoopbackVisitor', () => {
                     schemas.should.deep.equal([{
                         acls: [],
                         base: 'PersistedModel',
+                        description: 'A participant named MyBaseParticipant',
+                        idInjection: false,
+                        methods: [],
+                        name: namespaces ? 'org_acme_MyBaseParticipant' : 'MyBaseParticipant',
+                        options: {
+                            composer: {
+                                type: 'participant',
+                                namespace: 'org.acme',
+                                name: 'MyBaseParticipant',
+                                fqn: 'org.acme.MyBaseParticipant',
+                                abstract: true
+                            },
+                            validateUpsert: true
+                        },
+                        plural: namespaces ? 'org.acme.MyBaseParticipant' : 'MyBaseParticipant',
+                        properties: {
+                            $class: {
+                                default: 'org.acme.MyBaseParticipant',
+                                description: 'The class identifier for this type',
+                                required: false,
+                                type: 'string'
+                            },
+                            participantId: {
+                                description: 'The instance identifier for this type',
+                                id: true,
+                                required: true,
+                                type: 'string'
+                            }
+                        },
+                        relations: {},
+                        validations: []
+                    }, {
+                        acls: [],
+                        base: 'PersistedModel',
                         description: 'A participant named MyParticipant',
                         idInjection: false,
                         methods: [],
@@ -507,7 +590,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'participant',
                                 namespace: 'org.acme',
                                 name: 'MyParticipant',
-                                fqn: 'org.acme.MyParticipant'
+                                fqn: 'org.acme.MyParticipant',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -559,7 +643,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'transaction',
                                 namespace: 'org.acme',
                                 name: 'MyTransaction',
-                                fqn: 'org.acme.MyTransaction'
+                                fqn: 'org.acme.MyTransaction',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -617,7 +702,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'transaction',
                                 namespace: 'org.acme',
                                 name: 'MyBaseTransaction',
-                                fqn: 'org.acme.MyBaseTransaction'
+                                fqn: 'org.acme.MyBaseTransaction',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -656,7 +742,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'transaction',
                                 namespace: 'org.acme',
                                 name: 'MyTransaction',
-                                fqn: 'org.acme.MyTransaction'
+                                fqn: 'org.acme.MyTransaction',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -692,7 +779,7 @@ describe('LoopbackVisitor', () => {
                 // TODO: Added a timestamp here as that is now added most model parse...
                 // when System models are ready remove this.
                 // GITHUB: composer/issues/920
-                it('should generate one schema for a transaction that extends an abstract transaction', () => {
+                it('should generate two schemas for a transaction that extends an abstract transaction', () => {
                     const modelFile = new ModelFile(modelManager, `
                     namespace org.acme
                     abstract transaction MyBaseTransaction {
@@ -706,6 +793,46 @@ describe('LoopbackVisitor', () => {
                     schemas.should.deep.equal([{
                         acls: [],
                         base: 'PersistedModel',
+                        description: 'A transaction named MyBaseTransaction',
+                        forceId: true,
+                        idInjection: false,
+                        methods: [],
+                        name: namespaces ? 'org_acme_MyBaseTransaction' : 'MyBaseTransaction',
+                        options: {
+                            composer: {
+                                type: 'transaction',
+                                namespace: 'org.acme',
+                                name: 'MyBaseTransaction',
+                                fqn: 'org.acme.MyBaseTransaction',
+                                abstract: true
+                            },
+                            validateUpsert: true
+                        },
+                        plural: namespaces ? 'org.acme.MyBaseTransaction' : 'MyBaseTransaction',
+                        properties: {
+                            $class: {
+                                default: 'org.acme.MyBaseTransaction',
+                                description: 'The class identifier for this type',
+                                required: false,
+                                type: 'string'
+                            },
+                            transactionId: {
+                                description: 'The instance identifier for this type',
+                                id: true,
+                                generated: true,
+                                required: false,
+                                type: 'string'
+                            },
+                            timestamp: {
+                                required: false,
+                                type: 'date'
+                            }
+                        },
+                        relations: {},
+                        validations: []
+                    }, {
+                        acls: [],
+                        base: 'PersistedModel',
                         description: 'A transaction named MyTransaction',
                         forceId: true,
                         idInjection: false,
@@ -716,7 +843,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'transaction',
                                 namespace: 'org.acme',
                                 name: 'MyTransaction',
-                                fqn: 'org.acme.MyTransaction'
+                                fqn: 'org.acme.MyTransaction',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -769,7 +897,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'concept',
                                 namespace: 'org.acme',
                                 name: 'MyConcept',
-                                fqn: 'org.acme.MyConcept'
+                                fqn: 'org.acme.MyConcept',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -814,7 +943,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'concept',
                                 namespace: 'org.acme',
                                 name: 'MyBaseConcept',
-                                fqn: 'org.acme.MyBaseConcept'
+                                fqn: 'org.acme.MyBaseConcept',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -845,7 +975,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'concept',
                                 namespace: 'org.acme',
                                 name: 'MyConcept',
-                                fqn: 'org.acme.MyConcept'
+                                fqn: 'org.acme.MyConcept',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -894,7 +1025,8 @@ describe('LoopbackVisitor', () => {
                                 type: 'concept',
                                 namespace: 'org.acme',
                                 name: 'MyConcept',
-                                fqn: 'org.acme.MyConcept'
+                                fqn: 'org.acme.MyConcept',
+                                abstract: false
                             },
                             validateUpsert: true
                         },
@@ -952,7 +1084,8 @@ describe('LoopbackVisitor', () => {
                                     type: 'asset',
                                     namespace: 'org.acme.base',
                                     name: 'MyAsset',
-                                    fqn: 'org.acme.base.MyAsset'
+                                    fqn: 'org.acme.base.MyAsset',
+                                    abstract: false
                                 }
                             },
                             properties: {
@@ -994,7 +1127,8 @@ describe('LoopbackVisitor', () => {
                                     type: 'asset',
                                     namespace: 'org.acme.ext',
                                     name: 'MyOtherAsset',
-                                    fqn: 'org.acme.ext.MyOtherAsset'
+                                    fqn: 'org.acme.ext.MyOtherAsset',
+                                    abstract: false
                                 }
                             },
                             properties: {
@@ -1056,7 +1190,8 @@ describe('LoopbackVisitor', () => {
                                     type: 'asset',
                                     namespace: 'org.acme.base',
                                     name: 'MyInlineAsset',
-                                    fqn: 'org.acme.base.MyInlineAsset'
+                                    fqn: 'org.acme.base.MyInlineAsset',
+                                    abstract: false
                                 }
                             },
                             properties: {
@@ -1090,7 +1225,8 @@ describe('LoopbackVisitor', () => {
                                     type: 'asset',
                                     namespace: 'org.acme.base',
                                     name: 'MyAsset',
-                                    fqn: 'org.acme.base.MyAsset'
+                                    fqn: 'org.acme.base.MyAsset',
+                                    abstract: false
                                 }
                             },
                             properties: {
@@ -1128,7 +1264,8 @@ describe('LoopbackVisitor', () => {
                                     type: 'asset',
                                     namespace: 'org.acme.ext',
                                     name: 'MyOtherAsset',
-                                    fqn: 'org.acme.ext.MyOtherAsset'
+                                    fqn: 'org.acme.ext.MyOtherAsset',
+                                    abstract: false
                                 }
                             },
                             properties: {

--- a/packages/composer-common/test/codegen/loopbackvisitorcircular.js
+++ b/packages/composer-common/test/codegen/loopbackvisitorcircular.js
@@ -54,7 +54,7 @@ describe('LoopbackVisitor with Circular Model', () => {
 
                     // Visit all of the loaded model files and check that they were all generated
                     const schemas = modelManager.accept(visitor, { fileWriter: mockFileWriter });
-                    schemas.length.should.equal(49);
+                    schemas.length.should.equal(56);
                 });
 
             });

--- a/packages/composer-rest-server/server/boot/composer-discovery.js
+++ b/packages/composer-rest-server/server/boot/composer-discovery.js
@@ -690,7 +690,9 @@ function restrictModelMethods(modelSchema, model) {
     // We now want to filter out methods that we haven't implemented or don't want.
     // We use a whitelist of method names to do this.
     let whitelist;
-    if (modelSchema.options.composer.type === 'concept') {
+    if (modelSchema.options.composer.abstract) {
+        whitelist = [ ];
+    } else if (modelSchema.options.composer.type === 'concept') {
         whitelist = [ ];
     } else if (modelSchema.options.composer.type === 'transaction') {
         whitelist = [ 'create' ,'find', 'findById'];
@@ -740,7 +742,7 @@ module.exports = function (app, callback) {
         createQueryModel(app, dataSource);
 
         // Discover the model definitions (types) from the connector.
-        // This will go and find all of the non-abstract types in the business network definition.
+        // This will go and find all of the types in the business network definition.
         console.log('Discovering types from business network definition ...');
         return discoverModelDefinitions(dataSource);
 

--- a/packages/composer-rest-server/test/data/bond-network/models/bond.cto
+++ b/packages/composer-rest-server/test/data/bond-network/models/bond.cto
@@ -75,3 +75,19 @@ transaction EmitBondEvent {
 transaction EmitMultipleBondEvents {
 
 }
+
+abstract asset BaseAsset {
+
+}
+
+abstract concept BaseConcept {
+  
+}
+
+abstract participant BaseParticipant {
+  
+}
+
+abstract transaction BaseTransaction {
+  
+}

--- a/packages/composer-rest-server/test/server/boot/composer-discovery.js
+++ b/packages/composer-rest-server/test/server/boot/composer-discovery.js
@@ -99,6 +99,10 @@ describe('composer-discovery boot script', () => {
                 app.models.org_acme_bond_Bond.should.exist;
                 app.models.org_acme_bond_BondAsset.should.exist;
                 app.models.org_acme_bond_PublishBond.should.exist;
+                app.models.org_acme_bond_BaseAsset.should.exist;
+                app.models.org_acme_bond_BaseConcept.should.exist;
+                app.models.org_acme_bond_BaseParticipant.should.exist;
+                app.models.org_acme_bond_BaseTransaction.should.exist;
             });
     });
 
@@ -114,6 +118,10 @@ describe('composer-discovery boot script', () => {
                 app.models.Bond.should.exist;
                 app.models.BondAsset.should.exist;
                 app.models.PublishBond.should.exist;
+                app.models.BaseAsset.should.exist;
+                app.models.BaseConcept.should.exist;
+                app.models.BaseParticipant.should.exist;
+                app.models.BaseTransaction.should.exist;
             });
     });
 

--- a/packages/loopback-connector-composer/lib/businessnetworkconnector.js
+++ b/packages/loopback-connector-composer/lib/businessnetworkconnector.js
@@ -1132,12 +1132,6 @@ class BusinessNetworkConnector extends Connector {
                     })
                     .filter((classDeclaration) => {
 
-                        // Filter out any abstract types.
-                        return !classDeclaration.isAbstract();
-
-                    })
-                    .filter((classDeclaration) => {
-
                         // Filter out any system types.
                         return !classDeclaration.isSystemType();
 

--- a/packages/loopback-connector-composer/test/businessnetworkconnector.js
+++ b/packages/loopback-connector-composer/test/businessnetworkconnector.js
@@ -536,7 +536,7 @@ describe('BusinessNetworkConnector', () => {
             mockSerializer.toJSON.onFirstCall().returns({theValue : 'myId'});
 
             return new Promise((resolve, reject) => {
-                testConnector.all('org.acme.base.BaseAsset', {'where':{'theValue':'mockId'}}, { test: 'options' }, (error, result) => {
+                testConnector.all('org.acme.base.BaseAsset', {where:{theValue:'mockId'}}, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -557,7 +557,7 @@ describe('BusinessNetworkConnector', () => {
             mockBusinessNetworkConnection.buildQuery.returns({id :'mockQuery'});
             mockSerializer.toJSON.onFirstCall().returns({theString: 'myString'});
             return new Promise((resolve, reject) => {
-                testConnector.all('org.acme.base.BaseAsset', {'where':{'theString':'mockString'}}, { test: 'options' }, (error, result) => {
+                testConnector.all('org.acme.base.BaseAsset', {where:{theString:'mockString'}}, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -577,7 +577,7 @@ describe('BusinessNetworkConnector', () => {
             mockAssetRegistry.resolve.resolves({theValue : 'mockId', member: {theValue:'member1'}});
 
             return new Promise((resolve, reject) => {
-                testConnector.all('org.acme.base.BaseAsset', {'where':{'theValue':'mockId'}, 'include' : 'resolve'}, { test: 'options' }, (error, result) => {
+                testConnector.all('org.acme.base.BaseAsset', {where:{theValue:'mockId'}, include : 'resolve'}, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -602,7 +602,7 @@ describe('BusinessNetworkConnector', () => {
             mockBusinessNetworkConnection.buildQuery.returns({id :'mockQuery'});
 
             return new Promise((resolve, reject) => {
-                testConnector.all('org.acme.base.BaseAsset', {'where':{'theString':'mockString'}, 'include' : 'resolve'}, { test: 'options' }, (error, result) => {
+                testConnector.all('org.acme.base.BaseAsset', {where:{theString:'mockString'}, include : 'resolve'}, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -630,7 +630,7 @@ describe('BusinessNetworkConnector', () => {
             mockBusinessNetworkConnection.buildQuery.returns({id :'mockQuery'});
 
             return new Promise((resolve, reject) => {
-                testConnector.all('org.acme.base.BaseAsset', {'where':{'theString':'mockString'}, 'include' : 'resolve'}, { test: 'options' }, (error, result) => {
+                testConnector.all('org.acme.base.BaseAsset', {where:{theString:'mockString'}, include : 'resolve'}, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -656,7 +656,7 @@ describe('BusinessNetworkConnector', () => {
         it('should handle an error when an invalid model name is specified', () => {
             mockAssetRegistry.get.rejects(new Error('expected test error'));
             return new Promise((resolve, reject) => {
-                testConnector.all('org.acme.base.WrongBaseAsset', {'where':{'theValue':'mockId'}}, { test: 'options' }, (error, result) => {
+                testConnector.all('org.acme.base.WrongBaseAsset', {where:{theValue:'mockId'}}, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -668,7 +668,7 @@ describe('BusinessNetworkConnector', () => {
         it('should handle an error when trying to retrieve a specific Asset for a given id in a where clause', () => {
             mockAssetRegistry.get.rejects(new Error('expected test error'));
             return new Promise((resolve, reject) => {
-                testConnector.all('org.acme.base.BaseAsset', {'where':{'theValue':'mockId'}}, { test: 'options' }, (error, result) => {
+                testConnector.all('org.acme.base.BaseAsset', {where:{theValue:'mockId'}}, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -680,7 +680,7 @@ describe('BusinessNetworkConnector', () => {
         it('should handle an error when trying to retrieve a fully resolved specific Asset for a given id in a where clause', () => {
             mockAssetRegistry.resolve.rejects(new Error('expected test error'));
             return new Promise((resolve, reject) => {
-                testConnector.all('org.acme.base.BaseAsset', {'where':{'theValue':'mockId'}, 'include' : 'resolve'}, { test: 'options' }, (error, result) => {
+                testConnector.all('org.acme.base.BaseAsset', {where:{theValue:'mockId'}, include : 'resolve'}, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -691,7 +691,7 @@ describe('BusinessNetworkConnector', () => {
 
         it('should handle an error when trying to retrieve a fully resolved specific Asset for a given non-existing id in a where clause', () => {
             return new Promise((resolve, reject) => {
-                testConnector.all('org.acme.base.BaseAsset', {'where':{'theInvalidValue':'mockId'}, 'include' : 'resolve'}, { test: 'options' }, (error, result) => {
+                testConnector.all('org.acme.base.BaseAsset', {where:{theInvalidValue:'mockId'}, include : 'resolve'}, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -703,7 +703,7 @@ describe('BusinessNetworkConnector', () => {
         it('should return an empty list after an error when trying to retrieve a specific Asset by id if the error just indicates that the asset does not exist', () => {
             mockAssetRegistry.get.rejects(new Error('Error: Object with ID \'1112\' in collection with ID \'Asset:org.acme.vehicle.auction.Vehicle\' does not exist'));
             return new Promise((resolve, reject) => {
-                testConnector.all('org.acme.base.BaseAsset', {'where':{'theValue':'mockId'}}, { test: 'options' }, (error, result) => {
+                testConnector.all('org.acme.base.BaseAsset', {where:{theValue:'mockId'}}, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -721,7 +721,7 @@ describe('BusinessNetworkConnector', () => {
         it('should return an empty list after an error when trying to retrieve a fully resolved specific Asset by id if the error just indicates that the asset does not exist', () => {
             mockAssetRegistry.resolve.rejects(new Error('Error: Object with ID \'1112\' in collection with ID \'Asset:org.acme.vehicle.auction.Vehicle\' does not exist'));
             return new Promise((resolve, reject) => {
-                testConnector.all('org.acme.base.BaseAsset', {'where':{'theValue':'mockId'}, 'include' : 'resolve' }, { test: 'options' }, (error, result) => {
+                testConnector.all('org.acme.base.BaseAsset', {where:{theValue:'mockId'}, include : 'resolve' }, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -766,7 +766,7 @@ describe('BusinessNetworkConnector', () => {
 
             mockAssetRegistry.resolveAll.resolves([{assetId : 'mockId', stringValue : 'a big car'}, {assetId : 'mockId2', stringValue : 'a big fox'}]);
             return new Promise((resolve, reject) => {
-                testConnector.all('org.acme.base.BaseAsset', {'include' : 'resolve'}, { test: 'options' }, (error, result) => {
+                testConnector.all('org.acme.base.BaseAsset', {include : 'resolve'}, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -790,7 +790,7 @@ describe('BusinessNetworkConnector', () => {
             mockAssetRegistry.resolveAll.rejects(new Error('expected error'));
 
             return new Promise((resolve, reject) => {
-                testConnector.all('org.acme.base.BaseAsset', {'include' : 'resolve'}, { test: 'options' }, (error, result) => {
+                testConnector.all('org.acme.base.BaseAsset', {include : 'resolve'}, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -855,17 +855,17 @@ describe('BusinessNetworkConnector', () => {
     describe('#isResolveSet', () => {
 
         it('should return true if resolve is set to be true in a filter include', () => {
-            let FILTER = {'include' : 'resolve'};
+            let FILTER = {include : 'resolve'};
             testConnector.isResolveSet(FILTER).should.equal(true);
         });
 
         it('should return false if resolve is set to be true in a filter include', () => {
-            let FILTER = {'where' : { 'vin' : '1234' }, 'include' : 'noresolve'};
+            let FILTER = {where : { vin : '1234' }, include : 'noresolve'};
             testConnector.isResolveSet(FILTER).should.equal(false);
         });
 
         it('should return false if resolve is not set in a filter include', () => {
-            let FILTER = {'where' : { 'vin' : '1234' } };
+            let FILTER = {where : { vin : '1234' } };
             testConnector.isResolveSet(FILTER).should.equal(false);
         });
     });
@@ -911,7 +911,7 @@ describe('BusinessNetworkConnector', () => {
         it('should return count of 1 if the object exists', () => {
             mockAssetRegistry.exists.resolves(true);
             return new Promise((resolve, reject) => {
-                testConnector.count('org.acme.base.BaseAsset', { 'theValue':'mockId' }, { test: 'options' }, (error, result) => {
+                testConnector.count('org.acme.base.BaseAsset', { theValue:'mockId' }, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -927,7 +927,7 @@ describe('BusinessNetworkConnector', () => {
         it('should return count of 0 if the object exists', () => {
             mockAssetRegistry.exists.resolves(false);
             return new Promise((resolve, reject) => {
-                testConnector.count('org.acme.base.BaseAsset', { 'theValue':'mockId' }, { test: 'options' }, (error, result) => {
+                testConnector.count('org.acme.base.BaseAsset', { theValue:'mockId' }, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -944,7 +944,7 @@ describe('BusinessNetworkConnector', () => {
             mockBusinessNetworkConnection.query.resolves([{theString:'mockString'}, {theString:'mockString'}]);
             mockBusinessNetworkConnection.buildQuery.returns({id: 'mockQuery'});
             return new Promise((resolve, reject) => {
-                testConnector.count('org.acme.base.BaseAsset', { 'theString':'mockString' }, { test: 'options' }, (error, result) => {
+                testConnector.count('org.acme.base.BaseAsset', { theString:'mockString' }, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -962,7 +962,7 @@ describe('BusinessNetworkConnector', () => {
         it('should handle an error thrown from the build query', () => {
             mockBusinessNetworkConnection.buildQuery.throws(new Error('Test error'));
             return new Promise((resolve, reject) => {
-                testConnector.count('org.acme.base.BaseAsset', { 'theString':'mockString' }, { test: 'options' }, (error, result) => {
+                testConnector.count('org.acme.base.BaseAsset', { theString:'mockString' }, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -1007,7 +1007,7 @@ describe('BusinessNetworkConnector', () => {
         it('should return true if the object exists', () => {
             mockAssetRegistry.exists.resolves(true);
             return new Promise((resolve, reject) => {
-                testConnector.exists('org.acme.base.BaseAsset', { 'theValue':'mockId' }, { test: 'options' }, (error, result) => {
+                testConnector.exists('org.acme.base.BaseAsset', { theValue:'mockId' }, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -1023,7 +1023,7 @@ describe('BusinessNetworkConnector', () => {
         it('should return false if the object does not exist', () => {
             mockAssetRegistry.exists.resolves(false);
             return new Promise((resolve, reject) => {
-                testConnector.exists('org.acme.base.BaseAsset', { 'theValue':'mockId' }, { test: 'options' }, (error, result) => {
+                testConnector.exists('org.acme.base.BaseAsset', { theValue:'mockId' }, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -1039,7 +1039,7 @@ describe('BusinessNetworkConnector', () => {
         it('should handle an error from the composer registry.exists API', () => {
             mockAssetRegistry.exists.rejects(new Error('existence test error'));
             return new Promise((resolve, reject) => {
-                testConnector.exists('org.acme.base.BaseAsset', { 'theValue':'mockId' }, { test: 'options' }, (error, result) => {
+                testConnector.exists('org.acme.base.BaseAsset', { theValue:'mockId' }, { test: 'options' }, (error, result) => {
                     if (error) {
                         return reject(error);
                     }
@@ -1074,7 +1074,7 @@ describe('BusinessNetworkConnector', () => {
             return new Promise((resolve, reject) => {
                 mockSerializer.fromJSON.returns(resource);
                 mockAssetRegistry.update.resolves();
-                testConnector.updateAttributes('org.acme.base.BaseAsset', 'theId', { 'theValue' : 'updated' }, { test: 'options' }, (error) => {
+                testConnector.updateAttributes('org.acme.base.BaseAsset', 'theId', { theValue : 'updated' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -1082,7 +1082,7 @@ describe('BusinessNetworkConnector', () => {
                 });
             })
             .then((result) => {
-                sinon.assert.calledWith(mockSerializer.fromJSON, { '$class': 'org.acme.base.BaseAsset', 'theValue' : 'updated', prop1: 'woohoo' });
+                sinon.assert.calledWith(mockSerializer.fromJSON, { $class: 'org.acme.base.BaseAsset', theValue : 'updated', prop1: 'woohoo' });
                 sinon.assert.calledOnce(testConnector.ensureConnected);
                 sinon.assert.calledWith(testConnector.ensureConnected, { test: 'options' });
                 sinon.assert.calledOnce(testConnector.getRegistryForModel);
@@ -1095,7 +1095,7 @@ describe('BusinessNetworkConnector', () => {
             return new Promise((resolve, reject) => {
                 mockSerializer.fromJSON.returns(resource);
                 mockAssetRegistry.update.resolves();
-                testConnector.updateAttributes('org.acme.base.BaseAsset', 'theId', { '$class': 'org.acme.base.BaseAsset', 'theValue' : 'updated' }, { test: 'options' }, (error) => {
+                testConnector.updateAttributes('org.acme.base.BaseAsset', 'theId', { $class: 'org.acme.base.BaseAsset', theValue : 'updated' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -1103,7 +1103,7 @@ describe('BusinessNetworkConnector', () => {
                 });
             })
             .then((result) => {
-                sinon.assert.calledWith(mockSerializer.fromJSON, { '$class': 'org.acme.base.BaseAsset', 'theValue' : 'updated', prop1: 'woohoo' });
+                sinon.assert.calledWith(mockSerializer.fromJSON, { $class: 'org.acme.base.BaseAsset', theValue : 'updated', prop1: 'woohoo' });
                 sinon.assert.calledOnce(testConnector.ensureConnected);
                 sinon.assert.calledWith(testConnector.ensureConnected, { test: 'options' });
                 sinon.assert.calledOnce(testConnector.getRegistryForModel);
@@ -1116,7 +1116,7 @@ describe('BusinessNetworkConnector', () => {
             return new Promise((resolve, reject) => {
                 mockSerializer.fromJSON.returns(resource);
                 mockAssetRegistry.update.resolves();
-                testConnector.updateAttributes('org.acme.base.WrongBaseAsset', 'theId', { 'theValue' : 'updated' }, { test: 'options' }, (error) => {
+                testConnector.updateAttributes('org.acme.base.WrongBaseAsset', 'theId', { theValue : 'updated' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -1135,7 +1135,7 @@ describe('BusinessNetworkConnector', () => {
             return new Promise((resolve, reject) => {
                 mockSerializer.fromJSON.returns(resource);
                 mockAssetRegistry.update.rejects(new Error('Update error from Composer'));
-                testConnector.updateAttributes('org.acme.base.BaseAsset', 'theId', { 'theValue' : 'updated' }, { test: 'options' }, (error) => {
+                testConnector.updateAttributes('org.acme.base.BaseAsset', 'theId', { theValue : 'updated' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -1155,7 +1155,7 @@ describe('BusinessNetworkConnector', () => {
             return new Promise((resolve, reject) => {
                 mockSerializer.fromJSON.returns(resource);
                 mockAssetRegistry.update.rejects(new Error('Error: Object with ID \'1112\' in collection with ID \'Asset:org.acme.vehicle.auction.Vehicle\' does not exist'));
-                testConnector.updateAttributes('org.acme.base.BaseAsset', 'theId', { 'theValue' : 'updated' }, { test: 'options' }, (error) => {
+                testConnector.updateAttributes('org.acme.base.BaseAsset', 'theId', { theValue : 'updated' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -1197,7 +1197,7 @@ describe('BusinessNetworkConnector', () => {
             return new Promise((resolve, reject) => {
                 mockSerializer.fromJSON.returns(asset);
                 mockAssetRegistry.update.resolves();
-                testConnector.replaceById('org.acme.base.BaseAsset', '1', { 'assetId': '1', 'theValue' : 'updated' }, { test: 'options' }, (error) => {
+                testConnector.replaceById('org.acme.base.BaseAsset', '1', { assetId: '1', theValue : 'updated' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -1205,7 +1205,7 @@ describe('BusinessNetworkConnector', () => {
                 });
             })
             .then((result) => {
-                sinon.assert.calledWith(mockSerializer.fromJSON, { '$class': 'org.acme.base.BaseAsset', 'assetId': '1', 'theValue' : 'updated' });
+                sinon.assert.calledWith(mockSerializer.fromJSON, { $class: 'org.acme.base.BaseAsset', assetId: '1', theValue : 'updated' });
                 sinon.assert.calledOnce(testConnector.ensureConnected);
                 sinon.assert.calledWith(testConnector.ensureConnected, { test: 'options' });
                 sinon.assert.calledOnce(testConnector.getRegistryForModel);
@@ -1218,7 +1218,7 @@ describe('BusinessNetworkConnector', () => {
             return new Promise((resolve, reject) => {
                 mockSerializer.fromJSON.returns(asset);
                 mockAssetRegistry.update.resolves();
-                testConnector.replaceById('org.acme.base.BaseAsset', '1', { '$class': 'org.acme.base.BaseAsset', 'assetId': '1', 'theValue' : 'updated' }, { test: 'options' }, (error) => {
+                testConnector.replaceById('org.acme.base.BaseAsset', '1', { $class: 'org.acme.base.BaseAsset', assetId: '1', theValue : 'updated' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -1226,7 +1226,7 @@ describe('BusinessNetworkConnector', () => {
                 });
             })
             .then((result) => {
-                sinon.assert.calledWith(mockSerializer.fromJSON, { '$class': 'org.acme.base.BaseAsset', 'assetId': '1', 'theValue' : 'updated' });
+                sinon.assert.calledWith(mockSerializer.fromJSON, { $class: 'org.acme.base.BaseAsset', assetId: '1', theValue : 'updated' });
                 sinon.assert.calledOnce(testConnector.ensureConnected);
                 sinon.assert.calledWith(testConnector.ensureConnected, { test: 'options' });
                 sinon.assert.calledOnce(testConnector.getRegistryForModel);
@@ -1239,7 +1239,7 @@ describe('BusinessNetworkConnector', () => {
             return new Promise((resolve, reject) => {
                 mockSerializer.fromJSON.returns(asset);
                 mockAssetRegistry.update.resolves();
-                testConnector.replaceById('org.acme.base.WrongBaseAsset', '1', { 'assetId': '1', 'theValue' : 'updated' }, { test: 'options' }, (error) => {
+                testConnector.replaceById('org.acme.base.WrongBaseAsset', '1', { assetId: '1', theValue : 'updated' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -1258,7 +1258,7 @@ describe('BusinessNetworkConnector', () => {
             return new Promise((resolve, reject) => {
                 mockSerializer.fromJSON.returns(asset);
                 mockAssetRegistry.update.rejects(new Error('Update error from Composer'));
-                testConnector.replaceById('org.acme.base.BaseAsset', '1', { 'assetId': '1', 'theValue' : 'updated' }, { test: 'options' }, (error) => {
+                testConnector.replaceById('org.acme.base.BaseAsset', '1', { assetId: '1', theValue : 'updated' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -1278,7 +1278,7 @@ describe('BusinessNetworkConnector', () => {
             return new Promise((resolve, reject) => {
                 mockSerializer.fromJSON.returns(asset);
                 mockAssetRegistry.update.rejects(new Error('Error: Object with ID \'1112\' in collection with ID \'Asset:org.acme.vehicle.auction.Vehicle\' does not exist'));
-                testConnector.replaceById('org.acme.base.BaseAsset', '1', { 'assetId': '1', 'theValue' : 'updated' }, { test: 'options' }, (error) => {
+                testConnector.replaceById('org.acme.base.BaseAsset', '1', { assetId: '1', theValue : 'updated' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -1887,7 +1887,7 @@ describe('BusinessNetworkConnector', () => {
             mockAssetRegistry.get.resolves(resourceToDelete);
             mockAssetRegistry.remove.resolves();
             return new Promise((resolve, reject) => {
-                testConnector.destroyAll('org.acme.base.BaseAsset', { 'theValue' : 'foo' }, { test: 'options' }, (error) => {
+                testConnector.destroyAll('org.acme.base.BaseAsset', { theValue : 'foo' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -1922,7 +1922,7 @@ describe('BusinessNetworkConnector', () => {
         it('should handle an error when an invalid Object identifier is specified', () => {
             mockAssetRegistry.get.rejects(new Error('get error'));
             return new Promise((resolve, reject) => {
-                testConnector.destroyAll('org.acme.base.BaseAsset', { 'theWrongValue' : 'foo' }, { test: 'options' }, (error) => {
+                testConnector.destroyAll('org.acme.base.BaseAsset', { theWrongValue : 'foo' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -1939,7 +1939,7 @@ describe('BusinessNetworkConnector', () => {
         it('should handle an error when calling composer get for the given id', () => {
             mockAssetRegistry.get.rejects(new Error('get error'));
             return new Promise((resolve, reject) => {
-                testConnector.destroyAll('org.acme.base.BaseAsset', { 'theValue' : 'foo' }, { test: 'options' }, (error) => {
+                testConnector.destroyAll('org.acme.base.BaseAsset', { theValue : 'foo' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -1958,7 +1958,7 @@ describe('BusinessNetworkConnector', () => {
             mockAssetRegistry.get.resolves(resourceToDelete);
             mockAssetRegistry.remove.rejects(new Error('removal error'));
             return new Promise((resolve, reject) => {
-                testConnector.destroyAll('org.acme.base.BaseAsset', { 'theValue' : 'foo' }, { test: 'options' }, (error) => {
+                testConnector.destroyAll('org.acme.base.BaseAsset', { theValue : 'foo' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -1978,7 +1978,7 @@ describe('BusinessNetworkConnector', () => {
             mockAssetRegistry.get.resolves(resourceToDelete);
             mockAssetRegistry.remove.rejects(new Error('Error: Object with ID \'1112\' in collection with ID \'Asset:org.acme.vehicle.auction.Vehicle\' does not exist'));
             return new Promise((resolve, reject) => {
-                testConnector.destroyAll('org.acme.base.BaseAsset', { 'theValue' : 'foo' }, { test: 'options' }, (error) => {
+                testConnector.destroyAll('org.acme.base.BaseAsset', { theValue : 'foo' }, { test: 'options' }, (error) => {
                     if(error) {
                         return reject(error);
                     }
@@ -2835,67 +2835,68 @@ describe('BusinessNetworkConnector', () => {
     describe('#discoverSchemas', () => {
 
         const modelSchema = {
-            'acls' : [],
-            'base' : 'PersistedModel',
-            'description' : 'An asset named BaseAsset',
-            'idInjection' : false,
-            'methods' : [],
-            'name' : 'org_acme_base_BaseAsset',
-            'options' : {
-                'validateUpsert' : true,
-                'composer': {
-                    'type': 'asset',
-                    'namespace': 'org.acme.base',
-                    'name': 'BaseAsset',
-                    'fqn': 'org.acme.base.BaseAsset'
+            acls : [],
+            base : 'PersistedModel',
+            description : 'An asset named BaseAsset',
+            idInjection : false,
+            methods : [],
+            name : 'org_acme_base_BaseAsset',
+            options : {
+                validateUpsert : true,
+                composer: {
+                    type: 'asset',
+                    namespace: 'org.acme.base',
+                    name: 'BaseAsset',
+                    fqn: 'org.acme.base.BaseAsset',
+                    abstract: false
                 }
             },
-            'plural' : 'org.acme.base.BaseAsset',
-            'properties' : {
-                '$class' : {
-                    'default': 'org.acme.base.BaseAsset',
-                    'description': 'The class identifier for this type',
-                    'required': false,
-                    'type': 'string'
+            plural : 'org.acme.base.BaseAsset',
+            properties : {
+                $class : {
+                    default: 'org.acme.base.BaseAsset',
+                    description: 'The class identifier for this type',
+                    required: false,
+                    type: 'string'
                 },
-                'theValue' : {
-                    'description': 'The instance identifier for this type',
-                    'id': true,
-                    'required' : true,
-                    'type' : 'string'
+                theValue : {
+                    description: 'The instance identifier for this type',
+                    id: true,
+                    required : true,
+                    type : 'string'
                 },
-                'theString' : {
-                    'required' : false,
-                    'type' : 'string'
+                theString : {
+                    required : false,
+                    type : 'string'
                 },
-                'theInteger' : {
-                    'required' : false,
-                    'type' : 'number'
+                theInteger : {
+                    required : false,
+                    type : 'number'
                 },
-                'theDouble' : {
-                    'required' : false,
-                    'type' : 'number'
+                theDouble : {
+                    required : false,
+                    type : 'number'
                 },
-                'theLong' : {
-                    'required' : false,
-                    'type' : 'number'
+                theLong : {
+                    required : false,
+                    type : 'number'
                 },
-                'theDateTime' : {
-                    'required' : false,
-                    'type' : 'date'
+                theDateTime : {
+                    required : false,
+                    type : 'date'
                 },
-                'theBoolean' : {
-                    'required' : false,
-                    'type' : 'boolean'
+                theBoolean : {
+                    required : false,
+                    type : 'boolean'
                 },
-                'theMember': {
-                    'description': 'The identifier of an instance of theMember',
-                    'required': false,
-                    'type': 'any'
+                theMember: {
+                    description: 'The identifier of an instance of theMember',
+                    required: false,
+                    type: 'any'
                 }
             },
-            'relations' : {},
-            'validations' : []
+            relations : {},
+            validations : []
         };
 
         beforeEach(() => {


### PR DESCRIPTION
Type missing from Swagger leading to bad Java client gen #1055

We currently hide all abstract types from LoopBack, which means that the Swagger document produced by LoopBack is invalid.

Any reference to an abstract type from a concrete type results in Swagger document errors where the concrete type definition has a `$ref` to the abstract type definition which cannot be resolved. Any compliant Swagger parser will choke on this.