### PR TITLE
Update reference documentation for 'card list'

### DIFF
--- a/packages/composer-website/jekylldocs/reference/composer.card.list.md
+++ b/packages/composer-website/jekylldocs/reference/composer.card.list.md
@@ -21,4 +21,5 @@ Options:
   --help         Show help  [boolean]
   -v, --version  Show version number  [boolean]
   --name, -n     The name used to identify the card  [string]
+  --quiet, -q    Only display the card name  [boolean]
 ```


### PR DESCRIPTION
Update the documentation to include the new option `--quiet` for `composer card list`.

Option added in #3075