### PR TITLE
Change 'composer' to 'composer_full' Signed-off-by: Kartik Shah <krtk.6160@gmail.com>

### DIFF
--- a/packages/composer-website/jekylldocs/tutorials/developer-tutorial.md
+++ b/packages/composer-website/jekylldocs/tutorials/developer-tutorial.md
@@ -26,7 +26,7 @@ Before beginning this tutorial:
 
 ## Step One: Creating a business network structure
 
-The key concept for {{site.data.conrefs.composer}} is the **business network definition (BND)**. It defines the data model, transaction logic and access control rules for your blockchain solution. To create a BND,  we need to create a suitable project structure on disk.
+The key concept for {{site.data.conrefs.composer_full}} is the **business network definition (BND)**. It defines the data model, transaction logic and access control rules for your blockchain solution. To create a BND,  we need to create a suitable project structure on disk.
 
 The easiest way to get started is to use the Yeoman generator to create a skeleton business network. This will create a directory containing all of the components of a business network.
 


### PR DESCRIPTION
On line 29, the usage of 'site.data.conrefs.composer' causes nothing to be displayed in its place, when visiting the Composer docs hosted on github.io. Changing it to 'composer_full' should fix this issue.

