### PR TITLE
iss2952 change network deploy to network start

### DIFF
--- a/packages/composer-website/jekylldocs/managing/connector-information.md
+++ b/packages/composer-website/jekylldocs/managing/connector-information.md
@@ -14,4 +14,4 @@ excerpt:
 
 ## {{site.data.conrefs.hlf_full}}
 
-There are several cases where information specific to {{site.data.conrefs.hlf_full}} must be included in {{site.data.conrefs.composer_full}} commands, including `composer network deploy`, and `composer identity issue`.
+There are several cases where information specific to {{site.data.conrefs.hlf_full}} must be included in {{site.data.conrefs.composer_full}} commands, including `composer network start`, and `composer identity issue`.

--- a/packages/composer-website/jekylldocs/reference/commands.md
+++ b/packages/composer-website/jekylldocs/reference/commands.md
@@ -58,6 +58,8 @@ Lists all cards currently in your wallet: [composer card list](./composer.card.l
 
 Deploy a Business Network Definition: [composer network deploy](./composer.network.deploy.html)
 
+*Please note: It is recommended that users use the `composer network install` and `composer network start` commands instead of this command.*
+
 `composer network undeploy`
 
 Permanently disable a business network definition: [composer network undeploy](./composer.network.undeploy.html)


### PR DESCRIPTION
This change encourages users to use the `composer network install` and `composer network start` commands in favour of the `composer network deploy` command which could cause issues as per issue #2952