### PR TITLE
query to not be tied to first peer in list

### DIFF
--- a/packages/composer-connector-hlfv1/lib/hlfqueryhandler.js
+++ b/packages/composer-connector-hlfv1/lib/hlfqueryhandler.js
@@ -1,0 +1,188 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+const Logger = require('composer-common').Logger;
+const FABRIC_CONSTANTS = require('fabric-client/lib/Constants');
+
+const LOG = Logger.getLog('HLFQueryHandler');
+
+/**
+ * Class to provide intelligence on how to query peers when peers are not available.
+ * This is an initial implementation which could iterate and perhaps be pushed back
+ * into the fabric node-sdk in future
+ *
+ * The current implementation creates a list of query peers. The top of the list
+ * contains peers for the callers org, followed by peers in all other orgs.
+ * It will search through the list looking for a peer to respond successfully to
+ * a query then remember that peer, until it fails, then it will start looking
+ * for a new peer from the top of the list, ignoring the one that just failed.
+ * @private
+ */
+class HLFQueryHandler {
+
+    /**
+     * See if a peer is already in the list of peers provided. It uses the name of
+     * the peer as the node-sdk uses this as a unique identity.
+     * @param {Peer} peer the peer to check
+     * @param {Peer[]} listOfPeers the list of peers to check against
+     * @returns {boolean} true if peer is in the list, false otherwise
+     */
+    static isPeerInList(peer, listOfPeers) {
+        return listOfPeers.some((peerInList) => {
+            return peer.getName() === peerInList.getName();
+        });
+    }
+
+    /**
+     * Get a list of all query peers that are not in the other list of peers
+     * @param {Peer[]} allPeers a list of all the peers
+     * @param {Peer[]} peersAlreadyKnown a list of peers already known
+     * @return {Peer[]} list of other query peers or an empty array if none found
+     *
+     */
+    static getResidualQueryPeers(allPeers, peersAlreadyKnown) {
+        return allPeers.filter((peer) => {
+            return peer.isInRole(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE) && !HLFQueryHandler.isPeerInList(peer, peersAlreadyKnown);
+        });
+    }
+
+
+    /**
+     * constructor
+     * @param {HLFConnection} connection the connection to the hlfv1 fabric
+     */
+    constructor(connection) {
+        const method = 'constructor';
+        LOG.entry(method);
+        this.orgQueryPeers = connection.getChannelPeersInOrg([FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE]);
+        this.otherOrgQueryPeers = HLFQueryHandler.getResidualQueryPeers(connection.channel.getPeers(), this.orgQueryPeers);
+
+        // all query peers in org first followed by non org order
+        this.allQueryPeers = this.orgQueryPeers.concat(this.otherOrgQueryPeers);
+        this.queryPeerIndex = -1;
+
+        this.connection = connection;
+        LOG.exit(method);
+    }
+
+    /**
+     * Query Chaincode using the following rules
+     * 1. try the last successful peer
+     * 2. If that fails or this is the first time try all the peers in order
+     * starting with peers from the org and moving onto other org peers.
+     * @param {TransactionID} txId the transaction id to use
+     * @param {string} functionName the function name to invoke
+     * @param {string[]} args the arguments
+     * @returns {object} asynchronous response or async error.
+     */
+    async queryChaincode(txId, functionName, args) {
+        const method = 'queryChaincode';
+        LOG.entry(method, txId, functionName, args);
+        let success = false;
+        let payload;
+        let allErrors = [];
+
+        if (this.allQueryPeers.length === 0) {
+            const newError = new Error('No peers have been provided that can be queried');
+            LOG.error(method, newError);
+            throw newError;
+        }
+
+        // try the last successful peer
+        if (this.queryPeerIndex !== -1) {
+            let peer = this.allQueryPeers[this.queryPeerIndex];
+            try {
+                payload = await this.querySinglePeer(peer, txId, functionName, args);
+                success = true;
+            } catch (error) {
+                allErrors.push(error);
+                LOG.warn(method, `Peer ${peer} failed to respond. ${error}`);
+            }
+        }
+
+        if (!success) {
+
+            // last successful peer failed or this is the first attempt at any query, so try to find a
+            // peer to query.
+            let failedPeer = this.queryPeerIndex;  // could be -1 if first attempt
+            this.queryPeerIndex = -1;
+            //for (let i in this.allQueryPeers) {  // i is a string
+            for (let i = 0; i < this.allQueryPeers.length && !success; i++) {
+                if (i === failedPeer) {
+                    continue;
+                }
+                let peer = this.allQueryPeers[i];
+                try {
+                    payload = await this.querySinglePeer(peer, txId, functionName, args);
+                    this.queryPeerIndex = i;
+                    success = true;
+                    break;
+                } catch (error) {
+                    allErrors.push(error);
+                    LOG.warn(method, `Peer ${peer.getName()} failed to respond. ${error}`);
+                }
+            }
+        }
+
+        if (!success) {
+            const newError = new Error(`No peers available to query. last error was ${allErrors[allErrors.length-1]}`);
+            LOG.error(method, newError);
+            throw newError;
+        }
+
+        LOG.exit(method, payload);
+        return payload;
+
+    }
+
+    /**
+     * Send a query
+     * @param {Peer} peer The peer to query
+     * @param {TransactionID} txId the transaction id to use
+     * @param {string} functionName the function name of the query
+     * @param {array} args the arguments to ass
+     * @returns {Buffer} asynchronous response to query
+     */
+    async querySinglePeer(peer, txId, functionName, args) {
+        const method = 'querySinglePeer';
+        LOG.entry(method, peer, txId, functionName, args);
+        const request = {
+            targets: [peer],
+            chaincodeId: this.connection.businessNetworkIdentifier,
+            txId: txId,
+            fcn: functionName,
+            args: args
+        };
+
+        let payloads = await this.connection.channel.queryByChaincode(request);
+        LOG.debug(method, `Received ${payloads.length} payloads(s) from querying the composer runtime chaincode`, payloads);
+        if (!payloads.length) {
+            LOG.error(method, 'No payloads were returned from the query request:' + functionName);
+            throw new Error('No payloads were returned from the query request:' + functionName);
+        }
+        const payload = payloads[0];
+
+        if (payload instanceof Error) {
+            LOG.error(method, 'query payload returned an error: ' + payload);
+            throw payload;
+        }
+        LOG.exit(method, payload);
+        return payload;
+
+    }
+}
+
+module.exports = HLFQueryHandler;
+

--- a/packages/composer-connector-hlfv1/test/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/test/hlfconnection.js
@@ -31,7 +31,7 @@ const FabricCAClientImpl = require('fabric-ca-client');
 const HLFConnection = require('../lib/hlfconnection');
 const HLFConnectionManager = require('../lib/hlfconnectionmanager');
 const HLFSecurityContext = require('../lib/hlfsecuritycontext');
-//const HLFTxEventHandler = require('../lib/hlftxeventhandler');
+const HLFQueryHandler = require('../lib/hlfqueryhandler');
 
 const path = require('path');
 const semver = require('semver');
@@ -51,7 +51,7 @@ describe('HLFConnection', () => {
 
     let sandbox;
     let mockConnectionManager, mockChannel, mockClient, mockCAClient, mockUser, mockSecurityContext, mockBusinessNetwork;
-    let mockPeer1, mockPeer2, mockPeer3, mockEventHub1, mockEventHub2, mockEventHub3;
+    let mockPeer1, mockPeer2, mockPeer3, mockEventHub1, mockEventHub2, mockEventHub3, mockQueryHandler;
     let connectOptions;
     let connection;
     let mockTransactionID, logWarnSpy;
@@ -91,7 +91,8 @@ describe('HLFConnection', () => {
         mockPeer3.getName.returns('Peer3');
         mockEventHub3 = sinon.createStubInstance(ChannelEventHub);
         mockEventHub3.getPeerAddr.returns('EventHub3');
-
+        mockQueryHandler = sinon.createStubInstance(HLFQueryHandler);
+        sandbox.stub(HLFConnection, 'createQueryHandler').returns(mockQueryHandler);
         connection = new HLFConnection(mockConnectionManager, 'hlfabric1', 'org-acme-biznet', {}, mockClient, mockChannel, mockCAClient);
     });
 
@@ -108,6 +109,23 @@ describe('HLFConnection', () => {
         });
 
     });
+
+    describe('#createQueryHandler', () => {
+
+        it('should create a new query handler', () => {
+            // restore the createQueryHandler implementation as by default it is mocked out.
+            sandbox.restore();
+            sandbox = sinon.sandbox.create();
+            let mockConnection = sinon.createStubInstance(HLFConnection);
+            mockConnection.getChannelPeersInOrg.returns([]);
+            mockConnection.channel = mockChannel;
+            mockChannel.getPeers.returns([]);
+            let queryHandler = HLFConnection.createQueryHandler(mockConnection);
+            queryHandler.should.be.an.instanceOf(HLFQueryHandler);
+        });
+
+    });
+
 
     describe('#_getLoggedInUser', () => {
 
@@ -2467,99 +2485,22 @@ describe('HLFConnection', () => {
                 .should.be.rejectedWith(/invalid arg specified: 3.142/);
         });
 
-        it('should choose a valid peer from the same org', async () => {
-            sandbox.stub(connection, 'getChannelPeersInOrg').withArgs(['chaincodeQuery']).returns([mockPeer2, mockPeer3]);
-
+        it('should query chaincode and handle a good response', async () => {
             const response = Buffer.from('hello world');
-            mockChannel.queryByChaincode.resolves([response]);
+            mockQueryHandler.queryChaincode.withArgs(mockTransactionID, 'myfunc', ['arg1', 'arg2']).resolves(response);
+
             let result = await connection.queryChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2']);
-            sinon.assert.calledOnce(mockChannel.queryByChaincode);
-            sinon.assert.calledWith(mockChannel.queryByChaincode, {
-                chaincodeId: 'org-acme-biznet',
-                chaincodeVersion: connectorPackageJSON.version,
-                txId: mockTransactionID,
-                fcn: 'myfunc',
-                args: ['arg1', 'arg2'],
-                targets: [mockPeer2]
-            });
+            sinon.assert.calledOnce(mockQueryHandler.queryChaincode);
             result.equals(response).should.be.true;
         });
 
-        it('should cache a valid peer', async () => {
-            sandbox.stub(connection, 'getChannelPeersInOrg').withArgs(['chaincodeQuery']).returns([mockPeer2, mockPeer3]);
-
-            const response = Buffer.from('hello world');
-            mockChannel.queryByChaincode.resolves([response]);
-            await connection.queryChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2']);
-            connection.queryPeer.should.equal(mockPeer2);
-            await connection.queryChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2']);
-            connection.queryPeer.should.equal(mockPeer2);
-            sinon.assert.calledTwice(mockChannel.queryByChaincode);
-            sinon.assert.alwaysCalledWith(mockChannel.queryByChaincode, {
-                chaincodeId: 'org-acme-biznet',
-                chaincodeVersion: connectorPackageJSON.version,
-                txId: mockTransactionID,
-                fcn: 'myfunc',
-                args: ['arg1', 'arg2'],
-                targets: [mockPeer2]
-            });
-            sinon.assert.calledOnce(connection.getChannelPeersInOrg);
-        });
-
-
-        it('should choose a valid peer from all peers if no suitable one in same org', async () => {
-            mockPeer1.isInRole.withArgs('chaincodeQuery').returns(false);
-            mockPeer2.isInRole.withArgs('chaincodeQuery').returns(false);
-            mockPeer3.isInRole.withArgs('chaincodeQuery').returns(true);
-            sandbox.stub(connection, 'getChannelPeersInOrg').withArgs(['chaincodeQuery']).returns([]);
-            mockChannel.getPeers.returns([mockPeer1, mockPeer2, mockPeer3]);
-
-            const response = Buffer.from('hello world');
-            mockChannel.queryByChaincode.resolves([response]);
-            let result = await connection.queryChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2']);
-            sinon.assert.calledOnce(mockChannel.queryByChaincode);
-            sinon.assert.calledWith(mockChannel.queryByChaincode, {
-                chaincodeId: 'org-acme-biznet',
-                chaincodeVersion: connectorPackageJSON.version,
-                txId: mockTransactionID,
-                fcn: 'myfunc',
-                args: ['arg1', 'arg2'],
-                targets: [mockPeer3]
-            });
-            result.equals(response).should.be.true;
-        });
-
-        it('should throw if no suitable peers to query', () => {
-            mockPeer1.isInRole.withArgs('chaincodeQuery').returns(false);
-            mockPeer2.isInRole.withArgs('chaincodeQuery').returns(false);
-            mockPeer3.isInRole.withArgs('chaincodeQuery').returns(false);
-            sandbox.stub(connection, 'getChannelPeersInOrg').withArgs(['chaincodeQuery']).returns([]);
-            mockChannel.getPeers.returns([mockPeer1, mockPeer2, mockPeer3]);
-
-            mockChannel.queryByChaincode.resolves([]);
-            return connection.queryChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2'])
-                .should.be.rejectedWith(/Unable to determine/);
-        });
-
-
-        it('should throw if no responses are returned', () => {
-            sandbox.stub(connection, 'getChannelPeersInOrg').withArgs(['chaincodeQuery']).returns([mockPeer2, mockPeer3]);
-
-            mockChannel.queryByChaincode.resolves([]);
-            return connection.queryChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2'])
-                .should.be.rejectedWith(/No payloads were returned from the query request/);
-        });
-
-        it('should throw any responses that are errors', () => {
-            sandbox.stub(connection, 'getChannelPeersInOrg').withArgs(['chaincodeQuery']).returns([mockPeer2, mockPeer3]);
-
-            const response = [ new Error('such error') ];
-            mockChannel.queryByChaincode.resolves(response);
+        it('should query chaincode and handle an error response', () => {
+            const response = new Error('such error');
+            mockQueryHandler.queryChaincode.withArgs(mockTransactionID, 'myfunc', ['arg1', 'arg2']).rejects(response);
             return connection.queryChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2'])
                 .should.be.rejectedWith(/such error/);
 
         });
-
     });
 
     describe('#invokeChainCode', () => {

--- a/packages/composer-connector-hlfv1/test/hlfconnectionmanager.js
+++ b/packages/composer-connector-hlfv1/test/hlfconnectionmanager.js
@@ -651,6 +651,7 @@ describe('HLFConnectionManager', () => {
         it('should create a new HLFConnection', () => {
             let mockChannel = sinon.createStubInstance(Channel);
             let mockCAClient = sinon.createStubInstance(FabricCAClientImpl);
+            sandbox.stub(HLFConnection, 'createQueryHandler').returns('');
             let connection = HLFConnectionManager.createHLFConnection(connectionManager, 'profile', 'bn', {}, mockClient, mockChannel, mockCAClient);
             connection.should.be.an.instanceOf(HLFConnection);
         });

--- a/packages/composer-connector-hlfv1/test/hlfqueryhandler.js
+++ b/packages/composer-connector-hlfv1/test/hlfqueryhandler.js
@@ -1,0 +1,286 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const HLFQueryHandler = require('../lib/hlfqueryhandler');
+const HLFConnection = require('../lib/hlfconnection');
+const Peer = require('fabric-client/lib/Peer');
+const TransactionID = require('fabric-client/lib/TransactionID');
+const Channel = require('fabric-client/lib/Channel');
+const FABRIC_CONSTANTS = require('fabric-client/lib/Constants');
+
+const sinon = require('sinon');
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-as-promised'));
+
+describe('HLFQueryHandler', () => {
+
+    let sandbox;
+    let mockPeer1, mockPeer2, mockPeer3;
+    let mockConnection, mockTransactionID, mockChannel;
+    let queryHandler;
+
+    beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+        mockPeer1 = sinon.createStubInstance(Peer);
+        mockPeer1.getName.returns('Peer1');
+        mockPeer1.index = 1;
+        mockPeer2 = sinon.createStubInstance(Peer);
+        mockPeer2.getName.returns('Peer2');
+        mockPeer2.index = 2;
+        mockPeer3 = sinon.createStubInstance(Peer);
+        mockPeer3.getName.returns('Peer3');
+        mockPeer3.index = 3;
+        mockConnection = sinon.createStubInstance(HLFConnection);
+        mockTransactionID = sinon.createStubInstance(TransactionID);
+        mockChannel = sinon.createStubInstance(Channel);
+        mockConnection.channel = mockChannel;
+        mockConnection.getChannelPeersInOrg.withArgs([FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE]).returns([mockPeer2]);
+        mockChannel.getPeers.returns([mockPeer1, mockPeer2, mockPeer3]);
+        queryHandler = new HLFQueryHandler(mockConnection);
+
+    });
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('#isPeerInList', () => {
+        it('should find a peer in the list', () => {
+            let result = HLFQueryHandler.isPeerInList(mockPeer1, [mockPeer1, mockPeer3]);
+            result.should.be.true;
+            result = HLFQueryHandler.isPeerInList(mockPeer2, [mockPeer1, mockPeer2, mockPeer3]);
+            result.should.be.true;
+            result = HLFQueryHandler.isPeerInList(mockPeer1, [mockPeer3, mockPeer1]);
+            result.should.be.true;
+        });
+
+        it('should not find a peer in the list', () => {
+            let result = HLFQueryHandler.isPeerInList(mockPeer1, [mockPeer2, mockPeer3]);
+            result.should.be.false;
+        });
+
+    });
+
+    describe('#getResidualQueryPeers', () => {
+        it('should find a query peer in another org #1', () => {
+            let allPeers = [mockPeer1, mockPeer2, mockPeer3];
+            let orgQueryPeers = [mockPeer2];
+            mockPeer1.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(true);
+            mockPeer2.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(true);
+            mockPeer3.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(true);
+
+            let result = HLFQueryHandler.getResidualQueryPeers(allPeers, orgQueryPeers);
+            result.length.should.equal(2);
+            result.should.deep.equal([mockPeer1, mockPeer3]);
+
+        });
+
+        it('should find a query peer in another org #2', () => {
+            let allPeers = [mockPeer1, mockPeer2, mockPeer3];
+            let orgQueryPeers = [mockPeer2];
+            mockPeer1.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(true);
+            mockPeer2.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(true);
+            mockPeer3.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(false);
+
+            let result = HLFQueryHandler.getResidualQueryPeers(allPeers, orgQueryPeers);
+            result.length.should.equal(1);
+            result.should.deep.equal([mockPeer1]);
+
+        });
+
+        it('should find a query peer in another org #3', () => {
+            let allPeers = [mockPeer1, mockPeer2, mockPeer3];
+            let orgQueryPeers = [];
+            mockPeer1.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(true);
+            mockPeer2.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(true);
+            mockPeer3.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(false);
+
+            let result = HLFQueryHandler.getResidualQueryPeers(allPeers, orgQueryPeers);
+            result.length.should.equal(2);
+            result.should.deep.equal([mockPeer1, mockPeer2]);
+        });
+
+        it('should find no query peer in another org ', () => {
+            let allPeers = [mockPeer1, mockPeer2, mockPeer3];
+            let orgQueryPeers = [mockPeer2];
+            mockPeer1.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(false);
+            mockPeer2.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(true);
+            mockPeer3.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(false);
+
+            let result = HLFQueryHandler.getResidualQueryPeers(allPeers, orgQueryPeers);
+            result.length.should.equal(0);
+        });
+
+
+
+    });
+
+    describe('#constructor', () => {
+        it('should create a list of all queryable peers', () => {
+            sandbox.stub(HLFQueryHandler, 'getResidualQueryPeers').withArgs([mockPeer1, mockPeer2, mockPeer3], [mockPeer2]).returns([mockPeer3]);
+            let queryHandler = new HLFQueryHandler(mockConnection);
+            queryHandler.allQueryPeers.length.should.equal(2);
+            queryHandler.allQueryPeers.should.deep.equal([mockPeer2, mockPeer3]);
+        });
+    });
+
+    describe('#queryChaincode', () => {
+        beforeEach(() => {
+            mockPeer1.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(true);
+            mockPeer2.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(true);
+            mockPeer3.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(true);
+            queryHandler = new HLFQueryHandler(mockConnection);
+        });
+
+
+        it('should choose a valid peer from the same org', async () => {
+            const response = Buffer.from('hello world');
+            sandbox.stub(queryHandler, 'querySinglePeer').resolves(response);
+
+            let result = await queryHandler.queryChaincode(mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            sinon.assert.calledOnce(queryHandler.querySinglePeer);
+            sinon.assert.calledWith(queryHandler.querySinglePeer, mockPeer2, mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            queryHandler.queryPeerIndex.should.equal(0);
+            result.equals(response).should.be.true;
+        });
+
+        it('should cache a valid peer and reuse', async () => {
+            const response = Buffer.from('hello world');
+            sandbox.stub(queryHandler, 'querySinglePeer').resolves(response);
+
+            await queryHandler.queryChaincode(mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            let result = await queryHandler.queryChaincode(mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            sinon.assert.calledTwice(queryHandler.querySinglePeer);
+            sinon.assert.alwaysCalledWith(queryHandler.querySinglePeer, mockPeer2, mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            queryHandler.queryPeerIndex.should.equal(0);
+            result.equals(response).should.be.true;
+        });
+
+        it('should choose a valid peer from another org if no suitable in current org was provided', async () => {
+            const response = Buffer.from('hello world');
+            mockPeer1.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(false);
+            mockPeer2.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(false);
+            mockPeer3.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(true);
+            mockConnection.getChannelPeersInOrg.withArgs([FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE]).returns([]);
+            queryHandler = new HLFQueryHandler(mockConnection);
+            sandbox.stub(queryHandler, 'querySinglePeer').resolves(response);
+
+            let result = await queryHandler.queryChaincode(mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            sinon.assert.calledOnce(queryHandler.querySinglePeer);
+            sinon.assert.calledWith(queryHandler.querySinglePeer, mockPeer3, mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            queryHandler.queryPeerIndex.should.equal(0);  // index 0, is the first in the list of other org peers
+            result.equals(response).should.be.true;
+        });
+
+        it('should choose a valid peer from another org if current org one responds with error', async () => {
+            const response = Buffer.from('hello world');
+            const qsp = sandbox.stub(queryHandler, 'querySinglePeer');
+
+            /* this didn't work as the mockPeers look the same
+            qsp.withArgs(mockPeer2, 'aTxID', 'myfunc', ['arg1', 'arg2']).rejects(new Error('I failed'));
+            qsp.withArgs(mockPeer1, 'aTxID', 'myfunc', ['arg1', 'arg2']).rejects(new Error('I failed'));
+            qsp.withArgs(mockPeer3, 'aTxID', 'myfunc', ['arg1', 'arg2']).resolves(response);
+            */
+            qsp.onFirstCall().rejects(new Error('I failed'));
+            qsp.onSecondCall().rejects(new Error('I failed'));
+            qsp.onThirdCall().resolves(response);
+
+            let result = await queryHandler.queryChaincode(mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            sinon.assert.calledThrice(qsp);
+            sinon.assert.calledWith(qsp.thirdCall, mockPeer3, mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            queryHandler.queryPeerIndex.should.equal(2);
+            result.equals(response).should.be.true;
+        });
+
+        it('should handle when the last successful peer fails', async () => {
+            const response = Buffer.from('hello world');
+            const qsp = sandbox.stub(queryHandler, 'querySinglePeer');
+            qsp.onFirstCall().resolves(response);
+            qsp.onSecondCall().rejects(new Error('I failed'));
+            qsp.onThirdCall().resolves(response);
+
+            let result = await queryHandler.queryChaincode(mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            result.equals(response).should.be.true;
+            result = await queryHandler.queryChaincode(mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            result.equals(response).should.be.true;
+            sinon.assert.calledThrice(queryHandler.querySinglePeer);
+            sinon.assert.calledWith(queryHandler.querySinglePeer.firstCall, mockPeer2, mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            sinon.assert.calledWith(queryHandler.querySinglePeer.secondCall, mockPeer2, mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            sinon.assert.calledWith(queryHandler.querySinglePeer.thirdCall, mockPeer1, mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            queryHandler.queryPeerIndex.should.equal(1);
+            result.equals(response).should.be.true;
+
+        });
+
+        it('should throw if all peers respond with errors', () => {
+            const qsp = sandbox.stub(queryHandler, 'querySinglePeer');
+            qsp.onFirstCall().rejects(new Error('I failed 1'));
+            qsp.onSecondCall().rejects(new Error('I failed 2'));
+            qsp.onThirdCall().rejects(new Error('I failed 3'));
+
+            return queryHandler.queryChaincode(mockTransactionID, 'myfunc', ['arg1', 'arg2'])
+                .should.be.rejectedWith(/No peers available.+failed 3/);
+        });
+
+        it('should throw if no peers are suitable to query', () => {
+            mockPeer1.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(false);
+            mockPeer2.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(false);
+            mockPeer3.isInRole.withArgs(FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE).returns(false);
+            mockConnection.getChannelPeersInOrg.withArgs([FABRIC_CONSTANTS.NetworkConfig.CHAINCODE_QUERY_ROLE]).returns([]);
+            queryHandler = new HLFQueryHandler(mockConnection);
+
+
+            return queryHandler.queryChaincode(mockTransactionID, 'myfunc', ['arg1', 'arg2'])
+                .should.be.rejectedWith(/No peers have been provided/);
+        });
+    });
+
+    describe('#querySinglePeer', () => {
+
+        it('should query a single peer', async () => {
+            const response = Buffer.from('hello world');
+            mockChannel.queryByChaincode.resolves([response]);
+            mockConnection.businessNetworkIdentifier = 'org-acme-biznet';
+            let result = await queryHandler.querySinglePeer(mockPeer2, mockTransactionID, 'myfunc', ['arg1', 'arg2']);
+            sinon.assert.calledOnce(mockChannel.queryByChaincode);
+            sinon.assert.calledWith(mockChannel.queryByChaincode, {
+                chaincodeId: 'org-acme-biznet',
+                txId: mockTransactionID,
+                fcn: 'myfunc',
+                args: ['arg1', 'arg2'],
+                targets: [mockPeer2]
+            });
+            result.equals(response).should.be.true;
+
+        });
+
+        it('should throw if no responses are returned', () => {
+            mockChannel.queryByChaincode.resolves([]);
+            return queryHandler.querySinglePeer(mockPeer2, 'txid', 'myfunc', ['arg1', 'arg2'])
+                .should.be.rejectedWith(/No payloads were returned from the query request/);
+        });
+
+        it('should throw any responses that are errors', () => {
+            const response = [ new Error('such error') ];
+            mockChannel.queryByChaincode.resolves(response);
+            return queryHandler.querySinglePeer(mockPeer2, 'txid', 'myfunc', ['arg1', 'arg2'])
+                .should.be.rejectedWith(/such error/);
+
+        });
+
+    });
+
+});


### PR DESCRIPTION
The pull request allows for query to try alternative peers if it cannot communicate with the peer it uses queries for.
closes #2799 

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
