### PR TITLE
identity list link in docs was pointing to issuance

### DIFF
--- a/packages/composer-website/jekylldocs/managing/identity-list.md
+++ b/packages/composer-website/jekylldocs/managing/identity-list.md
@@ -4,7 +4,7 @@ title: Listing all identities in a business network
 category: tasks
 section: managing
 sidebar: sidebars/accordion-toc0.md
-excerpt: "[**A new identity can be issued to a participant using either the API or the command line**](../managing/identity-issue.html). Once a new identity has been issued, the identity can then be used by the participant to interact with the business network in the context of that participant."
+excerpt: "[**A new identity can be issued to a participant using either the API or the command line**](../managing/identity-list.html). Once a new identity has been issued, the identity can then be used by the participant to interact with the business network in the context of that participant."
 index-order: 806
 ---
 


### PR DESCRIPTION
now the link for listing identities points to the appropriate page.

Signed-off-by: David Conroy dconroy@gmail.com