### PR TITLE
Address and Set CLI unit tests to 100% coverage

### DIFF
--- a/packages/composer-cli/lib/cmds/card/lib/delete.js
+++ b/packages/composer-cli/lib/cmds/card/lib/delete.js
@@ -31,7 +31,7 @@ class Delete {
             if (cardExisted) {
                 cmdUtil.log(chalk.bold.blue('Deleted Business Network Card: ') + args.name);
             } else {
-                cmdUtil.log(chalk.bold.blue('Card not found: ') + args.name);
+                throw new Error(`Card not found: ${args.name}`);
             }
         });
     }

--- a/packages/composer-cli/package.json
+++ b/packages/composer-cli/package.json
@@ -92,9 +92,9 @@
     ],
     "all": true,
     "check-coverage": true,
-    "statements": 83,
-    "branches": 64,
-    "functions": 78,
-    "lines": 83
+    "statements": 100,
+    "branches": 100,
+    "functions": 100,
+    "lines": 100
   }
 }

--- a/packages/composer-cli/test/card/delete.js
+++ b/packages/composer-cli/test/card/delete.js
@@ -64,11 +64,8 @@ describe('composer card delete CLI', function() {
         adminConnectionStub.deleteCard.resolves(false);
         const cardName = 'CARD_NAME';
         const args = { name: cardName };
-        return DeleteCmd.handler(args).then(() => {
-            // regexp to quickly strip any colour coded console output
-            let regexp = new RegExp('.*Card not found:.*'+cardName);
-            sinon.assert.calledWith(consoleLogSpy, sinon.match(regexp));
-        });
+        let regexp = new RegExp('.*Card not found:.*'+cardName);
+        DeleteCmd.handler(args).should.be.rejectedWith(regexp);
     });
 
 });

--- a/packages/composer-cli/test/card/list.js
+++ b/packages/composer-cli/test/card/list.js
@@ -92,6 +92,21 @@ describe('composer card list CLI', () => {
         sinon.assert.calledWith(CmdUtil.log, sinon.match(/credentialsSet:.*Credentials set/));
     });
 
+    it('show card details for one card with certificates', async () => {
+        const testCard = new IdCard({ userName: 'conga', description: 'such description', roles: ['PeerAdmin', 'ChannelAdmin'] }, { name: 'profileName' });
+        testCard.setCredentials({certificate:'cert'});
+        adminConnectionStub.exportCard.resolves(testCard);
+        await ListCmd.handler({ name: 'cardname' });
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/userName:.*conga/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/description:.*such description/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/businessNetworkName:/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/identityId:.*[0-9a-z]{64}/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/roles:[^]*PeerAdmin[^]*ChannelAdmin/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/connectionProfile:[^]*name:.*profileName/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/secretSet:.*No secret set/));
+        sinon.assert.calledWith(CmdUtil.log, sinon.match(/credentialsSet:.*Credentials set, HSM managed/));
+    });
+
     it('show card details for one card without certificates', async () => {
         const testCard = new IdCard({ userName: 'conga', description: '', enrollmentSecret:'secret' }, { name: 'profileName' });
         adminConnectionStub.exportCard.resolves(testCard);

--- a/packages/composer-cli/test/identity/request.js
+++ b/packages/composer-cli/test/identity/request.js
@@ -109,6 +109,31 @@ describe('composer identity request CLI unit tests', () => {
             });
     });
 
+    it('should request an identity which is HSM managed', () => {
+        let argv = {
+            card : 'cardName',
+            user : USER_ID,
+            enrollSecret: USER_SECRET,
+        };
+        let fsStub = sandbox.stub(fs, 'writeFileSync');
+        sandbox.stub(os, 'homedir').returns('/x');
+        mockAdminConnection.requestIdentity.resolves({
+            certificate: 'a',
+            rootCertificate: 'c',
+            caName: 'caName',
+            enrollId : USER_ID
+        });
+        return Request.handler(argv)
+            .then(() => {
+                argv.thePromise.should.be.a('promise');
+                sinon.assert.calledOnce(mockAdminConnection.requestIdentity);
+                sinon.assert.calledWith(mockAdminConnection.requestIdentity, 'cardName', USER_ID, USER_SECRET);
+                sinon.assert.calledTwice(fsStub);
+                sinon.assert.calledWith(fsStub, '/x/.identityCredentials/SuccessKid-pub.pem', 'a');
+                sinon.assert.calledWith(fsStub, '/x/.identityCredentials/caName-root.pem', 'c');
+            });
+    });
+
     it('should fail gracefully if requestIdentity fails', () => {
         let argv = {
             cardName : 'cardName',

--- a/packages/composer-common/lib/cardstore/filesystemcardstore.js
+++ b/packages/composer-common/lib/cardstore/filesystemcardstore.js
@@ -92,7 +92,7 @@ class FileSystemCardStore extends BusinessNetworkCardStore {
             return card.toDirectory(cardPath, this.fs);
         }).catch(cause => {
             LOG.error(method, cause);
-            const error = new Error('Failed to save card: ' + cardName);
+            const error = new Error(`Failed to save card: ${cardName}. Reason: ${cause.message}`);
             error.cause = cause;
             throw error;
         });

--- a/packages/composer-common/lib/idcard.js
+++ b/packages/composer-common/lib/idcard.js
@@ -434,7 +434,7 @@ class IdCard {
             return Promise.all(credentialPromises);
         }).catch(cause => {
             LOG.error(method, cause);
-            throw newErrorWithCause('Failed to save card to directory: ' + cardDirectory, cause);
+            throw newErrorWithCause(`Failed to save card to directory: ${cardDirectory}. Reason: ${cause.message}`, cause);
         });
     }
 

--- a/packages/composer-tests-integration/features/cli.feature
+++ b/packages/composer-tests-integration/features/cli.feature
@@ -126,6 +126,13 @@ Feature: Cli steps
         Then The stdout information should include text matching /credentialsSet:      Credentials set/
         Then The stdout information should include text matching /Command succeeded/
 
+    Scenario: When using the CLI, I should get an error if I try to delete a card which doesn't exist
+        When I run the following CLI command
+            """
+            composer card delete -n whoami@basic-sample-network
+            """
+        Then The stdout information should include text matching /Command failed/
+
     Scenario: Using the CLI, I can verify that there no assets have been created yet
         When I run the following CLI command
             """

--- a/packages/composer-tests-integration/lib/clisteps.js
+++ b/packages/composer-tests-integration/lib/clisteps.js
@@ -48,7 +48,9 @@ module.exports = function () {
         response = await this.composer.runCLI(`composer network start --card TestPeerAdmin@org1 --networkAdmin admin --networkAdminEnrollSecret adminpw --archiveFile ${bnaFile} --file networkadmin.card`);
         checkOutput(response);
         response = await this.composer.runCLI(`composer card delete -n ${adminId}`);
-        checkOutput(response);
+        // can't check the response here, if it exists the card is deleted and you get a success
+        // if it didn't exist then you get a failed message. however if there is a problem then the
+        // import won't work so check the response to this.
         response = await this.composer.runCLI('composer card import --file networkadmin.card');
         checkOutput(response);
     });

--- a/packages/composer-tests-integration/lib/reststeps.js
+++ b/packages/composer-tests-integration/lib/reststeps.js
@@ -36,7 +36,9 @@ module.exports = function () {
         response = await this.composer.runCLI(`composer network start --card TestPeerAdmin@org1 --networkAdmin admin --networkAdminEnrollSecret adminpw --archiveFile ${bnaFile} --file networkadmin.card`);
         checkOutput(response);
         response = await this.composer.runCLI(`composer card delete -n ${adminId}`);
-        checkOutput(response);
+        // can't check the response here, if it exists the card is deleted and you get a success
+        // if it didn't exist then you get a failed message. however if there is a problem then the
+        // import won't work so check the response to this.
         response = await this.composer.runCLI('composer card import --file networkadmin.card');
         checkOutput(response);
         await this.composer.runBackground('REST_SVR', `composer-rest-server --card ${adminId} -n never -w true`, /Browse your REST API/);


### PR DESCRIPTION
- address some test debt for HSM
- ensure we keep 100% on cli by setting the required values to 100
- address card save error messages which are lacking in info
- address not found in card delete reported as a success

closes #2983 
closes #2835 

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
