### PR TITLE
Correct the creation of the registries if accessed via ''getRegistry"

### DIFF
--- a/packages/composer-client/lib/businessnetworkconnection.js
+++ b/packages/composer-client/lib/businessnetworkconnection.js
@@ -500,7 +500,8 @@ class BusinessNetworkConnection extends EventEmitter {
                                                    this.securityContext,
                                                    businessNetwork.getModelManager(),
                                                    businessNetwork.getFactory(),
-                                                   businessNetwork.getSerializer());
+                                                   businessNetwork.getSerializer(),
+                                                   this);
                 case 'Asset':
                     return new AssetRegistry(registry.id,
                                              registry.name,
@@ -515,7 +516,8 @@ class BusinessNetworkConnection extends EventEmitter {
                                                    this.securityContext,
                                                    businessNetwork.getModelManager(),
                                                    businessNetwork.getFactory(),
-                                                   businessNetwork.getSerializer());
+                                                   businessNetwork.getSerializer(),
+                                                   this);
                 }
             });
 

--- a/packages/composer-client/lib/businessnetworkconnection.js
+++ b/packages/composer-client/lib/businessnetworkconnection.js
@@ -495,11 +495,27 @@ class BusinessNetworkConnection extends EventEmitter {
             .then((registry) => {
                 switch (type) {
                 case 'Transaction':
-                    return new TransactionRegistry(registry.id, registry.name, this.securityContext, businessNetwork.getModelManager(), businessNetwork.getFactory(), businessNetwork.getSerializer());
+                    return new TransactionRegistry(registry.id,
+                                                   registry.name,
+                                                   this.securityContext,
+                                                   businessNetwork.getModelManager(),
+                                                   businessNetwork.getFactory(),
+                                                   businessNetwork.getSerializer());
                 case 'Asset':
-                    return new AssetRegistry(registry.id, registry.name, this.securityContext, businessNetwork.getModelManager(), businessNetwork.getFactory(), businessNetwork.getSerializer());
+                    return new AssetRegistry(registry.id,
+                                             registry.name,
+                                             this.securityContext,
+                                             businessNetwork.getModelManager(),
+                                             businessNetwork.getFactory(),
+                                             businessNetwork.getSerializer(),
+                                             this);
                 case 'Participant':
-                    return new ParticipantRegistry(registry.id, registry.name, this.securityContext, businessNetwork.getModelManager(), businessNetwork.getFactory(), businessNetwork.getSerializer());
+                    return new ParticipantRegistry(registry.id,
+                                                   registry.name,
+                                                   this.securityContext,
+                                                   businessNetwork.getModelManager(),
+                                                   businessNetwork.getFactory(),
+                                                   businessNetwork.getSerializer());
                 }
             });
 

--- a/packages/composer-tests-functional/systest/assets.js
+++ b/packages/composer-tests-functional/systest/assets.js
@@ -492,6 +492,51 @@ describe('Asset system tests', function() {
             });
     });
 
+    it('should store assets in the correct registry obtained from general get registry call', () => {
+        let assetRegistry;
+        let assetContainerRegistry;
+        return client
+            .getRegistry('systest.assets.SimpleAsset')
+            .then(function (result) {
+                assetRegistry = result;
+                let asset = createAsset('dogeAsset1');
+                return assetRegistry.add(asset);
+            })
+            .then(function () {
+                let asset = createAsset('dogeAsset2');
+                return assetRegistry.add(asset);
+            })
+            .then(function () {
+                let asset = createAsset('dogeAsset3');
+                return assetRegistry.add(asset);
+            })
+            .then(function () {
+                return client.getRegistry('systest.assets.SimpleAssetRelationshipContainer');
+            })
+            .then(function (result) {
+                assetContainerRegistry = result;
+                let assetContainer = createAssetRelationshipContainer();
+                let factory = client.getBusinessNetwork().getFactory();
+                assetContainer.simpleAsset = factory.newRelationship('systest.assets', 'SimpleAsset', 'dogeAsset1');
+                assetContainer.simpleAssets = [
+                    factory.newRelationship('systest.assets', 'SimpleAsset', 'dogeAsset2'),
+                    factory.newRelationship('systest.assets', 'SimpleAsset', 'dogeAsset3')
+                ];
+                return assetContainerRegistry.add(assetContainer);
+            })
+            .then(function () {
+                return assetContainerRegistry.getAll();
+            })
+            .then(function (assetContainers) {
+                assetContainers.length.should.equal(1);
+                validateAssetRelationshipContainer(assetContainers[0], 'dogeAssetRelationshipContainer');
+                return assetContainerRegistry.get('dogeAssetRelationshipContainer');
+            })
+            .then(function (assetContainer) {
+                validateAssetRelationshipContainer(assetContainer, 'dogeAssetRelationshipContainer');
+            });
+    });
+
     it('should resolve assets containing asset relationships from an asset registry', () => {
         let assetRegistry;
         let assetContainerRegistry;

--- a/packages/composer-tests-functional/systest/participants.js
+++ b/packages/composer-tests-functional/systest/participants.js
@@ -442,6 +442,50 @@ describe('Participant system tests', function() {
             });
     });
 
+    it('should store participants obtaining the registry from the generic call', () => {
+        let participantRegistry;
+        let participantContainerRegistry;
+        return client
+            .getRegistry('systest.participants.SimpleParticipant')
+            .then(function (result) {
+                participantRegistry = result;
+                let participant = createParticipant('dogeParticipant1');
+                return participantRegistry.add(participant);
+            })
+            .then(function () {
+                let participant = createParticipant('dogeParticipant2');
+                return participantRegistry.add(participant);
+            })
+            .then(function () {
+                let participant = createParticipant('dogeParticipant3');
+                return participantRegistry.add(participant);
+            })
+            .then(function () {
+                return client.getRegistry('systest.participants.SimpleParticipantContainer');
+            })
+            .then(function (result) {
+                participantContainerRegistry = result;
+                let participantContainer = createParticipantContainer();
+                participantContainer.simpleParticipant = createParticipant('dogeParticipant1');
+                participantContainer.simpleParticipants = [
+                    createParticipant('dogeParticipant2'),
+                    createParticipant('dogeParticipant3')
+                ];
+                return participantContainerRegistry.add(participantContainer);
+            })
+            .then(function () {
+                return participantContainerRegistry.getAll();
+            })
+            .then(function (participantContainers) {
+                participantContainers.length.should.equal(1);
+                validateParticipantContainer(participantContainers[0], 'dogeParticipantContainer');
+                return participantContainerRegistry.get('dogeParticipantContainer');
+            })
+            .then(function (participantContainer) {
+                validateParticipantContainer(participantContainer, 'dogeParticipantContainer');
+            });
+    });
+
     it('should store participants containing participant relationships in a participant registry', () => {
         let participantRegistry;
         let participantContainerRegistry;


### PR DESCRIPTION
The generic `getRegistry` api can be useful. 
Esp if you are loading in assets say from a JSON file. 

resolves issue #2937 