### PR TITLE
Enhance BusNet generator: add acl file, new tests and coverage checking

### DIFF
--- a/packages/generator-hyperledger-composer/generators/businessnetwork/index.js
+++ b/packages/generator-hyperledger-composer/generators/businessnetwork/index.js
@@ -92,6 +92,7 @@ module.exports = yeoman.Base.extend({
         let model = this._generateTemplateModel();
         this.fs.copyTpl(this.templatePath('**!(models|lib|test)*'), this.destinationPath(), model);
         this.fs.copyTpl(this.templatePath('models/namespace.cto'), this.destinationPath('models/'+this.namespace+'.cto'), model);
+        this.fs.copyTpl(this.templatePath('permissions.acl'), this.destinationPath('permissions.acl'), model);
         this.fs.move(this.destinationPath('_dot_eslintrc.yml'), this.destinationPath('.eslintrc.yml'), model);
         /* istanbul ignore else */
         if (!this.ismodel) {

--- a/packages/generator-hyperledger-composer/generators/businessnetwork/templates/models/namespace.cto
+++ b/packages/generator-hyperledger-composer/generators/businessnetwork/templates/models/namespace.cto
@@ -4,13 +4,15 @@
 
 namespace <%= namespace %>
 
-participant User identified by email {
-  o String email
+participant SampleParticipant identified by email {
+   o String email
+   o String name
 }
 
 asset SampleAsset identified by assetId {
   o String assetId
   o String value
+  --> SampleParticipant owner
 }
 
 transaction ChangeAssetValue {

--- a/packages/generator-hyperledger-composer/generators/businessnetwork/templates/package.json
+++ b/packages/generator-hyperledger-composer/generators/businessnetwork/templates/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1",
   "description": "<%= appdescription %>",
   "scripts": {
-    "test": "mocha --recursive"
+    "pretest": "npm run lint",
+    "lint": "eslint .",
+    "test": "nyc mocha -t 0 test/*.js"
   },
   "author": "<%= appauthor %>",
   "email": "<%= appemail %>",
@@ -14,8 +16,9 @@
     "composer-common": "<%= composerversion %>",
     "composer-connector-embedded": "<%= composerversion %>",
     "chai": "latest",
+    "chai-as-promised": "latest",
     "eslint": "latest",
-    "istanbul": "latest",
+    "nyc": "latest",
     "mkdirp": "latest",
     "mocha": "latest"
   }

--- a/packages/generator-hyperledger-composer/generators/businessnetwork/templates/permissions.acl
+++ b/packages/generator-hyperledger-composer/generators/businessnetwork/templates/permissions.acl
@@ -1,0 +1,51 @@
+/**
+ * Sample access control list.
+ */
+rule EverybodyCanReadEverything {
+    description: "Allow all participants read access to all resources"
+    participant: "<%= namespace %>.SampleParticipant"
+    operation: READ
+    resource: "<%= namespace %>.*"
+    action: ALLOW
+}
+
+rule EverybodyCanSubmitTransactions {
+    description: "Allow all participants to submit transactions"
+    participant: "<%= namespace %>.SampleParticipant"
+    operation: CREATE
+    resource: "<%= namespace %>.ChangeAssetValue"
+    action: ALLOW
+}
+
+rule OwnerHasFullAccessToTheirAssets {
+    description: "Allow all participants full access to their assets"
+    participant(p): "<%= namespace %>.SampleParticipant"
+    operation: ALL
+    resource(r): "<%= namespace %>.SampleAsset"
+    condition: (r.owner.getIdentifier() === p.getIdentifier())
+    action: ALLOW
+}
+
+rule SystemACL {
+  description:  "System ACL to permit all access"
+  participant: "org.hyperledger.composer.system.Participant"
+  operation: ALL
+  resource: "org.hyperledger.composer.system.**"
+  action: ALLOW
+}
+
+rule NetworkAdminUser {
+    description: "Grant business network administrators full access to user resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "**"
+    action: ALLOW
+}
+
+rule NetworkAdminSystem {
+    description: "Grant business network administrators full access to system resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "org.hyperledger.composer.system.**"
+    action: ALLOW
+}

--- a/packages/generator-hyperledger-composer/generators/businessnetwork/templates/test/logic.js
+++ b/packages/generator-hyperledger-composer/generators/businessnetwork/templates/test/logic.js
@@ -22,27 +22,52 @@ const BusinessNetworkConnection = require('composer-client').BusinessNetworkConn
 const { BusinessNetworkDefinition, CertificateUtil, IdCard } = require('composer-common');
 const path = require('path');
 
-require('chai').should();
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-as-promised'));
 
 const namespace = '<%= namespace%>';
 const assetType = 'SampleAsset';
+const assetNS = namespace + '.' + assetType;
+const participantType = 'SampleParticipant';
+const participantNS = namespace + '.' + participantType;
 
 describe('#' + namespace, () => {
     // In-memory card store for testing so cards are not persisted to the file system
     const cardStore = require('composer-common').NetworkCardStoreManager.getCardStore( { type: 'composer-wallet-inmemory' } );
+
+    // Embedded connection used for local testing
+    const connectionProfile = {
+        name: 'embedded',
+        'x-type': 'embedded'
+    };
+
+    // Name of the business network card containing the administrative identity for the business network
+    const adminCardName = 'admin';
+
+    // Admin connection to the blockchain, used to deploy the business network
     let adminConnection;
+
+    // This is the business network connection the tests will use.
     let businessNetworkConnection;
 
+    // This is the factory for creating instances of types.
+    let factory;
+
+    // Events emitted
+    let events;
+
+    // These are the identities for Alice and Bob.
+    const aliceCardName = 'alice';
+    const bobCardName = 'bob';
+
+    let businessNetworkName;
+
     before(async () => {
-        // Embedded connection used for local testing
-        const connectionProfile = {
-            name: 'embedded',
-            'x-type': 'embedded'
-        };
-        // Embedded connection does not need real credentials
+        // Generate certificates for use with the embedded connection
         const credentials = CertificateUtil.generate({ commonName: 'admin' });
 
-        // PeerAdmin identity used with the admin connection to deploy business networks
+        // Identity used with the admin connection to deploy business networks
         const deployerMetadata = {
             version: 1,
             userName: 'PeerAdmin',
@@ -50,77 +75,199 @@ describe('#' + namespace, () => {
         };
         const deployerCard = new IdCard(deployerMetadata, connectionProfile);
         deployerCard.setCredentials(credentials);
-
         const deployerCardName = 'PeerAdmin';
+
         adminConnection = new AdminConnection({ cardStore: cardStore });
 
         await adminConnection.importCard(deployerCardName, deployerCard);
         await adminConnection.connect(deployerCardName);
     });
 
+    /**
+     *
+     * @param {String} cardName The card name to use for this identity
+     * @param {Object} identity The identity details
+     */
+    async function importCardForIdentity(cardName, identity) {
+        const metadata = {
+            userName: identity.userID,
+            version: 1,
+            enrollmentSecret: identity.userSecret,
+            businessNetwork: businessNetworkName
+        };
+        const card = new IdCard(metadata, connectionProfile);
+        await adminConnection.importCard(cardName, card);
+    }
+
+    // This is called before each test is executed.
     beforeEach(async () => {
-        businessNetworkConnection = new BusinessNetworkConnection({ cardStore: cardStore });
-
-        const adminUserName = 'admin';
-        let adminCardName;
-
+        // Generate a business network definition from the project directory.
         let businessNetworkDefinition = await BusinessNetworkDefinition.fromDirectory(path.resolve(__dirname, '..'));
-
-        // Install the Composer runtime for the new business network
-        await adminConnection.install(businessNetworkDefinition.getName());
-
-        // Start the business network and configure an network admin identity
+        businessNetworkName = businessNetworkDefinition.getName();
+        await adminConnection.install(businessNetworkName);
         const startOptions = {
             networkAdmins: [
                 {
-                    userName: adminUserName,
+                    userName: 'admin',
                     enrollmentSecret: 'adminpw'
                 }
             ]
         };
+        const adminCards = await adminConnection.start(businessNetworkDefinition, startOptions);
+        await adminConnection.importCard(adminCardName, adminCards.get('admin'));
 
-        let adminCards = await adminConnection.start(businessNetworkDefinition, startOptions);
-        // Import the network admin identity for us to use
-        adminCardName = `${adminUserName}@${businessNetworkDefinition.getName()}`;
-        await adminConnection.importCard(adminCardName, adminCards.get(adminUserName));
-        // Connect to the business network using the network admin identity
+        // Create and establish a business network connection
+        businessNetworkConnection = new BusinessNetworkConnection({ cardStore: cardStore });
+        events = [];
+        businessNetworkConnection.on('event', event => {
+            events.push(event);
+        });
         await businessNetworkConnection.connect(adminCardName);
+
+        // Get the factory for the business network.
+        factory = businessNetworkConnection.getBusinessNetwork().getFactory();
+
+        const participantRegistry = await businessNetworkConnection.getParticipantRegistry(namespace + '.' + participantType);
+        // Create the participants.
+        const alice = factory.newResource(namespace, participantType, 'alice@email.com');
+        alice.name = 'Alice';
+
+        const bob = factory.newResource(namespace, participantType, 'bob@email.com');
+        bob.name = 'Bob';
+
+        participantRegistry.addAll([alice, bob]);
+
+        const assetRegistry = await businessNetworkConnection.getAssetRegistry(assetNS);
+        // Create the assets.
+        const asset1 = factory.newResource(namespace, assetType, '1');
+        asset1.owner = factory.newRelationship(namespace, participantType, 'alice@email.com');
+        asset1.value = '10';
+
+        const asset2 = factory.newResource(namespace, assetType, '2');
+        asset2.owner = factory.newRelationship(namespace, participantType, 'bob@email.com');
+        asset2.value = '20';
+
+        assetRegistry.addAll([asset1, asset2]);
+
+        // Issue the identities.
+        let identity = await businessNetworkConnection.issueIdentity(participantNS + '#alice@email.com', 'alice1');
+        await importCardForIdentity(aliceCardName, identity);
+        identity = await businessNetworkConnection.issueIdentity(participantNS + '#bob@email.com', 'bob1');
+        await importCardForIdentity(bobCardName, identity);
     });
 
-    describe('ChangeAssetValue()', () => {
-        it('should change the value property of ' + assetType + ' to newValue', async () => {
-            const factory = businessNetworkConnection.getBusinessNetwork().getFactory();
 
-            // Create a user participant
-            const user = factory.newResource(namespace, 'User', '<%= appauthor%>');
-
-            // Create the asset
-            const asset = factory.newResource(namespace, assetType, 'ASSET_001');
-            asset.value = 'old-value';
-
-            // Create a transaction to change the asset's value property
-            const changeAssetValue = factory.newTransaction(namespace, 'ChangeAssetValue');
-            changeAssetValue.relatedAsset = factory.newRelationship(namespace, assetType, asset.$identifier);
-            changeAssetValue.newValue = 'new-value';
-
-            let assetRegistry = await businessNetworkConnection.getAssetRegistry(namespace + '.' + assetType);
-
-            // Add the asset to the appropriate asset registry
-            await assetRegistry.add(asset);
-            let userRegistry = await businessNetworkConnection.getParticipantRegistry(namespace + '.User');
-
-            // Add the user to the appropriate participant registry
-            await userRegistry.add(user);
-
-            // Submit the transaction
-            await businessNetworkConnection.submitTransaction(changeAssetValue);
-
-            // Get the asset
-            let newAsset = await assetRegistry.get(asset.$identifier);
-
-            // Assert that the asset has the new value property
-            newAsset.value.should.equal(changeAssetValue.newValue);
+    /**
+     * Reconnect using a different identity.
+     * @param {String} cardName The name of the card for the identity to use
+     */
+    async function useIdentity(cardName) {
+        await businessNetworkConnection.disconnect();
+        businessNetworkConnection = new BusinessNetworkConnection({ cardStore: cardStore });
+        events = [];
+        businessNetworkConnection.on('event', (event) => {
+            events.push(event);
         });
+        await businessNetworkConnection.connect(cardName);
+        factory = businessNetworkConnection.getBusinessNetwork().getFactory();
+    }
+
+    it('Alice can read all of the assets', async () => {
+        // Use the identity for Alice.
+        await useIdentity(aliceCardName);
+        const assetRegistry = await businessNetworkConnection.getAssetRegistry(assetNS);
+        const assets = await assetRegistry.getAll();
+
+        // Validate the assets.
+        assets.should.have.lengthOf(2);
+        const asset1 = assets[0];
+        asset1.owner.getFullyQualifiedIdentifier().should.equal(participantNS + '#alice@email.com');
+        asset1.value.should.equal('10');
+        const asset2 = assets[1];
+        asset2.owner.getFullyQualifiedIdentifier().should.equal(participantNS + '#bob@email.com');
+        asset2.value.should.equal('20');
+    });
+
+    it('Bob can read all of the assets', async () => {
+        // Use the identity for Bob.
+        await useIdentity(bobCardName);
+        const assetRegistry = await businessNetworkConnection.getAssetRegistry(assetNS);
+        const assets = await assetRegistry.getAll();
+
+        // Validate the assets.
+        assets.should.have.lengthOf(2);
+        const asset1 = assets[0];
+        asset1.owner.getFullyQualifiedIdentifier().should.equal(participantNS + '#alice@email.com');
+        asset1.value.should.equal('10');
+        const asset2 = assets[1];
+        asset2.owner.getFullyQualifiedIdentifier().should.equal(participantNS + '#bob@email.com');
+        asset2.value.should.equal('20');
+    });
+
+    it('Alice can update owned assets via API', async () => {
+        // Use the identity for Alice.
+        await useIdentity(aliceCardName);
+
+        // Replicate the asset.
+        let asset1 = factory.newResource(namespace, assetType, '1');
+        asset1.owner = factory.newRelationship(namespace, participantType, 'alice@email.com');
+        asset1.value = '50';
+
+        // Update the asset, then get the asset.
+        const assetRegistry = await businessNetworkConnection.getAssetRegistry(assetNS);
+        await assetRegistry.update(asset1);
+
+        // Validate the asset.
+        asset1 = await assetRegistry.get('1');
+        asset1.owner.getFullyQualifiedIdentifier().should.equal(participantNS + '#alice@email.com');
+        asset1.value.should.equal('50');
+    });
+
+    it('Alice can update owned assets via transaction', async () => {
+        // Use the identity for Alice.
+        await useIdentity(aliceCardName);
+
+        // Create a transaction to change the asset's value property
+        const changeAssetValue = factory.newTransaction(namespace, 'ChangeAssetValue');
+        changeAssetValue.relatedAsset = factory.newRelationship(namespace, assetType, '1');
+        changeAssetValue.newValue = 'new-value';
+
+        // Submit the transaction
+        await businessNetworkConnection.submitTransaction(changeAssetValue);
+
+        // Get the asset
+        let assetRegistry = await businessNetworkConnection.getAssetRegistry(assetNS);
+        let newAsset = await assetRegistry.get('1');
+
+        // Assert that the asset has the new value property
+        newAsset.value.should.equal(changeAssetValue.newValue);
+    });
+
+    it('Alice cannot update Bob\'s assets via API', async () => {
+        // Use the identity for Alice.
+        await useIdentity(aliceCardName);
+
+        // Create the asset.
+        const asset2 = factory.newResource(namespace, assetType, '2');
+        asset2.owner = factory.newRelationship(namespace, participantType, 'bob@email.com');
+        asset2.value = '50';
+
+        // Try to update the asset, should fail.
+        const assetRegistry = await businessNetworkConnection.getAssetRegistry(assetNS);
+        assetRegistry.update(asset2).should.be.rejectedWith(/does not have .* access to resource/);
+    });
+
+    it('Alice cannot update Bob\'s assets via transaction', async () => {
+        // Use the identity for Alice.
+        await useIdentity(aliceCardName);
+
+        // Create a transaction to change the asset's value property
+        const changeAssetValue = factory.newTransaction(namespace, 'ChangeAssetValue');
+        changeAssetValue.relatedAsset = factory.newRelationship(namespace, assetType, '2');
+        changeAssetValue.newValue = 'new-value';
+
+        // Submit the transaction
+        await businessNetworkConnection.submitTransaction(changeAssetValue).should.be.rejectedWith(/does not have .* access to resource/);
     });
 
 });

--- a/packages/generator-hyperledger-composer/test/business-network.js
+++ b/packages/generator-hyperledger-composer/test/business-network.js
@@ -78,6 +78,7 @@ describe('hyperledger-composer:businessnetwork for generating a template busines
             busNetDir + '/.eslintrc.yml',
             busNetDir + '/README.md',
             busNetDir + '/package.json',
+            busNetDir + '/permissions.acl',
             busNetDir + '/models/' + passedNS +'.cto',
             busNetDir + '/lib/logic.js',
             busNetDir + '/test/logic.js'
@@ -93,6 +94,7 @@ describe('hyperledger-composer:businessnetwork for generating a template busines
             busNetDir + '/.eslintrc.yml',
             busNetDir + '/README.md',
             busNetDir + '/package.json',
+            busNetDir + '/permissions.acl',
             busNetDir + '/models/' + passedNS +'.cto',
             busNetDir + '/lib/logic.js',
             busNetDir + '/test/logic.js'


### PR DESCRIPTION
Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>

Contributes to #3385 by:
 - adding an ACL file to the business network generator
 - replacing tests that check ACL access rules are enforced
 - adding code coverage in npm test for generated busnet via nyc