### PR TITLE
Add missing sha.js dependency (resolves #3416)

### DIFF
--- a/packages/composer-common/package.json
+++ b/packages/composer-common/package.json
@@ -77,6 +77,7 @@
     "proxyquire": "1.7.11",
     "rimraf": "2.5.4",
     "semver": "5.3.0",
+    "sha.js": "2.4.8",
     "sprintf-js": "1.0.3",
     "temp": "0.8.3",
     "thenify": "3.2.1",


### PR DESCRIPTION
Cannot find module sha.js when loading composer-common #3416

Add missing `sha.js` dependency to `package.json` for the `composer-common` module.