### PR TITLE
Handling various uncaught errors when cancelling modals

### DIFF
--- a/packages/composer-playground/src/app/test/registry/registry.component.spec.ts
+++ b/packages/composer-playground/src/app/test/registry/registry.component.spec.ts
@@ -35,6 +35,7 @@ import { ResourceComponent } from '../resource/resource.component';
 import { ClientService } from '../../services/client.service';
 import { AlertService } from '../../basic-modals/alert.service';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { DrawerDismissReasons } from '../../common/drawer';
 
 import * as chai from 'chai';
 
@@ -263,6 +264,36 @@ describe(`RegistryComponent`, () => {
             tick();
             component.loadResources.should.be.called;
         }));
+
+        it('shoud handle closing by escape', fakeAsync(() => {
+            mockNgbModal.open = sandbox.stub().returns({
+                componentInstance: sandbox.stub(),
+                result: Promise.reject(DrawerDismissReasons.ESC)
+            });
+            mockAssetRegistry.id = 'registry_id';
+            component['_registry'] = mockAssetRegistry;
+
+            sinon.stub(component, 'loadResources');
+
+            component.openNewResourceModal();
+            tick();
+            mockAlertService.errorStatus$.next.should.not.have.been.called;
+        }));
+
+        it('should handle closing due to an error', fakeAsync(() => {
+            mockNgbModal.open = sandbox.stub().returns({
+                componentInstance: sandbox.stub(),
+                result: Promise.reject('error message')
+            });
+            mockAssetRegistry.id = 'registry_id';
+            component['_registry'] = mockAssetRegistry;
+
+            sinon.stub(component, 'loadResources');
+
+            component.openNewResourceModal();
+            tick();
+            mockAlertService.errorStatus$.next.should.have.been.calledWith('error message');
+        }));
     });
 
     describe('#hasOverflow', () => {
@@ -313,6 +344,41 @@ describe(`RegistryComponent`, () => {
             mockNgbModalRef.registryId.should.equal('registry_id');
             component.loadResources.should.be.called;
         }));
+
+        it('should handle closing by escape', fakeAsync(() => {
+            let mockNgbModalRef = sandbox.stub();
+            mockNgbModalRef.resource = null;
+
+            mockNgbModal.open = sandbox.stub().returns({
+                componentInstance: mockNgbModalRef,
+                result: Promise.reject(DrawerDismissReasons.ESC)
+            });
+            mockAssetRegistry.id = 'registry_id';
+            component['_registry'] = mockAssetRegistry;
+
+            sinon.stub(component, 'loadResources');
+
+            component.editResource(mockAsset);
+            tick();
+            mockAlertService.errorStatus$.next.should.not.have.been.called;
+        }));
+
+        it('should handle closing due to an error', fakeAsync(() => {
+            let mockNgbModalRef = sandbox.stub();
+            mockNgbModalRef.resource = null;
+            mockNgbModal.open = sandbox.stub().returns({
+                componentInstance: mockNgbModalRef,
+                result: Promise.reject('error message')
+            });
+            mockAssetRegistry.id = 'registry_id';
+            component['_registry'] = mockAssetRegistry;
+
+            sinon.stub(component, 'loadResources');
+
+            component.editResource(mockAsset);
+            tick();
+            mockAlertService.errorStatus$.next.should.have.been.calledWith('error message');
+        }));
     });
 
     describe('#openDeleteResourceModal', () => {
@@ -360,6 +426,26 @@ describe(`RegistryComponent`, () => {
             component.openDeleteResourceModal(mockResource);
             mockAlertService.errorStatus$.next.should.not.be.called;
             component.loadResources.should.not.be.called;
+        }));
+
+        it('should handle closing by escape', fakeAsync(() => {
+            sandbox.stub(component, 'loadResources');
+            mockNgbModalRef.result = Promise.reject(DrawerDismissReasons.ESC);
+            component['_registry'] = mockAssetRegistry;
+            component.openDeleteResourceModal(mockResource);
+            tick();
+            mockAlertService.errorStatus$.next.should.not.have.been.called;
+            component.loadResources.should.not.have.been.called;
+        }));
+
+        it('should handle closing due to an error', fakeAsync(() => {
+            sandbox.stub(component, 'loadResources');
+            mockNgbModalRef.result = Promise.reject('error message');
+            component['_registry'] = mockAssetRegistry;
+            component.openDeleteResourceModal(mockResource);
+            tick();
+            mockAlertService.errorStatus$.next.should.have.been.calledWith('error message');
+            component.loadResources.should.not.have.been.called;
         }));
     });
 
@@ -422,7 +508,7 @@ describe(`RegistryComponent`, () => {
 
             mockNgbModal.open = sinon.stub().returns({
                 componentInstance: componentInstance,
-                result: Promise.reject(1)
+                result: Promise.reject(DrawerDismissReasons.ESC)
             });
 
             let mockTransaction = {mock: 'transaction', eventsEmitted: ['event 1']};

--- a/packages/composer-playground/src/app/test/registry/registry.component.ts
+++ b/packages/composer-playground/src/app/test/registry/registry.component.ts
@@ -19,6 +19,7 @@ import { AlertService } from '../../basic-modals/alert.service';
 import { ResourceComponent } from '../resource/resource.component';
 import { DeleteComponent } from '../../basic-modals/delete-confirm/delete-confirm.component';
 import { ViewTransactionComponent } from '../view-transaction/view-transaction.component';
+import { DrawerDismissReasons } from '../../common/drawer';
 
 @Component({
     selector: 'registry',
@@ -101,6 +102,11 @@ export class RegistryComponent {
         modalRef.result.then(() => {
             // refresh current resource list
             this.loadResources();
+        })
+        .catch((error) => {
+            if (error !== DrawerDismissReasons.ESC ) {
+                this.alertService.errorStatus$.next(error);
+            }
         });
     }
 
@@ -117,6 +123,11 @@ export class RegistryComponent {
         editModalRef.result.then(() => {
             // refresh current resource list
             this.loadResources();
+        })
+        .catch((error) => {
+          if (error !== DrawerDismissReasons.ESC ) {
+              this.alertService.errorStatus$.next(error);
+            }
         });
     }
 
@@ -143,6 +154,11 @@ export class RegistryComponent {
                 // modal but will that always be true
 
             }
+        })
+        .catch((error) => {
+            if (error !== DrawerDismissReasons.ESC ) {
+                this.alertService.errorStatus$.next(error);
+            }
         });
     }
 
@@ -153,7 +169,7 @@ export class RegistryComponent {
             transactionModalRef.componentInstance.events = transaction.eventsEmitted;
 
             transactionModalRef.result.catch((error) => {
-                if (error && error !== 1) {
+                if (error && error !== DrawerDismissReasons.ESC) {
                     this.alertService.errorStatus$.next(error);
                 }
             });


### PR DESCRIPTION
Fix for #3422.
Handles previously uncaught errors when cancelling add or edit operations on participants or assets. I also found some uncaught errors when cancelling the deletion of a participant or asset, and fixed those as well.

Signed-off-by: Erin Hughes <erinhughes@erins-mbp.hursley.uk.ibm.com>