### PR TITLE
modify generator to enable options to be passed and add integration tests

### DIFF
--- a/packages/composer-tests-integration/README.md
+++ b/packages/composer-tests-integration/README.md
@@ -17,10 +17,21 @@ docker rm $(docker ps -aq)
 As long as the script finishes, it should tidy up all the artifacts that are created during tests but if it fails then you 
 may have to do a manual clean up.
 
-## Manual testing
+## Features
 
-Sometimes you might want to run an individual test in which case you can use the tagging feature of cucumber like this.
-First modify your `.feature` file to include a suitable tag.
+We are testing the following:
+ - General CLI commands (cli.feature)
+ - REST server (rest.feature)
+ - Queries against a REST server (queries.feature)
+ - The business network generator (generator-busnet.feature)
+
+Usefull information:
+ - The `check stdout` is based upon the last command run within the framework
+ - It is possible to save an alias from the stdout to substitute back later in a future command (grep cli.feature for `alias`)
+ - The REST server tests establish a series of background processes that are accessed via a `tasks` object
+
+## Manual testing
+Cucumber features and individual scenarios can be run in isolation through the use of tags. Each feature file has a tag at the top; if you are adding new features, ensure that you have a tag for that feature file so that it can be run in isolation. Running a single scenario can be useful for debugging and can be achieved thorugh use of a tag above the sceanrio itself:
 
 ```
 @testdeservespenguin
@@ -37,5 +48,8 @@ Then you can modify the `test-inner` task in the `package.json` file to add your
 ```
 "test-inner": "cucumber-js --tags @testdeservespenguin",
 ```
+
+The above will run the single scenario; to run the feature file in isolation, use the feature file tag.
+
 
 

--- a/packages/composer-tests-integration/features/cli.feature
+++ b/packages/composer-tests-integration/features/cli.feature
@@ -1,7 +1,8 @@
+@cli
 Feature: Cli steps
 
     Background:
-        Given I have generated crypto material
+        Given I have admin business cards available
 
     Scenario: Using the CLI, I can create a business network card
         Given I have the following items
@@ -209,15 +210,6 @@ Feature: Cli steps
             composer transaction submit --card admin@basic-sample-network -d '{"$class": "org.hyperledger.composer.system.AddAsset","registryType": "Asset","registryId": "org.acme.sample.NewSampleAsset", "targetRegistry" : "resource:org.hyperledger.composer.system.AssetRegistry#org.acme.sample.SampleAsset", "resources": [{"$class": "org.acme.sample.NewSampleAsset","assetId": "newNewAsset","description":"Description","owner": "resource:org.acme.sample.SampleParticipant#sal","value": "101"}]}'
             """
         Then The stdout information should include text matching /Transaction Submitted./
-        Then The stdout information should include text matching /Command succeeded/
-
-    Scenario: Using the CLI, I can check that the assets were created
-        When I run the following CLI command
-            """
-            Then The stdout information should include text matching /newAsset/
-            Then The stdout information should include text matching /newNewAsset/
-            composer network list --card admin@basic-sample-network
-            """
         Then The stdout information should include text matching /Command succeeded/
 
     Scenario: Using the CLI, I can check that the assets were created

--- a/packages/composer-tests-integration/features/generator-busnet.feature
+++ b/packages/composer-tests-integration/features/generator-busnet.feature
@@ -1,0 +1,92 @@
+@busnet-gen
+Feature: Business Network Generator
+    Background:
+        Given I have admin business cards available
+
+    Scenario: Using the Composer generator, I can generate a template network
+        When I run the following CLI command
+            | command | yo hyperledger-composer:businessnetwork |
+            | --appname | my-bus-net |
+            | --appdescription | a description for my business network |
+            | --appauthor | Captain Conga |
+            | --appemail | conga@congaverse.com |
+            | --applicense | Apache2.0 |
+            | --ns | conga.busnet |
+        Then I have the following files
+            | ../my-bus-net/.eslintrc.yml |
+            | ../my-bus-net/README.md |
+            | ../my-bus-net/package.json |
+            | ../my-bus-net/models/conga.busnet.cto |
+            | ../my-bus-net/lib/logic.js |
+            | ../my-bus-net/test/logic.js |
+
+    Scenario: Using the Composer generator, I can install the business network packages
+        When I run the following CLI command
+            """
+             npm install --prefix ./my-bus-net
+            """
+        Then The stdout information should include text matching /added .* packages/
+
+    Scenario: Using the Composer generator, I can generate a testable template network
+        When I run the following CLI command
+            """
+             npm test --prefix ./my-bus-net
+            """
+        Then The stdout information should include text matching /1 passing/
+
+    Scenario: I can build a bna from the generated template network
+        When I run the following CLI command
+            """
+            composer archive create -t dir -a ./tmp/my-bus-net.bna -n ./my-bus-net
+            """
+        Then The stdout information should include text matching /Command succeeded/
+        Then I have the following files
+            | ../tmp/my-bus-net.bna |
+
+    Scenario: I can deploy a bna created from a generated template business network
+        Given I have a deployed the bna for template network my-bus-net
+        When I run the following CLI command
+            """
+            composer network ping --card admin@my-bus-net
+            """
+        Then The stdout information should include text matching /The connection to the network was successfully tested: my-bus-net/
+        Then The stdout information should include text matching /Command succeeded/
+
+    Scenario: I can create an asset in the deployed template business network
+         When I run the following CLI command
+            """
+            composer transaction submit --card admin@my-bus-net -d '{"$class": "org.hyperledger.composer.system.AddAsset","registryType": "Asset","registryId": "conga.busnet.SampleAsset", "targetRegistry" : "resource:org.hyperledger.composer.system.AssetRegistry#conga.busnet.SampleAsset", "resources": [{"$class": "conga.busnet.SampleAsset","assetId": "newAsset","value": "101"}]}'
+            """
+        Then The stdout information should include text matching /Transaction Submitted./
+        Then The stdout information should include text matching /Command succeeded/
+
+    Scenario: I can list all assets in the deployed templeate business network and the asset
+         When I run the following CLI command
+            """
+            composer network list --card admin@my-bus-net -r conga.busnet.SampleAsset
+            """
+        Then The stdout information should include text matching /newAsset: /
+        Then The stdout information should include text matching /\$class:  conga.busnet.SampleAsset/
+        Then The stdout information should include text matching /assetId: newAsset/
+        Then The stdout information should include text matching /value:   101/
+        Then The stdout information should include text matching /Command succeeded/
+
+    Scenario: I can submit the template transaction in the deployed template business network
+         When I run the following CLI command
+            """
+            composer transaction submit --card admin@my-bus-net -d '{"$class": "conga.busnet.ChangeAssetValue", "relatedAsset": "resource:conga.busnet.SampleAsset#newAsset", "newValue": "5"}'
+            """
+        Then The stdout information should include text matching /Transaction Submitted./
+        Then The stdout information should include text matching /Command succeeded/
+
+    Scenario: I can list all assets in the deployed templeate business network and see the updated asset
+         When I run the following CLI command
+            """
+            composer network list --card admin@my-bus-net -r conga.busnet.SampleAsset
+            """
+        Then The stdout information should include text matching /newAsset: /
+        Then The stdout information should include text matching /\$class:  conga.busnet.SampleAsset/
+        Then The stdout information should include text matching /assetId: newAsset/
+        Then The stdout information should include text matching /value:   5/
+        Then The stdout information should include text matching /Command succeeded/
+

--- a/packages/composer-tests-integration/features/queries.feature
+++ b/packages/composer-tests-integration/features/queries.feature
@@ -1,3 +1,4 @@
+@queries
 Feature: Queries steps
 
     Scenario: Using the REST API, I can ping the network

--- a/packages/composer-tests-integration/features/rest.feature
+++ b/packages/composer-tests-integration/features/rest.feature
@@ -1,3 +1,4 @@
+@rest
 Feature: Rest steps
 
     Scenario: Using the REST API, I can ping the network

--- a/packages/composer-tests-integration/package.json
+++ b/packages/composer-tests-integration/package.json
@@ -10,6 +10,7 @@
     "licchk": "license-check",
     "postlicchk": "npm run lint",
     "lint": "eslint .",
+    "test-tagged": "cucumber-js --tags @busnet",
     "test-inner": "cucumber-js",
     "test-inner-nohsm": "cucumber-js --tags 'not @hsm'",
     "int-test": "npm run pretest && npm run lint && npm run start_verdaccio && node ./scripts/npm_serve && npm run test-inner && npm run stop_verdaccio",
@@ -76,7 +77,9 @@
     "composer-client": "0.17.5",
     "composer-common": "0.17.5",
     "composer-rest-server": "0.17.5",
+    "generator-hyperledger-composer": "0.17.5",
     "thenify-all": "1.6.0",
-    "verdaccio": "2.6.4"
+    "verdaccio": "2.6.4",
+    "yo": "2.0.1"
   }
 }

--- a/packages/composer-tests-integration/scripts/npm_serve.js
+++ b/packages/composer-tests-integration/scripts/npm_serve.js
@@ -56,11 +56,14 @@ let packages = [
     'composer-client',
     'loopback-connector-composer',
     'composer-rest-server',
-    'composer-cli'];
+    'composer-report',
+    'composer-cli',
+    'generator-hyperledger-composer'];
 
 // Packages to be installed in integration test(s)
 let testPackages = [
-    'composer-cli'
+    'composer-cli',
+    'generator-hyperledger-composer'
 ];
 
 return packages.reduce((promiseChain, p) => {

--- a/packages/composer-tests-integration/scripts/run-integration-tests.sh
+++ b/packages/composer-tests-integration/scripts/run-integration-tests.sh
@@ -27,8 +27,9 @@ rm -rf ${HOME}/.composer/cards/sal*
 rm -rf ${HOME}/.composer/client-data/sal*
 rm -rf ${HOME}/.composer/cards/ange*
 rm -rf ${HOME}/.composer/client-data/ange*
-rm -rf ./tmp/*
-rm -rf ./networkadmin
+rm -rf ./tmp/*           # temp folder for BNA files that are generated
+rm -rf ./my-bus-net      # business network created from generator
+rm -f ./networkadmin.card
 rm -rf ${HOME}/.npmrc
 if [ "${DOCKER_FILE}" != "" ]; then
     cd ../composer-runtime-hlfv1
@@ -159,10 +160,11 @@ for INTEST in $(echo ${INTEST} | tr "," " "); do
     rm -rf ${HOME}/.composer/cards/ange*
     rm -rf ${HOME}/.composer/client-data/ange*
     rm -rf ./tmp/*
+    rm -rf ./my-bus-net
     rm -rf ./networkadmin
     rm -rf ${HOME}/.npmrc
     rm ./*.tgz
-    rm ./networkadmin.card
+    rm -f ./networkadmin.card
     if [ "${DOCKER_FILE}" != "" ]; then
         cd ../composer-runtime-hlfv1
         rm .npmrc

--- a/packages/generator-hyperledger-composer/generators/businessnetwork/index.js
+++ b/packages/generator-hyperledger-composer/generators/businessnetwork/index.js
@@ -3,13 +3,11 @@
 const Util = require('./../util');
 
 let yeoman = require('yeoman-generator');
-
+let optionOrPrompt = require('yeoman-option-or-prompt');
 
 module.exports = yeoman.Base.extend({
-    constructor: function() {
-        yeoman.Base.apply(this, arguments);
-        this.options = this.env.options;
-    },
+
+    _optionOrPrompt: optionOrPrompt,
 
     prompting: function() {
         console.log('Welcome to the business network generator');
@@ -53,7 +51,7 @@ module.exports = yeoman.Base.extend({
             },
             {
                 type: 'input',
-                name: 'namespace',
+                name: 'ns',
                 message: 'Namespace:',
                 default: 'org.example.biznet',
                 store: true,
@@ -61,11 +59,11 @@ module.exports = yeoman.Base.extend({
             }
         ];
 
-        return this.prompt(questions)
+        return this._optionOrPrompt(questions)
             .then((answers) => {
                 this.appname = answers.appname;
                 this.appemail = answers.appemail;
-                this.namespace = answers.namespace;
+                this.namespace = answers.ns;
                 this.appdescription = answers.appdescription;
                 this.appauthor = answers.appauthor;
                 this.applicense = answers.applicense;

--- a/packages/generator-hyperledger-composer/package.json
+++ b/packages/generator-hyperledger-composer/package.json
@@ -17,7 +17,8 @@
     "composer-common": "0.17.5",
     "shelljs": "0.7.7",
     "underscore.string": "3.3.4",
-    "yeoman-generator": "0.24.1"
+    "yeoman-generator": "0.24.1",
+    "yeoman-option-or-prompt": "2.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/generator-hyperledger-composer/test/business-network.js
+++ b/packages/generator-hyperledger-composer/test/business-network.js
@@ -49,7 +49,7 @@ describe('hyperledger-composer:businessnetwork for generating a template busines
             appauthor: passedAuthor,
             appemail: passedEmail,
             applicense: passedLic,
-            namespace: passedNS,
+            ns: passedNS,
         })
         .on('error', function (error) {
             console.log('Error found:', error);


### PR DESCRIPTION
contributes to #3385 and closes #3306

Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>

It was necessary to change the generator to enable passing of parameters through as command line options ... which itself pulled in a new dependancy

Following this change it was possible to add integration tests to drive the new generator, within which we programatically:
- generate bus net over cli
- install busnet
- run busnet tests
- deploy busnet to Fabric
- create assets in deployed bus net
- run sample transaction to update asset
- check the above have occurred correctly through inspection of console output 