### PR TITLE
Add identifier for identity into error messages (resolves #3095, v0.16.x)

### DIFF
--- a/packages/composer-runtime/lib/identitymanager.js
+++ b/packages/composer-runtime/lib/identitymanager.js
@@ -100,8 +100,9 @@ class IdentityManager extends TransactionHandler {
 
                 // If it still doesn't exist, throw!
                 if (!identity) {
+                    identifier = this.identityService.getIdentifier();
                     identityName = this.identityService.getName();
-                    const error = new Error('The current identity has not been registered: ' + identityName);
+                    const error = new Error(`The current identity, with the name '${identityName}' and the identifier '${identifier}', has not been registered`);
                     error.identityName = identityName;
                     LOG.error(method, error);
                     throw error;
@@ -125,14 +126,14 @@ class IdentityManager extends TransactionHandler {
 
         // Check for a revoked identity.
         if (identity.state === 'REVOKED') {
-            const error = new Error('The current identity has been revoked');
+            const error = new Error(`The current identity, with the name '${identity.name}' and the identifier '${identity.getIdentifier()}', has been revoked`);
             LOG.error(method, error);
             throw error;
         }
 
         // Check for an issued or bound identity, in which case activation is required.
         if (identity.state === 'ISSUED' || identity.state === 'BOUND') {
-            const error = new Error('The current identity must be activated (ACTIVATION_REQUIRED)');
+            const error = new Error(`The current identity, with the name '${identity.name}' and the identifier '${identity.getIdentifier()}', must be activated (ACTIVATION_REQUIRED)`);
             error.activationRequired = true;
             LOG.error(method, error);
             throw error;
@@ -140,7 +141,7 @@ class IdentityManager extends TransactionHandler {
 
         // Ensure that the identity is activated.
         if (identity.state !== 'ACTIVATED') {
-            const error = new Error('The current identity is in an unknown state: ' + identity.state);
+            const error = new Error(`The current identity, with the name '${identity.name}' and the identifier '${identity.getIdentifier()}', is in an unknown state '${identity.state}'`);
             LOG.error(method, error);
             throw error;
         }
@@ -168,7 +169,7 @@ class IdentityManager extends TransactionHandler {
                 return participant;
             })
             .catch(() => {
-                const error = new Error('The current identity is bound to a participant that does not exist');
+                const error = new Error(`The current identity, with the name '${identity.name}' and the identifier '${identity.getIdentifier()}', is bound to a participant '${participant.toURI()}' that does not exist`);
                 LOG.error(method, error);
                 throw error;
             });
@@ -279,7 +280,7 @@ class IdentityManager extends TransactionHandler {
                 }
 
                 // Shouldn't get here.
-                throw new Error('The current identity cannot be activated because it is in an unknown state: ' + identity.state);
+                throw new Error(`The current identity, with the name '${identity.name}' and the identifier '${identity.getIdentifier()}', cannot be activated because it is in an unknown state '${identity.state}'`);
 
             })
             .then(() => {
@@ -306,7 +307,7 @@ class IdentityManager extends TransactionHandler {
 
         // Validate the issuer to check it matches the issuer of the identity.
         if (identity.issuer !== issuer) {
-            throw new Error('The current identity cannot be activated because the issuer is invalid');
+            throw new Error(`The current identity, with the name '${identity.name}' and the identifier '${identity.getIdentifier()}', cannot be activated because the issuer is invalid`);
         }
 
         // Create the new identity.

--- a/packages/composer-runtime/test/identitymanager.js
+++ b/packages/composer-runtime/test/identitymanager.js
@@ -100,7 +100,7 @@ describe('IdentityManager', () => {
             mockIdentityService.getIssuer.returns('26341f1fc63f30886c54abeba3aca520601126ae2a57869d1ec1a3f854ebc417');
             mockIdentityRegistry.get.withArgs('9f8b1a1e7280d40f4f14577ee4329473c60f04db3ea0f40c91f9684558c6ab50').rejects();
             return identityManager.getIdentity()
-                .should.be.rejectedWith(/The current identity has not been registered/);
+                .should.be.rejectedWith(/The current identity, with the name \'admin\' and the identifier \'7d85a9672abea0dfa45705eed99a536b8470d192e2a17e50c1fb86cb4bccae63\', has not been registered/);
         });
 
     });
@@ -111,34 +111,35 @@ describe('IdentityManager', () => {
 
         beforeEach(() => {
             identity = factory.newResource('org.hyperledger.composer.system', 'Identity', '9f8b1a1e7280d40f4f14577ee4329473c60f04db3ea0f40c91f9684558c6ab50');
+            identity.name = 'admin';
         });
 
         it('should throw for a revoked identity', () => {
             identity.state = 'REVOKED';
             (() => {
                 identityManager.validateIdentity(identity);
-            }).should.throw(/The current identity has been revoked/);
+            }).should.throw(/The current identity, with the name \'admin\' and the identifier \'9f8b1a1e7280d40f4f14577ee4329473c60f04db3ea0f40c91f9684558c6ab50\', has been revoked/);
         });
 
         it('should throw for an issued identity that requires activation', () => {
             identity.state = 'ISSUED';
             (() => {
                 identityManager.validateIdentity(identity);
-            }).should.throw(/The current identity must be activated \(ACTIVATION_REQUIRED\)/);
+            }).should.throw(/The current identity, with the name \'admin\' and the identifier \'9f8b1a1e7280d40f4f14577ee4329473c60f04db3ea0f40c91f9684558c6ab50\', must be activated \(ACTIVATION_REQUIRED\)/);
         });
 
         it('should throw for a bound identity that requires activation', () => {
             identity.state = 'BOUND';
             (() => {
                 identityManager.validateIdentity(identity);
-            }).should.throw(/The current identity must be activated \(ACTIVATION_REQUIRED\)/);
+            }).should.throw(/The current identity, with the name \'admin\' and the identifier \'9f8b1a1e7280d40f4f14577ee4329473c60f04db3ea0f40c91f9684558c6ab50\', must be activated \(ACTIVATION_REQUIRED\)/);
         });
 
         it('should throw for an identity in an unknown state', () => {
             identity.state = 'WOOPWOOP';
             (() => {
                 identityManager.validateIdentity(identity);
-            }).should.throw(/The current identity is in an unknown state/);
+            }).should.throw(/The current identity, with the name \'admin\' and the identifier \'9f8b1a1e7280d40f4f14577ee4329473c60f04db3ea0f40c91f9684558c6ab50\', is in an unknown state/);
         });
 
         it('should not throw for an activated identity', () => {
@@ -156,6 +157,7 @@ describe('IdentityManager', () => {
 
         beforeEach(() => {
             identity = factory.newResource('org.hyperledger.composer.system', 'Identity', '9f8b1a1e7280d40f4f14577ee4329473c60f04db3ea0f40c91f9684558c6ab50');
+            identity.name = 'admin';
             participant = factory.newResource('org.acme', 'SampleParticipant', 'alice@email.com');
             identity.participant = factory.newRelationship('org.acme', 'SampleParticipant', 'alice@email.com');
             mockParticipantRegistry = sinon.createStubInstance(Registry);
@@ -171,7 +173,7 @@ describe('IdentityManager', () => {
         it('should throw if the participant does not exist', () => {
             mockParticipantRegistry.get.withArgs('alice@email.com').rejects(new Error('such error'));
             return identityManager.getParticipant(identity)
-                .should.be.rejectedWith(/The current identity is bound to a participant that does not exist/);
+                .should.be.rejectedWith(/The current identity, with the name \'admin\' and the identifier \'9f8b1a1e7280d40f4f14577ee4329473c60f04db3ea0f40c91f9684558c6ab50\', is bound to a participant \'resource:org.acme.SampleParticipant#alice@email.com\' that does not exist/);
         });
 
     });
@@ -276,7 +278,7 @@ describe('IdentityManager', () => {
             identity.participant = factory.newRelationship('org.acme', 'SampleParticipant', 'alice@email.com');
             sinon.stub(identityManager, 'getIdentity').resolves(identity);
             return identityManager.activateCurrentIdentity(mockApi, tx)
-                .should.be.rejectedWith(/The current identity cannot be activated because it is in an unknown state/);
+                .should.be.rejectedWith(/The current identity, with the name \'alice1\' and the identifier \'e38b9db5b7167f8033fb48f04efe5d5fd7ec36c8d7be51ed019f81e1ac66657f\', cannot be activated because it is in an unknown state \'ACTIVATED\'/);
         });
 
     });
@@ -305,7 +307,7 @@ describe('IdentityManager', () => {
             mockIdentityRegistry.add.resolves();
             (() => {
                 identityManager.activateIssuedIdentity(mockIdentityRegistry, identity);
-            }).should.throw(/The current identity cannot be activated because the issuer is invalid/);
+            }).should.throw(/The current identity, with the name \'alice1\' and the identifier \'e38b9db5b7167f8033fb48f04efe5d5fd7ec36c8d7be51ed019f81e1ac66657f\', cannot be activated because the issuer is invalid/);
         });
 
         it('should remove and add the updated identity in the identity registry', () => {

--- a/packages/composer-tests-functional/systest/identities.js
+++ b/packages/composer-tests-functional/systest/identities.js
@@ -165,7 +165,7 @@ describe('Identity system tests', function() {
             .then(() => {
                 return client.ping();
             })
-            .should.be.rejectedWith(/The current identity has been revoked/);
+            .should.be.rejectedWith(/The current identity, with the name \'.+?\' and the identifier \'.+?\', has been revoked/);
     });
 
     it('should throw an exception for a ping request using a identity that is mapped to a non-existent participant', () => {
@@ -184,7 +184,7 @@ describe('Identity system tests', function() {
                 client = result;
                 return client.ping();
             })
-            .should.be.rejectedWith(/The current identity is bound to a participant that does not exist/);
+            .should.be.rejectedWith(/The current identity, with the name \'.+?\' and the identifier \'.+?\', is bound to a participant \'resource:systest.identities.SampleParticipant#bob@uk.ibm.com\' that does not exist/);
     });
 
     it('should issue an identity and make the participant available for transaction processor functions', () => {
@@ -261,7 +261,7 @@ describe('Identity system tests', function() {
                 let transaction = factory.newTransaction('systest.identities', 'SampleTransaction');
                 return client.submitTransaction(transaction);
             })
-            .should.be.rejectedWith(/The current identity has been revoked/);
+            .should.be.rejectedWith(/The current identity, with the name \'.+?\' and the identifier \'.+?\', has been revoked/);
     });
 
     it('should throw an exception for a transaction processor function using a identity that is mapped to a non-existent participant', () => {
@@ -282,7 +282,7 @@ describe('Identity system tests', function() {
                 let transaction = factory.newTransaction('systest.identities', 'SampleTransaction');
                 return client.submitTransaction(transaction);
             })
-            .should.be.rejectedWith(/The current identity is bound to a participant that does not exist/);
+            .should.be.rejectedWith(/The current identity, with the name \'.+?\' and the identifier \'.+?\', is bound to a participant \'resource:systest.identities.SampleParticipant#bob@uk.ibm.com\' that does not exist/);
     });
 
     xit('should export credentials for previously imported identity', function () {


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->
Error message for unrecognized identities needs more information #3095

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->