### PR TITLE
Handling an uncaught Playground error when cancelling a transaction

### DIFF
--- a/packages/composer-playground/src/app/test/test.component.ts
+++ b/packages/composer-playground/src/app/test/test.component.ts
@@ -17,6 +17,7 @@ import { ClientService } from '../services/client.service';
 import { AlertService } from '../basic-modals/alert.service';
 import { TransactionComponent } from './transaction/transaction.component';
 import { TransactionDeclaration } from 'composer-common';
+import { DrawerDismissReasons } from '../common/drawer';
 
 @Component({
     selector: 'app-test',
@@ -140,6 +141,11 @@ export class TestComponent implements OnInit, OnDestroy {
             }
 
             this.alertService.successStatus$.next(message);
+        })
+        .catch((error) => {
+            if (error !== DrawerDismissReasons.ESC ) {
+                this.alertService.errorStatus$.next(error);
+            }
         });
     }
 


### PR DESCRIPTION
Fix for #3274 .
Added a catch block to handle a previously uncaught error that occurred when cancelling a transaction in Playground.
Included tests to cover this, and also added a test for an uncovered branch of code in the same class.

Signed-off-by: Erin Hughes <erinhughes@erins-mbp.hursley.uk.ibm.com>