### PR TITLE
update fabric-client and fabric-ca-client version

### DIFF
--- a/packages/composer-connector-hlfv1/package.json
+++ b/packages/composer-connector-hlfv1/package.json
@@ -42,8 +42,8 @@
   "dependencies": {
     "composer-common": "0.16.5",
     "composer-runtime-hlfv1": "0.16.5",
-    "fabric-ca-client": "1.0.3",
-    "fabric-client": "1.0.3",
+    "fabric-ca-client": "1.0.4",
+    "fabric-client": "1.0.4",
     "fs-extra": "1.0.0",
     "grpc": ">=1.3.5 <1.7.0",
     "jsrsasign": "8.0.3",


### PR DESCRIPTION
Update composer-connector-hlfv1 package.json to update fabric-client and fabric-ca-client from 1.0.3 to 1.0.4

Closes #3473 

Signed-off-by: Sam Smith <smithsj@uk.ibm.com>
