### PR TITLE
Improve playground package.json editing

### DIFF
--- a/packages/composer-playground/e2e/specs/playground-tutorial.spec.ts
+++ b/packages/composer-playground/e2e/specs/playground-tutorial.spec.ts
@@ -99,7 +99,7 @@ describe('Playground Tutorial Define', (() => {
 
   describe('Connecting to the business network', (() => {
       it('should let the user connect to their sample network', (() => {
-        let expectedFiles = ['About\nREADME.md', 'Access Control\npermissions.acl'];
+        let expectedFiles = ['About\nREADME.md, package.json', 'Access Control\npermissions.acl'];
         return Login.connectViaIdCard(profile, networkName)
         .then(() => {
             // Should now be on main editor page for the business network
@@ -277,7 +277,7 @@ describe('Playground Tutorial Define', (() => {
 
   describe('Deploying the updated business network', (() => {
       it('should have the right number of files', (() => {
-          let expectedFiles = ['About\nREADME.md', 'Access Control\npermissions.acl', 'Model File\nmodels/org.acme.model.cto', 'Script File\nlib/script.js'];
+          let expectedFiles = ['About\nREADME.md, package.json', 'Access Control\npermissions.acl', 'Model File\nmodels/org.acme.model.cto', 'Script File\nlib/script.js'];
           Editor.retrieveNavigatorFileNames()
           .then((filelist: any) => {
               expect(filelist).to.be.an('array').lengthOf(4);

--- a/packages/composer-playground/src/app/editor/editor-files.pipe.spec.ts
+++ b/packages/composer-playground/src/app/editor/editor-files.pipe.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* tslint:disable:no-unused-variable */
+/* tslint:disable:no-unused-expression */
+/* tslint:disable:no-var-requires */
+/* tslint:disable:max-classes-per-file */
+import { EditorFilesPipe } from './editor-files.pipe';
+import { EditorFile } from '../services/editor-file';
+
+import * as chai from 'chai';
+
+let should = chai.should();
+
+describe('EditorFilesPipe', () => {
+    let pipe: EditorFilesPipe;
+
+    beforeEach(() => {
+        pipe = new EditorFilesPipe();
+    });
+
+    it('should filter out readme files', () => {
+        let readmeFile = new EditorFile('readme', 'readme.md', 'myContent', 'readme');
+        let filteredFiles = pipe.transform([readmeFile]);
+
+        filteredFiles.should.deep.equal([]);
+    });
+
+    it('should filter out package files', () => {
+        let packageFile = new EditorFile('package', 'package.json', 'myContent', 'package');
+        let filteredFiles = pipe.transform([packageFile]);
+
+        filteredFiles.should.deep.equal([]);
+    });
+
+    it('should not filter out other files', () => {
+        let modelFile = new EditorFile('model', 'model', 'myContent', 'model');
+        let scriptFile = new EditorFile('script', 'script', 'myContent', 'script');
+        let aclFile = new EditorFile('acl', 'acl', 'myContent', 'acl');
+        let queryFile = new EditorFile('query', 'query', 'myContent', 'query');
+
+        let filteredFiles = pipe.transform([modelFile, scriptFile, aclFile, queryFile]);
+
+        filteredFiles.should.deep.equal([modelFile, scriptFile, aclFile, queryFile]);
+    });
+});

--- a/packages/composer-playground/src/app/editor/editor-files.pipe.ts
+++ b/packages/composer-playground/src/app/editor/editor-files.pipe.ts
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Pipe, PipeTransform } from '@angular/core';
+
+import { EditorFile } from '../services/editor-file';
+
+@Pipe({ name: 'editorFilesFilter' })
+export class EditorFilesPipe implements PipeTransform {
+    transform(allFiles: EditorFile[]) {
+        return allFiles.filter((file) => !(file.isPackage() || file.isReadMe()));
+    }
+}

--- a/packages/composer-playground/src/app/editor/editor.component.html
+++ b/packages/composer-playground/src/app/editor/editor.component.html
@@ -3,15 +3,27 @@
         <span>Files</span>
         <perfect-scrollbar class="side-bar-nav" scroll-to-element [elementId]="listItem">
             <ul>
-                <li #editorFileList id="editorFileList{{fileIndex}}" *ngFor="let file of files; let fileIndex = index"
+                <li *ngIf="currentFile && aboutFileNames && aboutFileNames.length > 0" #editorFileList id="editorFileListAbout"
+                    [class.active]="currentFile.isPackage() || currentFile.isReadMe()" (click)="setCurrentFile(files[0])">
+                    <div class="flex-container">
+                        <div class="flex">
+                            <h3 [class.error]="invalidAboutFileIDs && invalidAboutFileIDs.length > 0">About</h3>
+                            <div [class.error]="invalidAboutFileIDs && invalidAboutFileIDs.length > 0">{{aboutFileNames.join(', ')}}</div>
+                        </div>
+                        <div *ngIf="invalidAboutFileIDs && invalidAboutFileIDs.length > 0" class="error_dot">
+                            <svg class="ibm-icon" aria-hidden="true">
+                                <use xlink:href="#icon-error_dot"></use>
+                            </svg>
+                        </div>
+                    </div>
+                </li>
+                <li #editorFileList id="editorFileList{{fileIndex}}" *ngFor="let file of (files | editorFilesFilter); let fileIndex = index"
                     [class.active]="file.id === currentFile.id" (click)="setCurrentFile(file)">
                     <div class="flex-container">
                         <div class="flex">
-                            <h3 [class.error]="file.invalid" *ngIf="file.package">Package Details</h3>
                             <h3 [class.error]="file.invalid" *ngIf="file.isModel()">Model File</h3>
                             <h3 [class.error]="file.invalid" *ngIf="file.isScript()">Script File</h3>
                             <h3 [class.error]="file.invalid" *ngIf="file.isAcl()">Access Control</h3>
-                            <h3 [class.error]="file.invalid" *ngIf="file.isReadMe()">About</h3>
                             <h3 [class.error]="file.invalid" *ngIf="file.isQuery()">Query File</h3>
                             <div [class.error]="file.invalid">{{file.displayID}}</div>
                         </div>
@@ -48,19 +60,16 @@
 <section class="main-view">
     <div class="main-view-content">
         <div>
-            <div *ngIf="editingPackage" class="business-network-details">
-                <h1>Editing package.json</h1>
-            </div>
-            <div *ngIf="!editActive && !editingPackage" class="business-network-details">
+            <div *ngIf="!editActive" class="business-network-details">
                 <div style="flex-shrink:1;align-self: center">
-                    <h1 *ngIf="currentFile && fileType(currentFile)!='Readme'" class="margin-right">{{
+                    <h1 *ngIf="currentFile && (fileType(currentFile)=='Readme' || fileType(currentFile)=='Package')" class="margin-right">About File</h1>
+                </div>
+                <div style="flex-shrink:1;align-self: center">
+                    <h1 *ngIf="currentFile && fileType(currentFile)!='Readme' && fileType(currentFile)!='Package'" class="margin-right">{{
                         fileType(currentFile) }} File</h1>
                 </div>
-                <div *ngIf="currentFile && fileType(currentFile)!='Readme'" style="flex-shrink:1;align-self:center"
+                <div *ngIf="currentFile" style="flex-shrink:1;align-self:center"
                      class="business-network-version small">{{currentFile.displayID}}
-                </div>
-                <div *ngIf="currentFile && fileType(currentFile)=='Readme'" style="flex-shrink:1;align-self:center"
-                     class="business-network-version small">v{{deployedPackageVersion}}
                 </div>
                 <div *ngIf="(currentFile && !preventNameEdit(currentFile))" class="edit_icon">
                     <button id="editFileButton" type="button" class="action" (click)="toggleEditActive()">
@@ -77,8 +86,8 @@
                     </button>
                 </div>
 
-                <div *ngIf="currentFile && fileType(currentFile)=='Readme'" class="readme_icon_preview">
-                    <button id="editFileButton" type="button" class="action" [class.active]="previewReadme"
+                <div *ngIf="currentFile && aboutFileNames && aboutFileNames.length > 1 && (fileType(currentFile)=='Readme' || fileType(currentFile)=='Package')" class="readme_icon_preview">
+                    <button id="previewReadmeButton" type="button" class="action" [class.active]="currentFile.isReadMe() && previewReadme"
                             (click)="setReadmePreview(true)">
                         <svg class="ibm-icon vertical-top" aria-hidden="true">
                             <use xlink:href="#icon-view_24"></use>
@@ -86,17 +95,26 @@
                     </button>
                 </div>
 
-                <div *ngIf="currentFile && fileType(currentFile)=='Readme'" class="readme_icon_edit">
-                    <button id="editFileButton" type="button" class="action" [class.active]="!previewReadme"
+                <div *ngIf="currentFile && aboutFileNames && aboutFileNames.length > 1 && (fileType(currentFile)=='Readme' || fileType(currentFile)=='Package')" class="readme_icon_edit">
+                    <button id="editReadmeButton" type="button" class="action" [class.active]="currentFile && currentFile.isReadMe() && !previewReadme"
                             (click)="setReadmePreview(false)">
                         <svg class="ibm-icon vertical-top" aria-hidden="true">
                             <use xlink:href="#icon-code_24"></use>
                         </svg>
                     </button>
                 </div>
+
+                <div *ngIf="currentFile && aboutFileNames && aboutFileNames.length > 1 && (fileType(currentFile)=='Readme' || fileType(currentFile)=='Package')" class="readme_icon_settings">
+                    <button id="editPackageButton" type="button" class="action" [class.active]="currentFile && currentFile.isPackage()"
+                            (click)="editPackageJson()">
+                        <svg class="ibm-icon vertical-top" aria-hidden="true">
+                            <use xlink:href="#icon-manage_24"></use>
+                        </svg>
+                    </button>
+                </div>
             </div>
 
-            <div *ngIf="editActive && fileType(currentFile)!='Readme'" class="business-network-details">
+            <div *ngIf="editActive && fileType(currentFile)!='Package' && fileType(currentFile)!='Readme'" class="business-network-details">
                 <div class="flex-container" style="flex-direction:column">
                     <div class="edit-file-row">
                         <label class="edit-file-label" for="editName">Name</label>

--- a/packages/composer-playground/src/app/editor/editor.component.scss
+++ b/packages/composer-playground/src/app/editor/editor.component.scss
@@ -167,16 +167,14 @@ app-editor {
         padding-top:4px;
     }
 
-    .readme_icon_edit {
+    .readme_icon_preview .readme_icon_edit .readme_icon_settings {
       flex-shrink: 1;
       padding-top:4px;
+      padding-right: 10px;
     }
 
     .readme_icon_preview {
-      flex-shrink: 1;
       margin-left: auto;
-      padding-top:4px;
-      padding-right: 10px;
     }
   }
 

--- a/packages/composer-playground/src/app/editor/editor.component.ts
+++ b/packages/composer-playground/src/app/editor/editor.component.ts
@@ -48,6 +48,8 @@ import { saveAs } from 'file-saver';
 export class EditorComponent implements OnInit, OnDestroy {
 
     private files: any = [];
+    private aboutFileNames: any[] = [];
+    private invalidAboutFileIDs: any[] = [];
     private currentFile: any = null;
     private deletableFile: boolean = false;
 
@@ -60,7 +62,6 @@ export class EditorComponent implements OnInit, OnDestroy {
     private noError: boolean = true;
 
     private editActive: boolean = false; // Are the input boxes visible?
-    private editingPackage: boolean = false; // Is the package.json being edited?
     private previewReadme: boolean = true; // Are we in preview mode for the README.md file?
 
     private deployedPackageVersion; // This is the deployed BND's package version
@@ -103,17 +104,10 @@ export class EditorComponent implements OnInit, OnDestroy {
 
                 if (this.fileService.getEditorFiles().length === 0) {
                     this.files = this.fileService.loadFiles();
-                } else {
-                    this.files = this.fileService.getEditorFiles();
                 }
 
+                this.updateFiles();
                 this.updatePackageInfo();
-
-                if (this.fileService.getCurrentFile() !== null) {
-                    this.setCurrentFile(this.fileService.getCurrentFile());
-                } else {
-                    this.setInitialFile();
-                }
             })
             .catch((error) => {
                 this.alertService.errorStatus$.next(error);
@@ -130,26 +124,20 @@ export class EditorComponent implements OnInit, OnDestroy {
         this.inputPackageVersion = metaData.getVersion();
     }
 
-    setInitialFile() {
-        if (this.files && this.files.length > 0) {
-            let initialFile = this.files.find((file) => {
-                return file.isReadMe();
-            });
-            if (!initialFile) {
-                initialFile = this.files[0];
-            }
-            this.setCurrentFile(initialFile);
-        }
-    }
-
     setCurrentFile(file) {
-        this.listItem = 'editorFileList' + this.findFileIndex(true, file.id);
+        let listItemIndex;
+        if (file.isPackage() || file.isReadMe()) {
+            listItemIndex = 'About';
+        } else {
+            listItemIndex = this.findFileIndex(true, file.id) - this.aboutFileNames.length;
+        }
+        this.listItem = 'editorFileList' + listItemIndex;
+
         let always = (this.currentFile === null || file.isPackage() || file.isReadMe() || file.isAcl() || file.isQuery());
         let conditional = (always || this.currentFile.id !== file.id || this.currentFile.displayID !== file.displayID);
         if (always || conditional) {
-            if (this.editingPackage) {
+            if (this.currentFile && this.currentFile.isPackage()) {
                 this.updatePackageInfo();
-                this.editingPackage = false;
             }
             if (file.isScript() || file.isModel() || file.isQuery()) {
                 this.deletableFile = true;
@@ -180,8 +168,33 @@ export class EditorComponent implements OnInit, OnDestroy {
         return name;
     }
 
-    updateFiles() {
+    updateFiles(selectFile = null) {
+        let initialFile;
         this.files = this.fileService.getEditorFiles();
+
+        this.aboutFileNames = [];
+        for (let i = 0; i < this.files.length; i++) {
+            let file = this.files[i];
+            if (file.isPackage() || file.isReadMe()) {
+                if (file.isReadMe()) {
+                    initialFile = file;
+                }
+                this.aboutFileNames.push(file.displayID);
+            } else {
+                if (!initialFile) {
+                    initialFile = file;
+                }
+                break;
+            }
+        }
+
+        if (selectFile) {
+            this.setCurrentFile(selectFile);
+        } else if (this.fileService.getCurrentFile()) {
+            this.setCurrentFile(this.fileService.getCurrentFile());
+        } else if (initialFile) {
+            this.setCurrentFile(initialFile);
+        }
     }
 
     addModelFile(contents = null) {
@@ -211,14 +224,13 @@ export class EditorComponent implements OnInit, OnDestroy {
         }
 
         let newFile = this.fileService.addFile(newModelNamespace, modelName, code, 'model');
-        this.setCurrentFile(newFile);
         try {
             let error = this.fileService.validateFile(newFile.getId(), newFile.getType());
             if (!error) {
                 this.fileService.updateBusinessNetwork(newFile.getId(), newFile);
             }
         } finally {
-            this.files = this.fileService.getEditorFiles();
+            this.updateFiles(newFile);
             this.noError = this.editorFilesValidate();
         }
     }
@@ -253,14 +265,13 @@ export class EditorComponent implements OnInit, OnDestroy {
         }
 
         let newFile = this.fileService.addFile(scriptName, scriptName, code, 'script');
-        this.setCurrentFile(newFile);
         try {
             let error = this.fileService.validateFile(newFile.getId(), newFile.getType());
             if (!error) {
                 this.fileService.updateBusinessNetwork(newFile.getId(), newFile);
             }
         } finally {
-            this.files = this.fileService.getEditorFiles();
+            this.updateFiles(newFile);
             this.noError = this.editorFilesValidate();
         }
     }
@@ -286,14 +297,13 @@ export class EditorComponent implements OnInit, OnDestroy {
 
     processQueryFileAddition(query) {
         let newFile = this.fileService.addFile(query.getIdentifier(), query.getIdentifier(), query.getDefinitions(), 'query');
-        this.setCurrentFile(newFile);
         try {
             let error = this.fileService.validateFile(newFile.getId(), newFile.getType());
             if (!error) {
                 this.fileService.updateBusinessNetwork(newFile.getId(), newFile);
             }
         } finally {
-            this.files = this.fileService.getEditorFiles();
+            this.updateFiles(newFile);
             this.noError = this.editorFilesValidate();
         }
     }
@@ -306,8 +316,7 @@ export class EditorComponent implements OnInit, OnDestroy {
             confirmModalRef.componentInstance.resource = 'file';
             confirmModalRef.result.then((result) => {
                 this.fileService.setBusinessNetworkReadme(readme);
-                this.files = this.fileService.getEditorFiles();
-                this.setCurrentFile(this.files[0]);
+                this.updateFiles(this.files[0]);
             }, (reason) => {
                 if (reason && reason !== 1) {
                     this.alertService.errorStatus$.next(reason);
@@ -315,8 +324,7 @@ export class EditorComponent implements OnInit, OnDestroy {
             });
         } else {
             this.fileService.setBusinessNetworkReadme(readme);
-            this.files = this.fileService.getEditorFiles();
-            this.setCurrentFile(this.files[0]);
+            this.updateFiles(readme);
         }
     }
 
@@ -342,14 +350,13 @@ export class EditorComponent implements OnInit, OnDestroy {
 
     processRuleFileAddition(rules) {
         let newFile = this.fileService.addFile(rules.getIdentifier(), rules.getIdentifier(), rules.getDefinitions(), 'acl');
-        this.setCurrentFile(newFile);
         try {
             let error = this.fileService.validateFile(newFile.getId(), newFile.getType());
             if (!error) {
                 this.fileService.updateBusinessNetwork(newFile.getId(), newFile);
             }
         } finally {
-            this.files = this.fileService.getEditorFiles();
+            this.updateFiles(newFile);
             this.noError = this.editorFilesValidate();
         }
     }
@@ -438,6 +445,11 @@ export class EditorComponent implements OnInit, OnDestroy {
      */
     setReadmePreview(preview: boolean) {
         this.previewReadme = preview;
+        this.setCurrentFile(this.fileService.getEditorReadMe());
+    }
+
+    editPackageJson() {
+        this.setCurrentFile(this.fileService.getEditorPackageFile());
     }
 
     /*
@@ -445,11 +457,6 @@ export class EditorComponent implements OnInit, OnDestroy {
      */
     toggleEditActive() {
         this.editActive = !this.editActive;
-        if (this.editActive && this.fileType(this.currentFile) === 'Readme') {
-            let mockPackageFile = new EditorFile('package', 'package.json', JSON.stringify(this.fileService.getMetaData().packageJson), 'package');
-            this.setCurrentFile(mockPackageFile);
-            this.hideEdit();
-        }
     }
 
     /*
@@ -492,11 +499,6 @@ export class EditorComponent implements OnInit, OnDestroy {
         }
     }
 
-    hideEdit() {
-        this.editActive = false;
-        this.editingPackage = true;
-    }
-
     /*
      * User selects to delete the current editor file
      */
@@ -532,10 +534,7 @@ export class EditorComponent implements OnInit, OnDestroy {
                     }
 
                     // remove file from list view
-                    this.files = this.fileService.getEditorFiles();
-
-                    // Make sure we set a file to remove the deleted file from the view
-                    this.setInitialFile();
+                    this.updateFiles();
 
                     // validate the remaining (acl/cto files and conditionally enable deploy
                     this.noError = this.editorFilesValidate();
@@ -569,13 +568,15 @@ export class EditorComponent implements OnInit, OnDestroy {
             return 'ACL';
         } else if (resource.isQuery()) {
             return 'Query';
+        } else if (resource.isPackage()) {
+            return 'Package';
         } else {
             return 'Readme';
         }
     }
 
     preventNameEdit(resource: EditorFile): boolean {
-        if (resource.isAcl() || resource.isQuery()) {
+        if (resource.isReadMe() || resource.isPackage() || resource.isAcl() || resource.isQuery()) {
             return true;
         } else {
             return false;
@@ -591,6 +592,7 @@ export class EditorComponent implements OnInit, OnDestroy {
     }
 
     editorFilesValidate(): boolean {
+        this.invalidAboutFileIDs = [];
         let allValid: boolean = true;
         for (let file of this.files) {
             if (file.isModel()) {
@@ -600,7 +602,6 @@ export class EditorComponent implements OnInit, OnDestroy {
                 } else {
                     file.invalid = false;
                 }
-
             } else if (file.isAcl()) {
                 if (this.fileService.validateFile(file.id, 'acl') !== null) {
                     allValid = false;
@@ -622,11 +623,15 @@ export class EditorComponent implements OnInit, OnDestroy {
                 } else {
                     file.invalid = false;
                 }
+            } else if (file.isPackage()) {
+                if (this.fileService.validateFile(file.id, 'package') !== null) {
+                    allValid = false;
+                    file.invalid = true;
+                    this.invalidAboutFileIDs.push(file.id);
+                } else {
+                    file.invalid = false;
+                }
             }
-        }
-
-        if (this.fileService.validateFile('package', 'package') !== null) {
-            allValid = false;
         }
 
         if (allValid) {

--- a/packages/composer-playground/src/app/editor/editor.module.ts
+++ b/packages/composer-playground/src/app/editor/editor.module.ts
@@ -19,6 +19,7 @@ import { CodemirrorModule } from 'ng2-codemirror';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { EditorComponent } from './editor.component';
+import { EditorFilesPipe } from './editor-files.pipe';
 import { EditorFileComponent } from './editor-file/editor-file.component';
 import { EditorService } from './editor.service';
 import { EditorRoutingModule } from './editor-routing.module';
@@ -31,7 +32,7 @@ import { FooterModule } from '../footer/footer.module';
 @NgModule({
     imports: [CommonModule, FormsModule, NgbModule, PerfectScrollbarModule, CodemirrorModule, DirectivesModule, FileImporterModule, DeployModule, EditorRoutingModule, FooterModule],
     entryComponents: [AddFileComponent],
-    declarations: [EditorComponent, EditorFileComponent, AddFileComponent]
+    declarations: [EditorComponent, EditorFilesPipe, EditorFileComponent, AddFileComponent]
 })
 
 export class EditorModule {

--- a/packages/composer-playground/src/app/services/file.service.spec.ts
+++ b/packages/composer-playground/src/app/services/file.service.spec.ts
@@ -410,7 +410,7 @@ describe('FileService', () => {
             testArray[4].getType().should.equal('query');
         })));
 
-        it('should return readme + model + script + acl + query + pacakage files if they are only items stored in the file service', fakeAsync(inject([FileService], (fileService: FileService) => {
+        it('should return readme + pacakage + model + script + acl + query files if they are only items stored in the file service', fakeAsync(inject([FileService], (fileService: FileService) => {
             let file = new EditorFile('1', '1', 'this is the readme', 'readme');
             let file2 = new EditorFile('1', '1', 'this is the model', 'model');
             let file3 = new EditorFile('1', '1', 'this is the script', 'script');
@@ -431,34 +431,31 @@ describe('FileService', () => {
             fileService['queryFile'] = file5;
             fileService['packageJson'] = file6;
 
-            fileService['includePackageJson'] = true;
-            let includePackageJson = true;
-
-            let testArray = fileService.getEditorFiles(includePackageJson);
+            let testArray = fileService.getEditorFiles();
 
             testArray[0].getId().should.equal('1');
             testArray[0].getContent().should.equal('this is the readme');
             testArray[0].getType().should.equal('readme');
 
             testArray[1].getId().should.equal('1');
-            testArray[1].getContent().should.equal('this is the model');
-            testArray[1].getType().should.equal('model');
+            testArray[1].getContent().should.equal('this is the package');
+            testArray[1].getType().should.equal('package');
 
             testArray[2].getId().should.equal('1');
-            testArray[2].getContent().should.equal('this is the script');
-            testArray[2].getType().should.equal('script');
+            testArray[2].getContent().should.equal('this is the model');
+            testArray[2].getType().should.equal('model');
 
             testArray[3].getId().should.equal('1');
-            testArray[3].getContent().should.equal('this is the acl');
-            testArray[3].getType().should.equal('acl');
+            testArray[3].getContent().should.equal('this is the script');
+            testArray[3].getType().should.equal('script');
 
             testArray[4].getId().should.equal('1');
-            testArray[4].getContent().should.equal('this is the query');
-            testArray[4].getType().should.equal('query');
+            testArray[4].getContent().should.equal('this is the acl');
+            testArray[4].getType().should.equal('acl');
 
             testArray[5].getId().should.equal('1');
-            testArray[5].getContent().should.equal('this is the package');
-            testArray[5].getType().should.equal('package');
+            testArray[5].getContent().should.equal('this is the query');
+            testArray[5].getType().should.equal('query');
         })));
     });
 

--- a/packages/composer-playground/src/app/services/file.service.ts
+++ b/packages/composer-playground/src/app/services/file.service.ts
@@ -189,10 +189,14 @@ export class FileService {
         return this.packageJson;
     }
 
-    getEditorFiles(includePackageJson = false): Array<EditorFile> {
+    getEditorFiles(): Array<EditorFile> {
         let files = [];
+
         if (this.getEditorReadMe() !== null) {
             files.push(this.getEditorReadMe());
+        }
+        if (this.getEditorPackageFile() !== null) {
+            files.push(this.getEditorPackageFile());
         }
 
         files = files.concat(this.getEditorModelFiles());
@@ -203,9 +207,7 @@ export class FileService {
         if (this.getEditorQueryFile() !== null) {
             files.push(this.getEditorQueryFile());
         }
-        if (includePackageJson && this.getEditorPackageFile() !== null) {
-            files.push(this.getEditorPackageFile());
-        }
+
         return files;
     }
 
@@ -397,6 +399,11 @@ export class FileService {
             default:
                 throw new Error('Attempted deletion of file unknown type: ' + type);
         }
+
+        if (this.currentFile && this.currentFile.id === id) {
+            this.currentFile = null;
+        }
+
         this.dirty = true;
     }
 

--- a/packages/composer-playground/tslint.json
+++ b/packages/composer-playground/tslint.json
@@ -30,8 +30,7 @@
         "no-output-rename": true,
         "pipe-naming": [
             true,
-            "camelCase",
-            "my"
+            "camelCase"
         ],
         "templates-use-public": false,
         "use-host-property-decorator": true,


### PR DESCRIPTION
Validation errors on the package.json file are now more obvious in
the playground, which is now edited via a 'settings' icon on the
About file

Note: json syntax errors are not currently picked up in the editor
validation so error markers are still not visible in that case

Required for #3241

Signed-off-by: James Taylor <jamest@uk.ibm.com>
