### PR TITLE
Add getCurrentIdentity to runtime API and ping response (resolves #2850)

### DIFF
--- a/packages/composer-cli/.eslintrc.yml
+++ b/packages/composer-cli/.eslintrc.yml
@@ -4,6 +4,7 @@ env:
     mocha: true
 extends: 'eslint:recommended'
 parserOptions:
+    ecmaVersion: 8
     sourceType:
         - script
 rules:
@@ -31,17 +32,17 @@ rules:
     dot-notation: error
     no-tabs: error
     no-trailing-spaces: error
-    # no-use-before-define: error
+    no-use-before-define: error
     no-useless-call: error
     no-with: error
     operator-linebreak: error
-    require-jsdoc:
-        - error
-        - require:
-            ClassDeclaration: true
-            MethodDefinition: true
-            FunctionDeclaration: true
-    valid-jsdoc:
-        - error
-        - requireReturn: false
+#    require-jsdoc:
+#        - error
+#        - require:
+#            ClassDeclaration: true
+#            MethodDefinition: true
+#            FunctionDeclaration: true
+#    valid-jsdoc:
+#        - error
+#        - requireReturn: false
     yoda: error

--- a/packages/composer-cli/lib/cmds/network/lib/ping.js
+++ b/packages/composer-cli/lib/cmds/network/lib/ping.js
@@ -46,6 +46,7 @@ class Ping {
             cmdUtil.log(chalk.blue.bold('The connection to the network was successfully tested: ')+businessNetworkDefinition.getName());
             cmdUtil.log(chalk.blue('\tversion: ') + result.version);
             cmdUtil.log(chalk.blue('\tparticipant: ') + (result.participant ? result.participant : '<no participant found>'));
+            cmdUtil.log(chalk.blue('\tidentity: ') + (result.identity ? result.identity : '<no identity found>'));
         }).catch((error) => {
             throw error;
         });

--- a/packages/composer-cli/test/network/ping.js
+++ b/packages/composer-cli/test/network/ping.js
@@ -14,13 +14,10 @@
 
 'use strict';
 
-const Client = require('composer-client');
-const BusinessNetworkConnection = Client.BusinessNetworkConnection;
-const Admin = require('composer-admin');
-const BusinessNetworkDefinition = Admin.BusinessNetworkDefinition;
-
-const Ping = require('../../lib/cmds/network/pingCommand.js');
+const BusinessNetworkConnection = require('composer-client').BusinessNetworkConnection;
+const BusinessNetworkDefinition = require('composer-admin').BusinessNetworkDefinition;
 const CmdUtil = require('../../lib/cmds/utils/cmdutils.js');
+const Ping = require('../../lib/cmds/network/pingCommand.js');
 
 const sinon = require('sinon');
 const chai = require('chai');
@@ -30,73 +27,97 @@ chai.use(require('chai-as-promised'));
 describe('composer network ping CLI unit tests', () => {
 
     let sandbox;
+    let argv;
     let mockBusinessNetworkConnection;
     let mockBusinessNetworkDefinition;
 
     beforeEach(() => {
         sandbox = sinon.sandbox.create();
+        argv = { card: 'cardname' };
         mockBusinessNetworkConnection = sinon.createStubInstance(BusinessNetworkConnection);
         mockBusinessNetworkDefinition = sinon.createStubInstance(BusinessNetworkDefinition);
-
         mockBusinessNetworkConnection.connect.resolves(mockBusinessNetworkDefinition);
         mockBusinessNetworkConnection.ping.resolves({
             version: '9.9.9',
-            participant: null
+            participant: null,
+            identity: null
         });
         sandbox.stub(CmdUtil, 'createBusinessNetworkConnection').returns(mockBusinessNetworkConnection);
+        sandbox.spy(CmdUtil, 'log');
         sandbox.stub(process, 'exit');
-
     });
 
     afterEach(() => {
         sandbox.restore();
     });
 
-    it('should test the connection to the business network using the supplied card', () => {
-        let argv = {
-            card:'cardname'
-        };
-        return Ping.handler(argv)
-            .then((res) => {
-                argv.thePromise.should.be.a('promise');
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'cardname');
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.ping);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.ping);
-            });
+    it('should test the connection to the business network using the supplied card', async () => {
+        await Ping.handler(argv);
+        argv.thePromise.should.be.a('promise');
+        sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
+        sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'cardname');
+        sinon.assert.calledOnce(mockBusinessNetworkConnection.ping);
+        sinon.assert.calledWith(mockBusinessNetworkConnection.ping);
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/version:.*?9.9.9/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/participant:.*?<no participant found>/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/identity:.*?<no identity found>/));
     });
 
-
-
-    it('should display the participant if a participant was found', () => {
+    it('should display the participant if a participant was found', async () => {
         mockBusinessNetworkConnection.ping.resolves({
             version: '9.9.9',
-            participant: 'org.doge.Doge#DOGE_1'
+            participant: 'org.doge.Doge#DOGE_1',
+            identity: null
         });
-        let argv = {card:'cardname'};
-        return Ping.handler(argv)
-            .then((res) => {
-                argv.thePromise.should.be.a('promise');
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'cardname');
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.ping);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.ping);
-            });
+        await Ping.handler(argv);
+        argv.thePromise.should.be.a('promise');
+        sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
+        sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'cardname');
+        sinon.assert.calledOnce(mockBusinessNetworkConnection.ping);
+        sinon.assert.calledWith(mockBusinessNetworkConnection.ping);
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/version:.*?9.9.9/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/participant:.*?org.doge.Doge#DOGE_1/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/identity:.*?<no identity found>/));
     });
 
-    it('should error when the connection cannot be tested', () => {
+    it('should display the identity if an identity was found', async () => {
+        mockBusinessNetworkConnection.ping.resolves({
+            version: '9.9.9',
+            participant: null,
+            identity: 'org.hyperledger.composer.system.Identity#IDENTITY_1'
+        });
+        await Ping.handler(argv);
+        argv.thePromise.should.be.a('promise');
+        sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
+        sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'cardname');
+        sinon.assert.calledOnce(mockBusinessNetworkConnection.ping);
+        sinon.assert.calledWith(mockBusinessNetworkConnection.ping);
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/version:.*?9.9.9/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/participant:.*?<no participant found>/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/identity:.*?org.hyperledger.composer.system.Identity#IDENTITY_1/));
+    });
+
+    it('should display the participant and identity if both a participant and an identity was found', async () => {
+        mockBusinessNetworkConnection.ping.resolves({
+            version: '9.9.9',
+            participant: 'org.doge.Doge#DOGE_1',
+            identity: 'org.hyperledger.composer.system.Identity#IDENTITY_1'
+        });
+        await Ping.handler(argv);
+        argv.thePromise.should.be.a('promise');
+        sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
+        sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'cardname');
+        sinon.assert.calledOnce(mockBusinessNetworkConnection.ping);
+        sinon.assert.calledWith(mockBusinessNetworkConnection.ping);
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/version:.*?9.9.9/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/participant:.*?org.doge.Doge#DOGE_1/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/identity:.*?org.hyperledger.composer.system.Identity#IDENTITY_1/));
+    });
+
+    it('should error when the connection cannot be tested', async () => {
         mockBusinessNetworkConnection.ping.rejects(new Error('such error'));
-        let argv = {
-            card:'cardname'
-        };
-        return Ping.handler(argv)
-            .catch((res) => {
-                argv.thePromise.should.be.a('promise');
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.connect);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect, 'cardname');
-                sinon.assert.calledOnce(mockBusinessNetworkConnection.ping);
-                sinon.assert.calledWith(mockBusinessNetworkConnection.ping);
-            });
+        await Ping.handler(argv)
+            .should.be.rejectedWith(/such error/);
     });
 
 });

--- a/packages/composer-rest-server/server/boot/composer-discovery.js
+++ b/packages/composer-rest-server/server/boot/composer-discovery.js
@@ -232,6 +232,10 @@ function registerPingMethod(app, dataSource, System, connector) {
                 type: 'string',
                 required: false
             },
+            identity: {
+                type: 'string',
+                required: false
+            },
             version: {
                 type: 'string',
                 required: true

--- a/packages/composer-rest-server/test/system.js
+++ b/packages/composer-rest-server/test/system.js
@@ -210,7 +210,8 @@ describe('System REST API unit tests', () => {
                     res.should.be.json;
                     res.body.should.deep.equal({
                         version: version,
-                        participant: 'org.hyperledger.composer.system.NetworkAdmin#admin'
+                        participant: 'org.hyperledger.composer.system.NetworkAdmin#admin',
+                        identity: `org.hyperledger.composer.system.Identity#${identityIds[0]}`
                     });
                 });
         });

--- a/packages/composer-runtime/.eslintrc.yml
+++ b/packages/composer-runtime/.eslintrc.yml
@@ -4,7 +4,7 @@ env:
     mocha: true
 extends: 'eslint:recommended'
 parserOptions:
-    ecmaVersion: 2015
+    ecmaVersion: 8
     sourceType:
         - script
 rules:
@@ -36,13 +36,13 @@ rules:
     no-useless-call: error
     no-with: error
     operator-linebreak: error
-    require-jsdoc:
-        - error
-        - require:
-            ClassDeclaration: true
-            MethodDefinition: true
-            FunctionDeclaration: true
-    valid-jsdoc:
-        - error
-        - requireReturn: false
+#    require-jsdoc:
+#        - error
+#        - require:
+#            ClassDeclaration: true
+#            MethodDefinition: true
+#            FunctionDeclaration: true
+#    valid-jsdoc:
+#        - error
+#        - requireReturn: false
     yoda: error

--- a/packages/composer-runtime/lib/api.js
+++ b/packages/composer-runtime/lib/api.js
@@ -47,6 +47,7 @@ class Api {
             'getAssetRegistry',
             'getParticipantRegistry',
             'getCurrentParticipant',
+            'getCurrentIdentity',
             'post',
             'emit',
             'buildQuery',
@@ -68,6 +69,7 @@ class Api {
         const factory = context.getFactory();
         const serializer = context.getSerializer();
         const participant = context.getParticipant();
+        const identity = context.getIdentity();
         const registryManager = context.getRegistryManager();
         const httpService = context.getHTTPService();
         const eventService = context.getEventService();
@@ -208,6 +210,28 @@ class Api {
             const method = 'getCurrentParticipant';
             LOG.entry(method);
             let result = participant;
+            LOG.exit(method, result);
+            return result;
+        };
+
+        /**
+         * Get the current identity. The current identity is the identity
+         * that was used to submit the current transaction.
+         * @example
+         * // Get the current identity.
+         * var currentIdentity = getCurrentIdentity();
+         * // Get the certificate from the current identity.
+         * var certificate = currentIdentity.certificate;
+         * @method module:composer-runtime#getCurrentIdentity
+         * @public
+         * @return {module:composer-common.Resource} The current identity,
+         * or null if the transaction was submitted using an identity that does
+         * not map to a participant.
+         */
+        this.getCurrentIdentity = function getCurrentIdentity() {
+            const method = 'getCurrentIdentity';
+            LOG.entry(method);
+            let result = identity;
             LOG.exit(method, result);
             return result;
         };

--- a/packages/composer-runtime/lib/context.js
+++ b/packages/composer-runtime/lib/context.js
@@ -148,6 +148,7 @@ class Context {
         this.api = null;
         this.identityManager = null;
         this.participant = null;
+        this.currentIdentity = null;
         this.transaction = null;
         this.accessController = null;
         this.sysregistries = null;

--- a/packages/composer-runtime/lib/engine.js
+++ b/packages/composer-runtime/lib/engine.js
@@ -481,9 +481,15 @@ class Engine {
         if (participant) {
             participantFQI = participant.getFullyQualifiedIdentifier();
         }
+        let identityFQI = null;
+        let identity = context.getIdentity();
+        if (identity) {
+            identityFQI = identity.getFullyQualifiedIdentifier();
+        }
         let result = {
             version: this.container.getVersion(),
-            participant: participantFQI
+            participant: participantFQI,
+            identity: identityFQI
         };
         LOG.exit(method, result);
         return Promise.resolve(result);

--- a/packages/composer-runtime/test/api.js
+++ b/packages/composer-runtime/test/api.js
@@ -47,6 +47,7 @@ describe('Api', () => {
     let factory;
     let serializer;
     let mockParticipant;
+    let mockIdentity;
     let mockRegistryManager;
     let mockEventService;
     let mockHTTPService;
@@ -82,6 +83,8 @@ describe('Api', () => {
         mockContext.getSerializer.returns(serializer);
         mockParticipant = sinon.createStubInstance(Resource);
         mockContext.getParticipant.returns(mockParticipant);
+        mockIdentity = sinon.createStubInstance(Resource);
+        mockContext.getIdentity.returns(mockIdentity);
         mockRegistryManager = sinon.createStubInstance(RegistryManager);
         mockContext.getRegistryManager.returns(mockRegistryManager);
         mockEventService = sinon.createStubInstance(EventService);
@@ -174,6 +177,14 @@ describe('Api', () => {
 
         it('should return the current participant', () => {
             api.getCurrentParticipant().should.equal(mockParticipant);
+        });
+
+    });
+
+    describe('#getCurrentIdentity', () => {
+
+        it('should return the current identity', () => {
+            api.getCurrentIdentity().should.equal(mockIdentity);
         });
 
     });

--- a/packages/composer-runtime/test/engine.js
+++ b/packages/composer-runtime/test/engine.js
@@ -720,32 +720,57 @@ describe('Engine', () => {
 
     describe('#ping', () => {
 
-        it('should throw for invalid arguments', () => {
-            let result = engine.query(mockContext, 'ping', ['no', 'args', 'supported']);
-            return result.should.be.rejectedWith(/Invalid arguments "\["no","args","supported"\]" to function "ping", expecting "\[\]"/);
+        it('should throw for invalid arguments', async () => {
+            await engine.query(mockContext, 'ping', ['no', 'args', 'supported'])
+                .should.be.rejectedWith(/Invalid arguments "\["no","args","supported"\]" to function "ping", expecting "\[\]"/);
         });
 
-        it('should return an object containing the version', () => {
-            return engine.query(mockContext, 'ping', [])
-                .then((result) => {
-                    result.should.deep.equal({
-                        version: version,
-                        participant: null
-                    });
-                });
+        it('should return an object containing the version', async () => {
+            const result = await engine.query(mockContext, 'ping', []);
+            result.should.deep.equal({
+                version: version,
+                participant: null,
+                identity: null
+            });
         });
 
-        it('should return an object containing the current participant', () => {
+        it('should return an object containing the current participant', async () => {
             let mockParticipant = sinon.createStubInstance(Resource);
             mockParticipant.getFullyQualifiedIdentifier.returns('org.doge.Doge#DOGE_1');
             mockContext.getParticipant.returns(mockParticipant);
-            return engine.query(mockContext, 'ping', [])
-                .then((result) => {
-                    result.should.deep.equal({
-                        version: version,
-                        participant: 'org.doge.Doge#DOGE_1'
-                    });
-                });
+            const result = await engine.query(mockContext, 'ping', []);
+            result.should.deep.equal({
+                version: version,
+                participant: 'org.doge.Doge#DOGE_1',
+                identity: null
+            });
+        });
+
+        it('should return an object containing the current identity', async () => {
+            let mockIdentity = sinon.createStubInstance(Resource);
+            mockIdentity.getFullyQualifiedIdentifier.returns('org.hyperledger.composer.system.Identity#IDENTITY_1');
+            mockContext.getIdentity.returns(mockIdentity);
+            const result = await engine.query(mockContext, 'ping', []);
+            result.should.deep.equal({
+                version: version,
+                participant: null,
+                identity: 'org.hyperledger.composer.system.Identity#IDENTITY_1'
+            });
+        });
+
+        it('should return an object containing the current participant and identity', async () => {
+            let mockParticipant = sinon.createStubInstance(Resource);
+            mockParticipant.getFullyQualifiedIdentifier.returns('org.doge.Doge#DOGE_1');
+            mockContext.getParticipant.returns(mockParticipant);
+            let mockIdentity = sinon.createStubInstance(Resource);
+            mockIdentity.getFullyQualifiedIdentifier.returns('org.hyperledger.composer.system.Identity#IDENTITY_1');
+            mockContext.getIdentity.returns(mockIdentity);
+            const result = await engine.query(mockContext, 'ping', []);
+            result.should.deep.equal({
+                version: version,
+                participant: 'org.doge.Doge#DOGE_1',
+                identity: 'org.hyperledger.composer.system.Identity#IDENTITY_1'
+            });
         });
 
     });

--- a/packages/composer-tests-functional/systest/data/accesscontrols.js
+++ b/packages/composer-tests-functional/systest/data/accesscontrols.js
@@ -21,17 +21,6 @@ function participantsAreEqual(participant1, participant2) {
 }
 
 /**
- * Handle the sample transaction.
- * @param {systest.accesscontrols.SampleTransaction} transaction The transaction
- * @transaction
- */
-function handleSampleTransaction(transaction) {
-    if (getCurrentParticipant().getFullyQualifiedIdentifier() !== 'systest.identities.SampleParticipant#bob@uk.ibm.com') {
-        throw new Error('wrong participant');
-    }
-}
-
-/**
  * basic update transactions
  * @param {systest.accesscontrols.UpdateAssetValue} transaction The transaction
  * @transaction

--- a/packages/composer-tests-functional/systest/data/identities.cto
+++ b/packages/composer-tests-functional/systest/data/identities.cto
@@ -6,6 +6,10 @@ participant SampleParticipant identified by email {
   o String lastName
 }
 
-transaction SampleTransaction  {
+transaction TestGetCurrentParticipant  {
+  
+}
+
+transaction TestGetCurrentIdentity  {
   
 }

--- a/packages/composer-tests-functional/systest/data/identities.js
+++ b/packages/composer-tests-functional/systest/data/identities.js
@@ -2,11 +2,23 @@
 
 /**
  * Handle the sample transaction.
- * @param {systest.identities.SampleTransaction} transaction The transaction
+ * @param {systest.identities.TestGetCurrentParticipant} transaction The transaction
  * @transaction
  */
-function handleSampleTransaction(transaction) {
+function onTestGetCurrentParticipant(transaction) {
     if (getCurrentParticipant().getFullyQualifiedIdentifier() !== 'systest.identities.SampleParticipant#bob@uk.ibm.com') {
         throw new Error('wrong participant');
+    }
+}
+
+/**
+ * Handle the sample transaction.
+ * @param {systest.identities.TestGetCurrentIdentity} transaction The transaction
+ * @transaction
+ */
+function onTestGetCurrentIdentity(transaction) {
+    const identity = getCurrentIdentity();
+    if (identity.participant.getFullyQualifiedIdentifier() !== 'systest.identities.SampleParticipant#bob@uk.ibm.com') {
+        throw new Error('wrong identity');
     }
 }

--- a/packages/composer-tests-functional/systest/identities.js
+++ b/packages/composer-tests-functional/systest/identities.js
@@ -16,13 +16,13 @@
 'use strict';
 
 const AdminConnection = require('composer-admin').AdminConnection;
+const BusinessNetworkConnection = require('composer-client').BusinessNetworkConnection;
 const BusinessNetworkDefinition = require('composer-admin').BusinessNetworkDefinition;
-
 const fs = require('fs');
+const IdCard = require('composer-common').IdCard;
 const path = require('path');
-const uuid = require('uuid');
-
 const TestUtil = require('./testutil');
+const uuid = require('uuid');
 
 const chai = require('chai');
 chai.should();
@@ -30,19 +30,17 @@ chai.use(require('chai-as-promised'));
 
 process.setMaxListeners(Infinity);
 
-describe('Identity system tests', function() {
+describe.only('Identity system tests', function() {
 
     this.retries(TestUtil.retries());
+
     let cardStore;
     let bnID;
-    beforeEach(() => {
-        return TestUtil.resetBusinessNetwork(cardStore,bnID, 0);
-    });
     let businessNetworkDefinition;
     let client;
     let participant;
 
-    before(function () {
+    before(async () => {
         // In this systest we are intentionally not fully specifying the model file with a fileName, and supplying null as the value
         const modelFiles = [
             { fileName: null, contents: fs.readFileSync(path.resolve(__dirname, 'data/identities.cto'), 'utf8') }
@@ -55,198 +53,46 @@ describe('Identity system tests', function() {
             businessNetworkDefinition.getModelManager().addModelFile(modelFile.contents, modelFile.fileName);
         });
         scriptFiles.forEach((scriptFile) => {
-            let scriptManager = businessNetworkDefinition.getScriptManager();
+            const scriptManager = businessNetworkDefinition.getScriptManager();
             scriptManager.addScript(scriptManager.createScript(scriptFile.identifier, 'JS', scriptFile.contents));
         });
         bnID = businessNetworkDefinition.getName();
-        return TestUtil.deploy(businessNetworkDefinition)
-            .then((_cardStore) => {
-                cardStore = _cardStore;
-                return TestUtil.getClient(cardStore,'systest-identities')
-                    .then((result) => {
-                        client = result;
-                    });
-            });
+        cardStore = await TestUtil.deploy(businessNetworkDefinition);
+        client = await TestUtil.getClient(cardStore,'systest-identities');
     });
 
-    after(function () {
-        return TestUtil.undeploy(businessNetworkDefinition);
+    after(async () => {
+        await TestUtil.undeploy(businessNetworkDefinition);
     });
 
-    beforeEach(() => {
-        let factory = client.getBusinessNetwork().getFactory();
+    beforeEach(async () => {
+        await TestUtil.resetBusinessNetwork(cardStore,bnID, 0);
+        const factory = client.getBusinessNetwork().getFactory();
         participant = factory.newResource('systest.identities', 'SampleParticipant', 'bob@uk.ibm.com');
         participant.firstName = 'Bob';
         participant.lastName = 'Bobbington';
-        return client.getParticipantRegistry('systest.identities.SampleParticipant')
-            .then((participantRegistry) => {
-                return participantRegistry.add(participant);
-            });
+        const participantRegistry = await client.getParticipantRegistry('systest.identities.SampleParticipant');
+        await participantRegistry.add(participant);
     });
 
-    afterEach(() => {
-        return TestUtil.getClient(cardStore,'systest-identities')
-            .then((result) => {
-                client = result;
-            });
+    afterEach(async () => {
+        client = await TestUtil.getClient(cardStore,'systest-identities');
     });
 
-    it('should issue an identity and make it available for a ping request', () => {
-        let identity = uuid.v4();
-        return client.issueIdentity(participant, identity)
-            .then((identity) => {
-                return TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
-            })
-            .then((result) => {
-                client = result;
-                return client.ping();
-            })
-            .then((result) => {
-                result.participant.should.equal(participant.getFullyQualifiedIdentifier());
-            });
-    });
+    let identityIndex = 1;
 
-    it('should issue an identity that can issue another identity and make it available for a ping request', () => {
-        let identity = uuid.v4();
-        let identity2 = uuid.v4();
-        let participant2;
-        return client.issueIdentity(participant, identity, {issuer: true})
-            .then((identity) => {
-                return TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
-            })
-            .then((result) => {
-                client = result;
-                return client.ping();
-            })
-            .then((result) => {
-                result.participant.should.equal(participant.getFullyQualifiedIdentifier());
-                let factory = client.getBusinessNetwork().getFactory();
-                participant2 = factory.newResource('systest.identities', 'SampleParticipant', 'frank@uk.ibm.com');
-                participant2.firstName = 'Frank';
-                participant2.lastName = 'Frankly';
-                return client.getParticipantRegistry('systest.identities.SampleParticipant');
-            })
-            .then((participantRegistry) => {
-                return participantRegistry.add(participant2);
-            })
-            .then(() => {
-                return client.issueIdentity(participant2, identity2, {issuer: true});
-            })
-            .then((identity) => {
-                return TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
-            })
-            .then((result) => {
-                client = result;
-                return client.ping();
-            })
-            .then((result) => {
-                result.participant.should.equal(participant2.getFullyQualifiedIdentifier());
-            });
-    });
-
-    xit('should bind an identity and make it available for a ping request', function () {
-        let identity, certificate, privateKey;
-        identity = uuid.v4();
+    /**
+     * Get the next identity.
+     * @return {Object} The next identity.
+     */
+    function getNextIdentity() {
+        let certificate, privateKey;
         if (TestUtil.isHyperledgerFabricV1()) {
-            const certificateFile = path.resolve(__dirname, '../hlfv1/crypto-config/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/signcerts/User1@org1.example.com-cert.pem');
+            const certificateFile = path.resolve(__dirname, `../hlfv1/crypto-config/peerOrganizations/org1.example.com/users/User${identityIndex}@org1.example.com/msp/signcerts/User${identityIndex}@org1.example.com-cert.pem`);
             certificate = fs.readFileSync(certificateFile, 'utf8');
-            const privateKeyFile = path.resolve(__dirname, '../hlfv1/crypto-config/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/keystore/key.pem');
+            const privateKeyFile = path.resolve(__dirname, `../hlfv1/crypto-config/peerOrganizations/org1.example.com/users/User${identityIndex}@org1.example.com/msp/keystore/key.pem`);
             privateKey = fs.readFileSync(privateKeyFile, 'utf8');
-        } else {
-            certificate = [
-                '----- BEGIN CERTIFICATE -----',
-                Buffer.from('User1@org1.example.com' + ':' + uuid.v4()).toString('base64'),
-                '----- END CERTIFICATE -----'
-            ].join('\n').concat('\n');
-            privateKey = 'not used';
-        }
-        return client.bindIdentity(cardStore, participant, certificate)
-            .then(() => {
-                const admin = new AdminConnection({cardStore});
-                if (TestUtil.isHyperledgerFabricV1()) {
-                    return admin.importIdentity('composer-systests-org1', identity, certificate, privateKey);
-                } else {
-                    return admin.importIdentity('composer-systests', identity, certificate, privateKey);
-                }
-            })
-            .then(() => {
-                return TestUtil.getClient(cardStore,'systest-identities', identity, 'not used');
-            })
-            .then((result) => {
-                client = result;
-                return client.ping();
-            })
-            .then((result) => {
-                result.participant.should.equal(participant.getFullyQualifiedIdentifier());
-            });
-    });
-
-    it('should throw an exception for a ping request using a revoked identity', () => {
-        let identityName = uuid.v4();
-        return client.issueIdentity(participant, identityName)
-            .then((identity) => {
-                return TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
-            })
-            .then((result) => {
-                client = result;
-                return client.getIdentityRegistry();
-            })
-            .then((identityRegistry) => {
-                return identityRegistry.getAll();
-            })
-            .then((identities) => {
-                const identity = identities.find((identity) => {
-                    return identity.name === identityName;
-                });
-                return client.revokeIdentity(identity);
-            })
-            .then(() => {
-                return client.ping();
-            })
-            .should.be.rejectedWith(/The current identity, with the name \'.+?\' and the identifier \'.+?\', has been revoked/);
-    });
-
-    it('should throw an exception for a ping request using a identity that is mapped to a non-existent participant', () => {
-        let identity = uuid.v4();
-        return client.issueIdentity(participant, identity)
-            .then((identity) => {
-                return client.getParticipantRegistry('systest.identities.SampleParticipant')
-                    .then((participantRegistry) => {
-                        return participantRegistry.remove(participant);
-                    })
-                    .then(() => {
-                        return TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
-                    });
-            })
-            .then((result) => {
-                client = result;
-                return client.ping();
-            })
-            .should.be.rejectedWith(/The current identity, with the name \'.+?\' and the identifier \'.+?\', is bound to a participant \'resource:systest.identities.SampleParticipant#bob@uk.ibm.com\' that does not exist/);
-    });
-
-    it('should issue an identity and make the participant available for transaction processor functions', () => {
-        let identity = uuid.v4();
-        return client.issueIdentity(participant, identity)
-            .then((identity) => {
-                return TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
-            })
-            .then((result) => {
-                client = result;
-                let factory = client.getBusinessNetwork().getFactory();
-                let transaction = factory.newTransaction('systest.identities', 'SampleTransaction');
-                return client.submitTransaction(transaction);
-            });
-    });
-
-    xit('should bind an identity and make the participant available for transaction processor functions', function () {
-        let identity, certificate, privateKey;
-        identity = uuid.v4();
-        if (TestUtil.isHyperledgerFabricV1()) {
-            const certificateFile = path.resolve(__dirname, '../hlfv1/crypto-config/peerOrganizations/org1.example.com/users/User2@org1.example.com/msp/signcerts/User2@org1.example.com-cert.pem');
-            certificate = fs.readFileSync(certificateFile, 'utf8');
-            const privateKeyFile = path.resolve(__dirname, '../hlfv1/crypto-config/peerOrganizations/org1.example.com/users/User2@org1.example.com/msp/keystore/key.pem');
-            privateKey = fs.readFileSync(privateKeyFile, 'utf8');
+            identityIndex++;
         } else {
             certificate = [
                 '----- BEGIN CERTIFICATE -----',
@@ -255,111 +101,183 @@ describe('Identity system tests', function() {
             ].join('\n').concat('\n');
             privateKey = 'not used';
         }
-        return client.bindIdentity(participant, certificate)
-            .then(() => {
-                const admin = new AdminConnection();
-                if (TestUtil.isHyperledgerFabricV1()) {
-                    return admin.importIdentity('composer-systests-org1', identity, certificate, privateKey);
-                } else {
-                    return admin.importIdentity('composer-systests', identity, certificate, privateKey);
-                }
-            })
-            .then(() => {
-                return TestUtil.getClient('systest-identities', identity, 'not used');
-            })
-            .then((result) => {
-                client = result;
-                let factory = client.getBusinessNetwork().getFactory();
-                let transaction = factory.newTransaction('systest.identities', 'SampleTransaction');
-                return client.submitTransaction(transaction);
-            });
+        return { certificate, privateKey };
+    }
+
+    it('should issue an identity and make the participant available for a ping request', async () => {
+        const identityName = uuid.v4();
+        const identity = await client.issueIdentity(participant, identityName);
+        client = await TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
+        const result = await client.ping();
+        result.participant.should.equal(participant.getFullyQualifiedIdentifier());
     });
 
-    it('should throw an exception for a transaction processor function using a revoked identity', () => {
-        let identityName = uuid.v4();
-        return client.issueIdentity(participant, identityName)
-            .then((identity) => {
-                return TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
-            })
-            .then((result) => {
-                client = result;
-                return client.getIdentityRegistry();
-            })
-            .then((identityRegistry) => {
-                return identityRegistry.getAll();
-            })
-            .then((identities) => {
-                const identity = identities.find((identity) => {
-                    return identity.name === identityName;
-                });
-                return client.revokeIdentity(identity);
-            })
-            .then(() => {
-                let factory = client.getBusinessNetwork().getFactory();
-                let transaction = factory.newTransaction('systest.identities', 'SampleTransaction');
-                return client.submitTransaction(transaction);
-            })
+    it('should issue an identity and make the identity available for a ping request', async () => {
+        const identityName = uuid.v4();
+        const identity = await client.issueIdentity(participant, identityName);
+        client = await TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
+        const result = await client.ping();
+        const identityRegistry = await client.getIdentityRegistry();
+        const identities = await identityRegistry.getAll();
+        const matchingIdentity = identities.find((identity) => {
+            return identity.name === identityName;
+        });
+        result.identity.should.equal(matchingIdentity.getFullyQualifiedIdentifier());
+    });
+
+    it('should issue an identity that can issue another identity and make it available for a ping request', async () => {
+        const identityName = uuid.v4();
+        const identityName2 = uuid.v4();
+        const identity = await client.issueIdentity(participant, identityName, {issuer: true});
+        client = await TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
+        const result = await client.ping();
+        result.participant.should.equal(participant.getFullyQualifiedIdentifier());
+        const factory = client.getBusinessNetwork().getFactory();
+        const participant2 = factory.newResource('systest.identities', 'SampleParticipant', 'frank@uk.ibm.com');
+        participant2.firstName = 'Frank';
+        participant2.lastName = 'Frankly';
+        const participantRegistry = await client.getParticipantRegistry('systest.identities.SampleParticipant');
+        await participantRegistry.add(participant2);
+        const identity2 = await client.issueIdentity(participant2, identityName2, {issuer: true});
+        client = await TestUtil.getClient(cardStore,'systest-identities', identity2.userID, identity2.userSecret);
+        const result2 = await client.ping();
+        result2.participant.should.equal(participant2.getFullyQualifiedIdentifier());
+    });
+
+    it('should bind an identity and make it available for a ping request', async function () {
+        const identityName = uuid.v4();
+        const cardName = `${identityName}@systest-identities`;
+        const { certificate, privateKey } = getNextIdentity();
+        await client.bindIdentity(participant, certificate);
+        const card = new IdCard({ businessNetwork: 'systest-identities', userName: identityName }, TestUtil.getCurrentConnectionProfile());
+        card.setCredentials({ certificate, privateKey });
+        const admin = new AdminConnection({ cardStore });
+        await admin.importCard(cardName, card);
+        client = new BusinessNetworkConnection({ cardStore });
+        await client.connect(cardName);
+        const result = await client.ping();
+        result.participant.should.equal(participant.getFullyQualifiedIdentifier());
+    });
+
+    it('should throw an exception for a ping request using a revoked identity', async () => {
+        const identityName = uuid.v4();
+        const identity = await client.issueIdentity(participant, identityName);
+        client = await TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
+        const identityRegistry = await client.getIdentityRegistry();
+        const identities = await identityRegistry.getAll();
+        const matchingIdentity = identities.find((identity) => {
+            return identity.name === identityName;
+        });
+        await client.revokeIdentity(matchingIdentity);
+        await client.ping()
             .should.be.rejectedWith(/The current identity, with the name \'.+?\' and the identifier \'.+?\', has been revoked/);
     });
 
-    it('should throw an exception for a transaction processor function using a identity that is mapped to a non-existent participant', () => {
-        let identity = uuid.v4();
-        return client.issueIdentity(participant, identity)
-            .then((identity) => {
-                return client.getParticipantRegistry('systest.identities.SampleParticipant')
-                    .then((participantRegistry) => {
-                        return participantRegistry.remove(participant);
-                    })
-                    .then(() => {
-                        return TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
-                    });
-            })
-            .then((result) => {
-                client = result;
-                let factory = client.getBusinessNetwork().getFactory();
-                let transaction = factory.newTransaction('systest.identities', 'SampleTransaction');
-                return client.submitTransaction(transaction);
-            })
+    it('should throw an exception for a ping request using a identity that is mapped to a non-existent participant', async () => {
+        const identityName = uuid.v4();
+        const identity = await client.issueIdentity(participant, identityName);
+        const participantRegistry = await client.getParticipantRegistry('systest.identities.SampleParticipant');
+        client = await TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
+        await participantRegistry.remove(participant);
+        await client.ping()
             .should.be.rejectedWith(/The current identity, with the name \'.+?\' and the identifier \'.+?\', is bound to a participant \'resource:systest.identities.SampleParticipant#bob@uk.ibm.com\' that does not exist/);
     });
 
-    xit('should export credentials for previously imported identity', function () {
-        let profileName;
-        let certificate;
-        let privateKey;
-        if (TestUtil.isHyperledgerFabricV1()) {
-            profileName = 'composer-systests-org1';
-            const certificateFile = path.resolve(__dirname, '../hlfv1/crypto-config/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/signcerts/User1@org1.example.com-cert.pem');
-            certificate = fs.readFileSync(certificateFile, 'utf8').replace(/\r/g, '');
-            const privateKeyFile = path.resolve(__dirname, '../hlfv1/crypto-config/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/keystore/key.pem');
-            privateKey = fs.readFileSync(privateKeyFile, 'utf8').replace(/\r/g, '');
-        } else {
-            profileName = 'composer-systests';
-            certificate =
-                '----- BEGIN CERTIFICATE -----\n' +
-                Buffer.from('User2@org1.example.com' + ':' + uuid.v4()).toString('base64') + '\n' +
-                '----- END CERTIFICATE -----\n';
-            privateKey = 'FAKE_PRIVATE_KEY';
-        }
+    it('should issue an identity and make the participant available for transaction processor functions', async () => {
+        const identityName = uuid.v4();
+        const identity = await client.issueIdentity(participant, identityName);
+        client = await TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
+        const factory = client.getBusinessNetwork().getFactory();
+        const transaction = factory.newTransaction('systest.identities', 'TestGetCurrentParticipant');
+        await client.submitTransaction(transaction);
+    });
 
-        const identity = uuid.v4();
+    it('should issue an identity and make the identity available for transaction processor functions', async () => {
+        const identityName = uuid.v4();
+        const identity = await client.issueIdentity(participant, identityName);
+        client = await TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
+        const factory = client.getBusinessNetwork().getFactory();
+        const transaction = factory.newTransaction('systest.identities', 'TestGetCurrentIdentity');
+        await client.submitTransaction(transaction);
+    });
 
-        const adminConnection = new AdminConnection({cardStore});
+    it('should bind an identity and make the participant available for transaction processor functions', async function () {
+        const identityName = uuid.v4();
+        const cardName = `${identityName}@systest-identities`;
+        const { certificate, privateKey } = getNextIdentity();
+        await client.bindIdentity(participant, certificate);
+        const card = new IdCard({ businessNetwork: 'systest-identities', userName: identityName }, TestUtil.getCurrentConnectionProfile());
+        card.setCredentials({ certificate, privateKey });
+        const admin = new AdminConnection({ cardStore });
+        await admin.importCard(cardName, card);
+        client = new BusinessNetworkConnection({ cardStore });
+        await client.connect(cardName);
+        const factory = client.getBusinessNetwork().getFactory();
+        const transaction = factory.newTransaction('systest.identities', 'TestGetCurrentParticipant');
+        await client.submitTransaction(transaction);
+    });
 
-        return adminConnection.importIdentity(profileName, identity, certificate, privateKey)
-            .then(() => {
-                return adminConnection.exportIdentity(profileName, identity);
-            })
-            .then((credentials) => {
-                // Remove any carriage returns that may have been added by fabric
-                credentials.certificate = credentials.certificate.replace(/\r/g, '');
-                credentials.privateKey = credentials.privateKey.replace(/\r/g, '');
+    it('should bind an identity and make the identity available for transaction processor functions', async function () {
+        const identityName = uuid.v4();
+        const cardName = `${identityName}@systest-identities`;
+        const { certificate, privateKey } = getNextIdentity();
+        await client.bindIdentity(participant, certificate);
+        const card = new IdCard({ businessNetwork: 'systest-identities', userName: identityName }, TestUtil.getCurrentConnectionProfile());
+        card.setCredentials({ certificate, privateKey });
+        const admin = new AdminConnection({ cardStore });
+        await admin.importCard(cardName, card);
+        client = new BusinessNetworkConnection({ cardStore });
+        await client.connect(cardName);
+        const factory = client.getBusinessNetwork().getFactory();
+        const transaction = factory.newTransaction('systest.identities', 'TestGetCurrentIdentity');
+        await client.submitTransaction(transaction);
+    });
 
-                credentials.should.deep.equal({
-                    certificate: certificate,
-                    privateKey: privateKey
-                });
-            });
+    it('should throw an exception for a transaction processor function using a revoked identity', async () => {
+        const identityName = uuid.v4();
+        const identity = await client.issueIdentity(participant, identityName);
+        client = await TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
+        const identityRegistry = await client.getIdentityRegistry();
+        const identities = await identityRegistry.getAll();
+        const matchingIdentity = identities.find((identity) => {
+            return identity.name === identityName;
+        });
+        await client.revokeIdentity(matchingIdentity);
+        const factory = client.getBusinessNetwork().getFactory();
+        const transaction = factory.newTransaction('systest.identities', 'TestGetCurrentParticipant');
+        await client.submitTransaction(transaction)
+            .should.be.rejectedWith(/The current identity, with the name \'.+?\' and the identifier \'.+?\', has been revoked/);
+    });
+
+    it('should throw an exception for a transaction processor function using a identity that is mapped to a non-existent participant', async () => {
+        const identityName = uuid.v4();
+        const identity = await client.issueIdentity(participant, identityName);
+        const participantRegistry = await client.getParticipantRegistry('systest.identities.SampleParticipant');
+        client = await TestUtil.getClient(cardStore,'systest-identities', identity.userID, identity.userSecret);
+        await participantRegistry.remove(participant);
+        const factory = client.getBusinessNetwork().getFactory();
+        const transaction = factory.newTransaction('systest.identities', 'TestGetCurrentParticipant');
+        await client.submitTransaction(transaction)
+            .should.be.rejectedWith(/The current identity, with the name \'.+?\' and the identifier \'.+?\', is bound to a participant \'resource:systest.identities.SampleParticipant#bob@uk.ibm.com\' that does not exist/);
+    });
+
+    it('should export credentials for previously imported identity', async () => {
+        const identityName = uuid.v4();
+        const cardName = `${identityName}@systest-identities`;
+        const { certificate, privateKey } = getNextIdentity();
+        const card = new IdCard({ businessNetwork: 'systest-identities', userName: identityName }, TestUtil.getCurrentConnectionProfile());
+        card.setCredentials({ certificate, privateKey });
+        const admin = new AdminConnection({ cardStore });
+        await admin.importCard(cardName, card);
+        const card2 = await admin.exportCard(cardName);
+        // Remove any carriage returns that may have been added by fabric
+        const credentials = card2.getCredentials();
+        credentials.certificate = credentials.certificate.replace(/\r/g, '');
+        credentials.privateKey = credentials.privateKey.replace(/\r/g, '');
+        credentials.should.deep.equal({
+            certificate: certificate,
+            privateKey: privateKey
+        });
     });
 
 });

--- a/packages/composer-tests-functional/systest/testutil.js
+++ b/packages/composer-tests-functional/systest/testutil.js
@@ -1055,6 +1055,14 @@ class TestUtil {
         return testRetries;
     }
 
+    /**
+     * Get the current connection profile.
+     * @return {Object} The current connection profile.
+     */
+    static getCurrentConnectionProfile() {
+        return currentCp;
+    }
+
 }
 
 module.exports = TestUtil;

--- a/packages/composer-tests-integration/features/cli.feature
+++ b/packages/composer-tests-integration/features/cli.feature
@@ -105,6 +105,7 @@ Feature: Cli steps
         Then The stdout information should include text matching /The connection to the network was successfully tested: basic-sample-network/
         Then The stdout information should include text matching /version:/
         Then The stdout information should include text matching /participant: org.hyperledger.composer.system.NetworkAdmin#admin/
+        Then The stdout information should include text matching /identity: org.hyperledger.composer.system.Identity#.+?/
         Then The stdout information should include text matching /Command succeeded/
 
     Scenario: Using the CLI, I can verify that there no assets have been created yet
@@ -142,6 +143,7 @@ Feature: Cli steps
         Then The stdout information should include text matching /The connection to the network was successfully tested: basic-sample-network/
         Then The stdout information should include text matching /version:/
         Then The stdout information should include text matching /participant: org.hyperledger.composer.system.NetworkAdmin#admin/
+        Then The stdout information should include text matching /identity: org.hyperledger.composer.system.Identity#.+?/
         Then The stdout information should include text matching /Command succeeded/
 
     Scenario: Using the CLI, I can validate that listing all the networks includes my update

--- a/packages/composer-tests-integration/features/queries.feature
+++ b/packages/composer-tests-integration/features/queries.feature
@@ -8,7 +8,8 @@ Feature: Queries steps
             """
               {
                 "version": _.isString,
-                "participant": "org.hyperledger.composer.system.NetworkAdmin#admin"
+                "participant": "org.hyperledger.composer.system.NetworkAdmin#admin",
+                "identity": _.isString
               }
             """
 

--- a/packages/composer-tests-integration/features/rest.feature
+++ b/packages/composer-tests-integration/features/rest.feature
@@ -8,7 +8,8 @@ Feature: Rest steps
             """
               {
                 "version": _.isString,
-                "participant": "org.hyperledger.composer.system.NetworkAdmin#admin"
+                "participant": "org.hyperledger.composer.system.NetworkAdmin#admin",
+                "identity": _.isString
               }
             """
 

--- a/packages/composer-website/jekylldocs/business-network/programmatic-access-control.md
+++ b/packages/composer-website/jekylldocs/business-network/programmatic-access-control.md
@@ -11,13 +11,29 @@ index-order: 508
 # Programmatic access control
 
 It is recommended that you use declarative access control to implement access control rules in your business network definition.
-However, you can implement programmatic access control in your transaction processors by retrieving and testing the current participant.
-You can run tests against the properties of the current participant to permit or reject the execution of a transaction processor function.
+However, you can implement programmatic access control in your transaction processors by retrieving and testing either the current participant or the current identity.
+You can run tests against the properties of the current participant or the current identity to permit or reject the execution of a transaction processor function.
+
+A transaction processor function can call the `getCurrentParticipant` function to get the current participant:
+
+```javascript
+let currentParticipant = getCurrentParticipant();
+```
+
+The current participant is an instance of a modelled participant from the business network definition, or an instance of the system type `org.hyperledger.composer.system.NetworkAdmin`.
+
+A transaction processor function can call the `getCurrentIdentity` function to get the current identity:
+
+```javascript
+let currentIdentity = getCurrentIdentity();
+```
+
+The current identity is an instance of the system type `org.hyperledger.composer.system.Identity`, which represents an identity within a deployed business network.
 
 ## Before you start
 
-Before you follow these steps, you must have modeled a participant in a Business
-Network Definition and deployed it as a Business Network. You must have created
+Before you follow these steps, you must have modeled a participant in a business
+network definition and deployed it as a business network. You must have created
 some instances of those participants, and issued those participants with identities.
 
 The procedure below shows an example using the following participant models:
@@ -77,5 +93,21 @@ participant PrivilegedPerson extends Person {
            throw new Error('Transaction can only be submitted by the owner of the asset');
        }
        // Current participant must be the owner of the asset to get here.
+   }
+   ```
+
+3. In your transaction processor function, verify the certificate of the current identity
+   meets the requirements by using the `getCurrentIdentity` function:
+
+   ```javascript
+   async function onPrivilegedTransaction(privilegedTransaction) {
+       let currentIdentity = getCurrentIdentity();
+       // Get the PEM encoded certificate from the current identity.
+       let certificate = currentIdentity.certificate;
+       // Perform testing on the PEM encoded certificate.
+       if (!certificate.match(/^----BEGIN CERTIFICATE----/)) {
+            throw new Error('Transaction can only be submitted by a person with a valid certificate');
+       }
+       // Current identity must have a valid certificate to get here.
    }
    ```


### PR DESCRIPTION
Need ability to get an Identity's public key #2850

Add the function `getCurrentIdentity` to the runtime API, which can be called by a transaction processor function to return the current identity. This function returns an instance of `org.hyperledger.composer.system.Identity`, which provides the `certificate` field.

Expose the current identity through the ping response as well, which means it will show up via the JavaScript API (`BusinessNetworkConnection.ping`), the REST API (`/api/system/ping`), and the CLI (`composer network ping`).