### PR TITLE
Next doc links should point to playground for 0.17.x (#3159)

### DIFF
--- a/packages/composer-website/jekylldocs/_data/links.yml
+++ b/packages/composer-website/jekylldocs/_data/links.yml
@@ -1,3 +1,3 @@
 
 playground:
-  https://composer-playground.mybluemix.net
+  https://composer-playground-next.mybluemix.net


### PR DESCRIPTION
Contributes to #3159

Change 
0.17.x tutorials/playground-tutorial link 'Composer Playground' to point to:  http://composer-playground-next.mybluemix.net/login
