### PR TITLE
correct usage of wallet in connector remove identity

### DIFF
--- a/packages/composer-connector-server/lib/connectorserver.js
+++ b/packages/composer-connector-server/lib/connectorserver.js
@@ -218,6 +218,7 @@ class ConnectorServer {
     connectionManagerRemoveIdentity(connectionProfile, connectionOptions, id, callback) {
         const method = 'connectionManagerRemoveIdentity';
         LOG.entry(method, connectionProfile, id);
+        connectionOptions.wallet = this.businessNetworkCardStore.getWallet(connectionOptions.cardName);
         return this.connectionProfileManager.getConnectionManagerByType(connectionOptions['x-type'])
             .then((connectionManager) => {
                 return connectionManager.removeIdentity(connectionProfile, connectionOptions, id);


### PR DESCRIPTION
Signed-off-by: Matthew B White <whitemat@uk.ibm.com>

Connector Server didn't correctly use the 'local' wallet and instead tried to use the proxy one passed from Playground. 