### PR TITLE
iss2952 change network deploy to network start

### DIFF
--- a/packages/composer-website/jekylldocs/managing/connector-information.md
+++ b/packages/composer-website/jekylldocs/managing/connector-information.md
@@ -14,4 +14,4 @@ excerpt:
 
 ## {{site.data.conrefs.hlf_full}}
 
-There are several cases where information specific to {{site.data.conrefs.hlf_full}} must be included in {{site.data.conrefs.composer_full}} commands, including `composer network deploy`, and `composer identity issue`.
+There are several cases where information specific to {{site.data.conrefs.hlf_full}} must be included in {{site.data.conrefs.composer_full}} commands, including `composer network start`, and `composer identity issue`.

--- a/packages/composer-website/jekylldocs/reference/commands.md
+++ b/packages/composer-website/jekylldocs/reference/commands.md
@@ -58,6 +58,8 @@ Lists all cards currently in your wallet: [composer card list](./composer.card.l
 
 Deploy a Business Network Definition: [composer network deploy](./composer.network.deploy.html)
 
+*Please note: It is recommended that users use the `composer network install` and `composer network start` commands instead of this command.*
+
 `composer network undeploy`
 
 Permanently disable a business network definition: [composer network undeploy](./composer.network.undeploy.html)

--- a/packages/composer-website/jekylldocs/reference/composer.network.deploy.md
+++ b/packages/composer-website/jekylldocs/reference/composer.network.deploy.md
@@ -14,7 +14,7 @@ The `composer network deploy` utility is used to deploy a business network archi
 Before using this command, read the topic [Deploying and Updating Business Networks](../business-network/bnd-deploy.html).
 
 ```
-composer network deploy -a digitalPropertyNetwork.bna -A admin -S -c PeerAdmin@hlfv1 -f admincard
+composer network deploy -a digitalPropertyNetwork.bna -A admin -S adminpw -c PeerAdmin@hlfv1 -f admincard
 ```
 
 ### Options
@@ -39,7 +39,7 @@ Options:
 ## Example Output
 
 ```
-composer network deploy -a digitalPropertyNetwork.bna -A admin -S -c PeerAdmin@hlfv1 -f admincard
+composer network deploy -a digitalPropertyNetwork.bna -A admin -S adminpw -c PeerAdmin@hlfv1 -f admincard
 
 Deploying business network from archive digitalPropertyNetwork.bna
 Business network definition:


### PR DESCRIPTION
Signed-off-by: Sam Smith <smithsj@uk.ibm.com>
Discourage users from using `composer network deploy`.
Encourage `composer network install` and `composer network start`
