### PR TITLE
Corrections to test code for the composer-cli

### DIFF
--- a/packages/composer-cli/cli.js
+++ b/packages/composer-cli/cli.js
@@ -17,7 +17,7 @@
 
 // not using the config file module as this could be run anwhere so suppress warning
 process.env.SUPPRESS_NO_CONFIG_WARNING = true;
-
+const cmdUtil = require('./lib/cmds/utils/cmdutils');
 const yargs = require('yargs');
 const chalk = require('chalk');
 const version = 'v' +require('./package.json').version;
@@ -39,11 +39,11 @@ if (typeof(results.thePromise) !== 'undefined'){
     results.thePromise.then( () => {
 
         if (!results.quiet) {
-            console.log(chalk.green('\nCommand succeeded\n'));
+            cmdUtil.log(chalk.green('\nCommand succeeded\n'));
         }
         process.exit(0);
     }).catch((error) => {
-        console.log(error+chalk.red('\nCommand failed\n'));
+        cmdUtil.log(error+chalk.red('\nCommand failed\n'));
         process.exit(1);
     });
 } else {

--- a/packages/composer-cli/lib/cmds/network/lib/list.js
+++ b/packages/composer-cli/lib/cmds/network/lib/list.js
@@ -43,8 +43,7 @@ class List {
         let spinner;
         let cardName = argv.card;
 
-        spinner = ora('List business network from card '+ cardName );
-        spinner.start();
+        spinner = ora('List business network from card '+ cardName ).start();
 
         businessNetworkConnection = cmdUtil.createBusinessNetworkConnection();
         return businessNetworkConnection.connect(cardName)
@@ -113,9 +112,8 @@ class List {
             return businessNetworkConnection.disconnect();
         })
         .catch(error => {
-            if (spinner) {
-                spinner.fail();
-            }
+            spinner.fail();
+
             cmdUtil.log(List.getError(error));
             throw error;
         });

--- a/packages/composer-cli/test/archive/create.js
+++ b/packages/composer-cli/test/archive/create.js
@@ -64,7 +64,7 @@ describe('composer archive create unit tests', function () {
 
 
 
-        it('Good path, all parms correctly specified.', function () {
+        it('should correctly execute when all parms correctly specified.', function () {
 
             let argv = {archiveFile: 'testArchiveFile.zip'
                         , sourceType: 'dir'
@@ -79,7 +79,7 @@ describe('composer archive create unit tests', function () {
             });
         });
 
-        it('Good path, all parms correctly specified & cwd ', function () {
+        it('should correctly execute all parms correctly specified & cwd ', function () {
 
             let argv = {archiveFile: 'testArchiveFile.zip'
             ,sourceType: 'dir'
@@ -94,7 +94,7 @@ describe('composer archive create unit tests', function () {
             });
         });
 
-        it('Good path, all parms correctly specified - no archive', function () {
+        it('should correctly execute when all parms correctly specified - no archive', function () {
 
             let argv = {sourceType: 'dir'
            ,sourceName:  '/home/mwhite/biznet'};
@@ -108,7 +108,7 @@ describe('composer archive create unit tests', function () {
             });
         });
 
-        it('Good path, module name - archivefile & modulename that exists', function () {
+        it('should correctly execute when module name - archivefile & modulename that exists', function () {
 
             let argv = {archiveFile: 'testArchiveFile.zip',
                 moduleName: 'fs'};
@@ -122,7 +122,7 @@ describe('composer archive create unit tests', function () {
             });
         });
 
-        it('Good path, module name - archivefile & modulename that does not exists', function () {
+        it('should correctly execute when module name - archivefile & modulename that does not exists', function () {
 
             let argv = {archiveFile: 'testArchiveFile.zip',
                 sourceType: 'module', sourceName: 'fake'};

--- a/packages/composer-cli/test/archive/list.js
+++ b/packages/composer-cli/test/archive/list.js
@@ -62,7 +62,7 @@ describe('composer archive list unit tests', function () {
 
     describe('List handler() method tests', function () {
 
-        it('Good path, all parms correctly specified.', function () {
+        it('should correctly execute when all parms correctly specified.', function () {
 
             let argv = {archiveFile: 'testArchiveFile.zip'};
 

--- a/packages/composer-cli/test/cli.js
+++ b/packages/composer-cli/test/cli.js
@@ -102,6 +102,12 @@ describe('composer cli', () => {
             require('../cli.js');
             sinon.assert.calledWith(process.exit, 0);
         });
+        it('Should handle resolved promise, with the quiet setting', () => {
+            sandbox.stub(yargs, 'describe').returns({ argv: {thePromise: new fakePromise(),quiet:true} });
+            delete require.cache[path.resolve(__dirname, '../cli.js')];
+            require('../cli.js');
+            sinon.assert.calledWith(process.exit, 0);
+        });
         it('Should handle rejected promise', () => {
             sandbox.stub(yargs, 'describe').returns({ argv: {thePromise: new fakePromise()} });
             delete require.cache[path.resolve(__dirname, '../cli.js')];

--- a/packages/composer-cli/test/generator/createCode.js
+++ b/packages/composer-cli/test/generator/createCode.js
@@ -98,7 +98,7 @@ describe('composer generator create unit tests', function () {
 
     describe('Deploy handler() method tests', function () {
 
-        it('Good path, all parms correctly specified.', function () {
+        it('should correctly execute when all parms correctly specified.', function () {
 
             let argv = {archiveFile: 'testArchiveFile.zip'
                         ,format: 'Go'
@@ -116,7 +116,7 @@ describe('composer generator create unit tests', function () {
             });
         });
 
-        it('Good path, all parms correctly specified.', function () {
+        it('should correctly execute when all parms correctly specified.', function () {
 
             let argv = {archiveFile: 'testArchiveFile.zip'
                         ,format: 'PlantUML'
@@ -132,7 +132,7 @@ describe('composer generator create unit tests', function () {
                 sinon.assert.calledWith(mockBusinessNetworkDefinition.accept,mockPlantUML,parameters);
             });
         });
-        it('Good path, all parms correctly specified.', function () {
+        it('should correctly execute when all parms correctly specified.', function () {
 
             let argv = {archiveFile: 'testArchiveFile.zip'
                         ,format: 'Typescript'
@@ -148,7 +148,7 @@ describe('composer generator create unit tests', function () {
                 sinon.assert.calledWith(mockBusinessNetworkDefinition.accept,mockTypescript,parameters);
             });
         });
-        it('Good path, all parms correctly specified.', function () {
+        it('should correctly execute when all parms correctly specified.', function () {
 
             let argv = {archiveFile: 'testArchiveFile.zip'
                         ,format: 'JSONSchema'
@@ -165,7 +165,7 @@ describe('composer generator create unit tests', function () {
             });
         });
 
-        it('Good path, all parms correctly specified.', function () {
+        it('should correctly execute when all parms correctly specified', function () {
 
             let argv = {archiveFile: 'testArchiveFile.zip'
                                     ,format: 'Java'
@@ -182,7 +182,7 @@ describe('composer generator create unit tests', function () {
                         });
         });
 
-        it('Invalid generator specified', function () {
+        it('Should throw error when Invalid generator specified', function () {
 
             let argv = {archiveFile: 'testArchiveFile.zip'
                         ,format: 'I-do-not-exist'

--- a/packages/composer-cli/test/identity/issue.js
+++ b/packages/composer-cli/test/identity/issue.js
@@ -27,6 +27,7 @@ const sinon = require('sinon');
 const chai = require('chai');
 chai.should();
 chai.use(require('chai-as-promised'));
+const ora = require('ora');
 
 const fs = require('fs');
 
@@ -64,6 +65,18 @@ describe('composer identity issue CLI unit tests', () => {
 
     afterEach(() => {
         sandbox.restore();
+    });
+
+    it('should handler error case when spinner might not have been created correctly', () => {
+        let argv = {
+            card:'cardname',
+            newUserId: 'dogeid1',
+            participantId: 'org.doge.Doge#DOGE_1'
+        };
+        sandbox.stub(CmdUtil,'log').throws(new Error());
+        sandbox.stub(ora,'start').returns();
+        return Issue.handler(argv)
+        .should.be.rejectedWith();
     });
 
     it('should issue a new identity using the specified profile', () => {

--- a/packages/composer-cli/test/index.js
+++ b/packages/composer-cli/test/index.js
@@ -38,7 +38,7 @@ describe('composer main cli fn', function () {
 
     describe('Main test', function () {
 
-        it('Good path', function () {
+        it('should correctly execute and return version', function () {
             let version = require('../index.js').version;
             version.should.not.be.null;
 

--- a/packages/composer-cli/test/network/deploy.js
+++ b/packages/composer-cli/test/network/deploy.js
@@ -76,7 +76,7 @@ describe('composer deploy network CLI unit tests', function () {
 
     describe('Deploy handler() method tests', function () {
 
-        it('Good path, optional parameter -O /path/to/options.json specified.', function () {
+        it('should correctly execute when optional parameter -O /path/to/options.json specified.', function () {
 
             let argv = {card:'cardname'
                         ,archiveFile: 'testArchiveFile.zip'
@@ -127,7 +127,7 @@ describe('composer deploy network CLI unit tests', function () {
             });
         });
 
-        it('Good path, optional parameter -o endorsementPolicyFile= specified.', function () {
+        it('should correctly execute when optional parameter -o endorsementPolicyFile= specified.', function () {
 
             let argv = {card:'cardname'
                         ,archiveFile: 'testArchiveFile.zip'
@@ -162,7 +162,7 @@ describe('composer deploy network CLI unit tests', function () {
         });
 
 
-        it('Good path, optional parameter -o endorsementPolicy= specified.', function () {
+        it('should correctly execute when optional parameter -o endorsementPolicy= specified.', function () {
 
             let argv = {card:'cardname'
                         ,archiveFile: 'testArchiveFile.zip'
@@ -192,7 +192,7 @@ describe('composer deploy network CLI unit tests', function () {
         });
 
 
-        it('Good path, all parms correctly specified.', function () {
+        it('should correctly execute when all parms correctly specified.', function () {
             let argv = {card:'cardname'
                         ,archiveFile: 'testArchiveFile.zip'
                         ,networkAdmin: 'admin'
@@ -219,7 +219,7 @@ describe('composer deploy network CLI unit tests', function () {
             });
         });
 
-        it('Good path, all parms correctly specified, including optional logLevel.', function () {
+        it('should correctly execute when all parms correctly specified, including optional logLevel.', function () {
 
             let argv = {card:'cardname'
                        ,archiveFile: 'testArchiveFile.zip'
@@ -250,7 +250,7 @@ describe('composer deploy network CLI unit tests', function () {
             });
         });
 
-        it('Good path, all parms correctly specified. with the certificate', function () {
+        it('should correctly execute when, all parms correctly specified. with the certificate', function () {
 
             let argv = {card:'cardname'
                         ,archiveFile: 'testArchiveFile.zip'
@@ -286,7 +286,7 @@ describe('composer deploy network CLI unit tests', function () {
             });
         };
 
-        it('Good path, network administrator specified', function () {
+        it('should correctly execute when network administrator specified', function () {
 
 
             let argv = {card:'cardname'
@@ -314,7 +314,7 @@ describe('composer deploy network CLI unit tests', function () {
             });
         });
 
-        it('Good path, network administrator and bootstrap transactions specified', function () {
+        it('should correctly execute when network administrator and bootstrap transactions specified', function () {
 
             let argv = {card:'cardname'
                         ,networkAdmin: 'admin1'

--- a/packages/composer-cli/test/network/download.js
+++ b/packages/composer-cli/test/network/download.js
@@ -61,7 +61,7 @@ describe('composer network download CLI unit tests', function () {
 
     describe('Download handler() method tests', function () {
 
-        it('Good path, all parms correctly specified.', function () {
+        it('should correctly execute when all parms correctly specified.', function () {
 
             let argv = {enrollId: 'WebAppAdmin'
                        ,enrollSecret: 'DJY27pEnl16d'
@@ -77,7 +77,7 @@ describe('composer network download CLI unit tests', function () {
             });
         });
 
-        it('Good path, all parms correctly specified. No enroll secret', function () {
+        it('should correctly execute when all parms correctly specified. No enroll secret', function () {
 
             let argv = {enrollId: 'WebAppAdmin'
                                    ,archiveFile: 'testArchiveFile.zip'
@@ -92,7 +92,7 @@ describe('composer network download CLI unit tests', function () {
                         });
         });
 
-        it('Good path, all parms correctly specified with card.', function () {
+        it('should correctly execute when all parms correctly specified with card.', function () {
             let argv = {card: 'cardName'};
             return DownloadCmd.handler(argv)
             .then ((result) => {

--- a/packages/composer-cli/test/network/list.js
+++ b/packages/composer-cli/test/network/list.js
@@ -253,10 +253,6 @@ describe('composer network list CLI unit tests', function () {
 
     });
 
-
-
-
-
     describe('#getMatchingRegistries function tests', function () {
         const MOCK_ASSET_REGISTRIES = {'AssetRegistry' : 'FooAssetRegistry'};
         const MOCK_PARTICIPANT_REGISTRIES = {'ParticipantRegistry' : 'BarParticipantRegistry'};

--- a/packages/composer-cli/test/network/start.js
+++ b/packages/composer-cli/test/network/start.js
@@ -64,6 +64,8 @@ describe('composer start network CLI unit tests', function () {
         sandbox.stub(CmdUtil, 'createAdminConnection').returns(mockAdminConnection);
         sandbox.stub(process, 'exit');
 
+        sandbox.stub(fs, 'writeFileSync');
+
         return businessNetworkDefinition.toArchive()
             .then((archive) => {
                 testBusinessNetworkArchive = archive;
@@ -76,7 +78,7 @@ describe('composer start network CLI unit tests', function () {
 
     describe('Deploy handler() method tests', function () {
 
-        it('Good path, optional parameter -O /path/to/options.json specified.', function () {
+        it('should correctly execute when optional parameter -O /path/to/options.json specified.', function () {
 
             let argv = {card:'cardname'
                         ,archiveFile: 'testArchiveFile.zip'
@@ -108,7 +110,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(BusinessNetworkDefinition.fromArchive);
                 sinon.assert.calledWith(BusinessNetworkDefinition.fromArchive, testBusinessNetworkArchive);
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
-
+                sinon.assert.calledTwice(fs.writeFileSync);
                 sinon.assert.calledOnce(mockAdminConnection.connect);
                 sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
@@ -119,7 +121,7 @@ describe('composer start network CLI unit tests', function () {
             });
         });
 
-        it('Good path, optional parameter -o endorsementPolicyFile= specified.', function () {
+        it('should correctly execute when optional parameter -o endorsementPolicyFile= specified.', function () {
 
             let argv = {card:'cardname'
                        ,option: 'endorsementPolicyFile=/path/to/some/file.json'
@@ -135,7 +137,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(BusinessNetworkDefinition.fromArchive);
                 sinon.assert.calledWith(BusinessNetworkDefinition.fromArchive, testBusinessNetworkArchive);
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
-
+                sinon.assert.calledTwice(fs.writeFileSync);
                 sinon.assert.calledOnce(mockAdminConnection.connect);
                 sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
@@ -147,7 +149,7 @@ describe('composer start network CLI unit tests', function () {
         });
 
 
-        it('Good path, optional parameter -o endorsementPolicy= specified.', function () {
+        it('should correctly execute when optional parameter -o endorsementPolicy= specified.', function () {
 
             let argv = {card:'cardname'
                        ,archiveFile: 'testArchiveFile.zip'
@@ -165,7 +167,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(BusinessNetworkDefinition.fromArchive);
                 sinon.assert.calledWith(BusinessNetworkDefinition.fromArchive, testBusinessNetworkArchive);
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
-
+                sinon.assert.calledTwice(fs.writeFileSync);
                 sinon.assert.calledOnce(mockAdminConnection.connect);
                 sinon.assert.calledWith(mockAdminConnection.connect,'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
@@ -177,7 +179,7 @@ describe('composer start network CLI unit tests', function () {
         });
 
 
-        it('Good path, all parms correctly specified.', function () {
+        it('should correctly execute when all parms correctly specified.', function () {
 
             let argv = {card:'cardname'
                        ,archiveFile: 'testArchiveFile.zip'
@@ -194,7 +196,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(BusinessNetworkDefinition.fromArchive);
                 sinon.assert.calledWith(BusinessNetworkDefinition.fromArchive, testBusinessNetworkArchive);
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
-
+                sinon.assert.calledTwice(fs.writeFileSync);
                 sinon.assert.calledOnce(mockAdminConnection.connect);
                 sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
@@ -203,7 +205,7 @@ describe('composer start network CLI unit tests', function () {
             });
         });
 
-        it('Good path, all parms correctly specified. with the certificate', function () {
+        it('should correctly execute when all parms correctly specified. with the certificate', function () {
 
             let argv = {card:'cardname'
                                    ,archiveFile: 'testArchiveFile.zip'
@@ -220,7 +222,7 @@ describe('composer start network CLI unit tests', function () {
                             sinon.assert.calledOnce(BusinessNetworkDefinition.fromArchive);
                             sinon.assert.calledWith(BusinessNetworkDefinition.fromArchive, testBusinessNetworkArchive);
                             sinon.assert.calledOnce(CmdUtil.createAdminConnection);
-
+                            sinon.assert.calledTwice(fs.writeFileSync);
                             sinon.assert.calledOnce(mockAdminConnection.connect);
                             sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                             sinon.assert.calledOnce(mockAdminConnection.start);
@@ -228,7 +230,7 @@ describe('composer start network CLI unit tests', function () {
 
                         });
         });
-        it('Good path, all parms correctly specified. File output set for the card', function () {
+        it('should correctly execute when all parms correctly specified. File output set for the card', function () {
 
             let argv = {card:'cardname'
                                    ,archiveFile: 'testArchiveFile.zip'
@@ -246,7 +248,7 @@ describe('composer start network CLI unit tests', function () {
                             sinon.assert.calledOnce(BusinessNetworkDefinition.fromArchive);
                             sinon.assert.calledWith(BusinessNetworkDefinition.fromArchive, testBusinessNetworkArchive);
                             sinon.assert.calledOnce(CmdUtil.createAdminConnection);
-
+                            sinon.assert.calledTwice(fs.writeFileSync);
                             sinon.assert.calledOnce(mockAdminConnection.connect);
                             sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                             sinon.assert.calledOnce(mockAdminConnection.start);
@@ -255,7 +257,7 @@ describe('composer start network CLI unit tests', function () {
                         }       );
         });
 
-        it('Good path, all parms correctly specified, including optional logLevel.', function () {
+        it('should correctly execute when all parms correctly specified, including optional logLevel.', function () {
 
             let argv = {card:'cardname'
                        ,archiveFile: 'testArchiveFile.zip'
@@ -273,7 +275,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(BusinessNetworkDefinition.fromArchive);
                 sinon.assert.calledWith(BusinessNetworkDefinition.fromArchive, testBusinessNetworkArchive);
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
-
+                sinon.assert.calledTwice(fs.writeFileSync);
                 sinon.assert.calledOnce(mockAdminConnection.connect);
                 sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
@@ -281,7 +283,7 @@ describe('composer start network CLI unit tests', function () {
             });
         });
 
-        it('Good path, no secret, all other parms correctly specified.', function () {
+        it('should correctly execute when no secret, all other parms correctly specified.', function () {
 
             let argv = {card:'cardname'
                        ,archiveFile: 'testArchiveFile.zip'
@@ -298,7 +300,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(BusinessNetworkDefinition.fromArchive);
                 sinon.assert.calledWith(BusinessNetworkDefinition.fromArchive, testBusinessNetworkArchive);
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
-
+                sinon.assert.calledTwice(fs.writeFileSync);
                 sinon.assert.calledOnce(mockAdminConnection.connect);
                 sinon.assert.calledWith(mockAdminConnection.connect,'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
@@ -316,7 +318,7 @@ describe('composer start network CLI unit tests', function () {
             });
         };
 
-        it('Good path, network administrator specified', function () {
+        it('should correctly execute when, network administrator specified', function () {
 
             let argv = {card:'cardname'
                         ,archiveFile: 'testArchiveFile.zip'
@@ -333,7 +335,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(BusinessNetworkDefinition.fromArchive);
                 sinon.assert.calledWith(BusinessNetworkDefinition.fromArchive, testBusinessNetworkArchive);
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
-
+                sinon.assert.calledTwice(fs.writeFileSync);
                 sinon.assert.calledOnce(mockAdminConnection.connect);
                 sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
@@ -341,7 +343,7 @@ describe('composer start network CLI unit tests', function () {
             });
         });
 
-        it('Good path, network administrator and bootstrap transactions specified', function () {
+        it('should correctly execute when network administrator and bootstrap transactions specified', function () {
 
             let argv = {card:'cardname'
                         ,archiveFile: 'testArchiveFile.zip'
@@ -370,7 +372,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(BusinessNetworkDefinition.fromArchive);
                 sinon.assert.calledWith(BusinessNetworkDefinition.fromArchive, testBusinessNetworkArchive);
                 sinon.assert.calledOnce(CmdUtil.createAdminConnection);
-
+                sinon.assert.calledTwice(fs.writeFileSync);
                 sinon.assert.calledOnce(mockAdminConnection.connect);
                 sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                 sinon.assert.calledOnce(mockAdminConnection.start);
@@ -421,7 +423,7 @@ describe('composer start network CLI unit tests', function () {
                 });
         });
 
-        it('Good path, network administrator specified', function () {
+        it('should correctly execute when network administrator specified', function () {
 
             let argv = {card:'cardname'
                                     ,archiveFile: 'testArchiveFile.zip'
@@ -439,7 +441,7 @@ describe('composer start network CLI unit tests', function () {
                             sinon.assert.calledOnce(BusinessNetworkDefinition.fromArchive);
                             sinon.assert.calledWith(BusinessNetworkDefinition.fromArchive, testBusinessNetworkArchive);
                             sinon.assert.calledOnce(CmdUtil.createAdminConnection);
-
+                            sinon.assert.calledTwice(fs.writeFileSync);
                             sinon.assert.calledOnce(mockAdminConnection.connect);
                             sinon.assert.calledWith(mockAdminConnection.connect, 'cardname');
                             sinon.assert.calledOnce(mockAdminConnection.start);
@@ -451,7 +453,7 @@ describe('composer start network CLI unit tests', function () {
 
     describe('Deploy getArchiveFileContents() method tests', function () {
 
-        it('Archive file exists', function () {
+        it('Should correctly get the archive file contents if it exists', function () {
 
             sandbox.stub(fs, 'existsSync').returns(true);
             let testArchiveFileContents = JSON.stringify(testBusinessNetworkArchive);
@@ -464,7 +466,7 @@ describe('composer start network CLI unit tests', function () {
 
         });
 
-        it('Archive file does not exist', function () {
+        it('Should throw correct error if archive file does not exist', function () {
 
             sandbox.stub(fs, 'existsSync').returns(false);
             let testArchiveFileContents = JSON.stringify(testBusinessNetworkArchive);
@@ -474,7 +476,7 @@ describe('composer start network CLI unit tests', function () {
             (() => {Start.getArchiveFileContents(testArchiveFile);}).should.throw('Archive file '+testArchiveFile+' does not exist.');
 
         });
-        it('Unexpected errror', function () {
+        it('Should handle correctly any unexpected errors', function () {
 
             let argv = {card:'cardname'
                                                ,archiveFile: 'testArchiveFile.zip'

--- a/packages/composer-cli/test/network/undeploy.js
+++ b/packages/composer-cli/test/network/undeploy.js
@@ -57,7 +57,7 @@ describe('composer undeploy network CLI unit tests', function () {
 
     describe('Undeploy handler() method tests', function () {
 
-        it('Good path, all parms correctly specified.', function () {
+        it('should correctly execute when all parms correctly specified.', function () {
 
             let argv = {card:'cardname'
                        ,archiveFile: 'testArchiveFile.zip'};

--- a/packages/composer-cli/test/network/update.js
+++ b/packages/composer-cli/test/network/update.js
@@ -86,7 +86,7 @@ describe('composer update network CLI unit tests', function () {
     });
 
     describe('using network cards', ()=>{
-        it('Good path with update enabled', function () {
+        it('should correctly execute when with update enabled', function () {
             let businessNetworkDefinition = new BusinessNetworkDefinition('my-network@1.0.0');
 
             let testBusinessNetworkArchive;

--- a/packages/composer-cli/test/network/upgrade.js
+++ b/packages/composer-cli/test/network/upgrade.js
@@ -50,7 +50,7 @@ describe('composer upgrade runtime CLI unit tests', function () {
 
     describe('Upgrade handler() method tests', function () {
 
-        it('Good path, all parms correctly specified.', function () {
+        it('should correctly execute when all parms correctly specified.', function () {
 
             let argv = {card:'cardname'
                        ,businessNetworkName: 'org-acme-biznet'};

--- a/packages/composer-cli/test/report/report.js
+++ b/packages/composer-cli/test/report/report.js
@@ -14,6 +14,8 @@
 
 'use strict';
 
+const Report = require('../../lib/cmds/report.js');
+
 const ReportCmd = require('../../lib/cmds/report/reportCommand.js');
 const chai = require('chai');
 const sinon = require('sinon');
@@ -23,8 +25,6 @@ const fs = require('fs');
 const os = require('os');
 const nodereport = require('node-report');
 const tar = require('tar');
-
-
 
 describe('composer report CLI', function() {
     const sandbox = sinon.sandbox.create();
@@ -88,4 +88,10 @@ describe('composer report CLI', function() {
             sinon.assert.calledWith(consoleLogSpy, sinon.match(/Output file: .*composer-report-\d{8}T\d{6}\.tgz$/));
         });
     });
+
+    it('should execute top level report command',()=>{
+        let result = Report.handler({some:'args'});
+        result.should.be.an.instanceOf(Promise);
+    });
+
 });

--- a/packages/composer-cli/test/runtime/install.js
+++ b/packages/composer-cli/test/runtime/install.js
@@ -50,7 +50,7 @@ describe('composer install runtime CLI unit tests', function () {
 
     describe('Install handler() method tests', function () {
 
-        it('Good path, all parms correctly specified.', function () {
+        it('should correctly execute when all parms correctly specified.', function () {
 
             let argv = {card:'cardname'
                        ,connectionProfileName: 'testProfile'};
@@ -67,7 +67,7 @@ describe('composer install runtime CLI unit tests', function () {
             });
         });
 
-        it('Good path, all params correctly specified (card base)', function () {
+        it('hould correctly execute when all params correctly specified (card base)', function () {
 
             let argv = {card:'cardname'};
             return InstallCmd.handler(argv)


### PR DESCRIPTION
- Stubbed out the file system to prevent cards being written to disk
- Added some tests to increase the coverage
- Did alter the network use of spinner to simplify the code and make it testable.

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>
