### PR TITLE
add alias map to cucumber tests

### DIFF
--- a/packages/composer-tests-integration/features/cli.feature
+++ b/packages/composer-tests-integration/features/cli.feature
@@ -323,11 +323,12 @@ Feature: Cli steps
         Then The stdout information should include text matching /issuer:/
         Then The stdout information should include text matching /state:       ACTIVATED/
         Then The stdout information should include text matching /Command succeeded/
+        Then I save group 1 from the console output matching pattern ^[\S\s]*identityId:\s+([\S\s]*)\n\s+name:\s+bob[\S\s]*$ as alias BOBID
 
     Scenario: Using the CLI, I can revoke Bob's identity
-        When I run the following CLI command
+        When I substitue the alias BOBID and run the following CLI command
             """
-            composer identity revoke --identityId BOBSID --card admin@basic-sample-network
+            composer identity revoke --identityId BOBID --card admin@basic-sample-network
             """
         Then The stdout information should include text matching /was revoked and can no longer be used to connect to the business network./
         Then The stdout information should include text matching /Command succeeded/

--- a/packages/composer-tests-integration/lib/clisteps.js
+++ b/packages/composer-tests-integration/lib/clisteps.js
@@ -28,12 +28,20 @@ module.exports = function () {
         return this.composer.runCLI(table);
     });
 
+    this.When(/^I substitue the alias (.*?) and run the following CLI command$/, {timeout: 240 * 1000}, function (alias, table) {
+        return this.composer.runCLIWithAlias(alias, table);
+    });
+
     this.When(/^I spawn the following background task (.+?), and wait for \/(.+?)\/$/, {timeout: 240 * 1000}, function (label, regex, table) {
         return this.composer.runBackground(label, table, new RegExp(regex));
     });
 
     this.When(/^I kill task named (.+?)$/, {timeout: 240 * 1000}, function (label) {
         return this.composer.killBackground(label);
+    });
+
+    this.When(/^I save group (.+?) from the console output matching pattern (.+?) as alias (.*?)$/, function (group, regex, alias) {
+        return this.composer.saveMatchingGroupAsAlias(new RegExp(regex, 'g'), group, alias);
     });
 
     this.Then(/^The stdout information should include text matching \/(.+?)\/$/, function (regex) {

--- a/packages/composer-tests-integration/lib/hooks.js
+++ b/packages/composer-tests-integration/lib/hooks.js
@@ -18,13 +18,14 @@ const Composer = require('./composer');
 
 module.exports = function () {
     let tasks = {};
+    let aliasMap = new Map();
 
     this.Before(function (scenarioResult) {
         const uri = scenarioResult.scenario.uri;
         const errorExpected = scenarioResult.scenario.steps.some((step) => {
             return !!step.name.match(/^I should get an error/);
         });
-        this.composer = new Composer(uri, errorExpected, tasks);
+        this.composer = new Composer(uri, errorExpected, tasks, aliasMap);
         return Promise.resolve();
     });
 


### PR DESCRIPTION
This PR closes #3027 

Two methods are introduced and the existing feature file modified to use the new methods:
 - enable the saving off of a regex group match into an alias map
 - enable the substitution of an alias prior to running a CLI command