### PR TITLE
issue 3305 add report into integration tests

### DIFF
--- a/packages/composer-tests-integration/README.md
+++ b/packages/composer-tests-integration/README.md
@@ -1,2 +1,41 @@
 # Composer-Integration-Tests
-Integration tests for Hyperledger Composer
+## Integration tests for Hyperledger Composer
+
+To run the tests, make sure you've lerna bootstrapped and then run the script that starts the integration tests with 
+
+```
+./scripts/run-integration-tests.sh
+```
+
+Note that this leaves a load of docker containers hanging around afterwards which you can get rid of using the good old 
+
+```
+docker ps -aq | xargs docker kill
+docker rm $(docker ps -aq)
+```
+
+As long as the script finishes, it should tidy up all the artifacts that are created during tests but if it fails then you 
+may have to do a manual clean up.
+
+## Manual testing
+
+Sometimes you might want to run an individual test in which case you can use the tagging feature of cucumber like this.
+First modify your `.feature` file to include a suitable tag.
+
+```
+@testdeservespenguin
+    Scenario: Using the CLI, I can run a composer fish command to create some fish
+        When I run the following CLI command
+            """
+            composer fish
+            """
+        Then The stdout information should include text matching /your fish has been created/
+```
+
+Then you can modify the `test-inner` task in the `package.json` file to add your tag like this:
+
+```
+"test-inner": "cucumber-js --tags @testdeservespenguin",
+```
+
+

--- a/packages/composer-tests-integration/features/cli.feature
+++ b/packages/composer-tests-integration/features/cli.feature
@@ -367,5 +367,17 @@ Feature: Cli steps
         Then The stdout information should include text matching /The current identity, with the name '.+?' and the identifier '.+?', has been revoked/
         Then The stderr information should include text matching /List business network from card bob@basic-sample-network/
 
+    @sams
+    Scenario: Using the CLI, I can run a composer report command to create a file about the current environment
+        When I run the following CLI command
+            """
+            composer report
+            """
+        Then The stdout information should include text matching /Creating Composer report/
+        Then The stdout information should include text matching /Triggering node report.../
+        Then The stdout information should include text matching /Created archive file: composer-report-/
+        Then The stdout information should include text matching /Command succeeded/
+        Then A new file matching this regex should be created /composer-report-/
+
 
 

--- a/packages/composer-tests-integration/lib/clisteps.js
+++ b/packages/composer-tests-integration/lib/clisteps.js
@@ -51,4 +51,8 @@ module.exports = function () {
     this.Then(/^The stderr information should include text matching \/(.+?)\/$/, function (regex) {
         return this.composer.checkConsoleOutput(new RegExp(regex), true);
     });
+
+    this.Then(/^A new file matching this regex should be created \/(.+?)\/$/, function (regex) {
+        return this.composer.checkFileWasCreated(new RegExp(regex));
+    });
 };

--- a/packages/composer-tests-integration/lib/composer.js
+++ b/packages/composer-tests-integration/lib/composer.js
@@ -483,6 +483,27 @@ class Composer {
     }
 
     /**
+     * Check that a file with a name matching the regex has been created.
+     * @param {RegExp} [regex] regular expression.
+     * @return {Promise} - Pomise that will be resolved or rejected with an error
+     */
+    checkFileWasCreated(regex) {
+        return new Promise( (resolve, reject) => {
+            let fileExists = false;
+            fs.readdirSync('.').forEach((file) => {
+                if(file.match(regex)) {
+                    fileExists = true;
+                }
+            });
+            if(fileExists) {
+                resolve();
+            } else {
+                reject('could not find file with name matching ', regex);
+            }
+        });
+    }
+
+    /**
      * Check the HTTP response status
      * @param {Number} code expected HTTP response code.
      * @return {Promise} - Pomise that will be resolved or rejected with an error

--- a/packages/composer-tests-integration/scripts/run-integration-tests.sh
+++ b/packages/composer-tests-integration/scripts/run-integration-tests.sh
@@ -142,6 +142,8 @@ for INTEST in $(echo ${INTEST} | tr "," " "); do
     rm -rf ./tmp/*
     rm -rf ./networkadmin
     rm -rf ${HOME}/.npmrc
+    rm ./*.tgz
+    rm ./networkadmin.card
     if [ "${DOCKER_FILE}" != "" ]; then
         cd ../composer-runtime-hlfv1
         rm .npmrc


### PR DESCRIPTION
issue 3305 add report into integration tests

Signed-off-by: Sam Smith <smithsj@uk.ibm.com>

Added basic report capability into integration tests to make sure that it works. 
No checking of .tgz file contents since there's only node-report content in there at the moment which isn't in our control. Also no checking of messages from node-report (which seem to be issued to stderr for some reason).
