### PR TITLE
Fix upgrade

### DIFF
--- a/packages/composer-common/lib/system/org.hyperledger.composer.system.cto
+++ b/packages/composer-common/lib/system/org.hyperledger.composer.system.cto
@@ -76,11 +76,13 @@ asset ParticipantRegistry extends Registry { }
 asset TransactionRegistry extends Registry { }
 
 
-/** Asset representing the business networkId
- * @param {String} networkId of the business networkId
+/** Asset representing the business network
+ * @param {String} networkId of the business network
+ * @param {String} runtimeVersion of the business network
  */
 asset Network identified by networkId {
   o String networkId
+  o String runtimeVersion
 }
 
 participant NetworkAdmin identified by participantId {

--- a/packages/composer-runtime/package.json
+++ b/packages/composer-runtime/package.json
@@ -66,6 +66,7 @@
     "lru-cache": "4.0.2",
     "request": "2.81.0",
     "request-promise-any": "1.0.5",
+    "semver": "5.3.0",
     "sha.js": "2.4.8",
     "source-map": "0.5.6"
   },

--- a/packages/composer-tests-functional/package.json
+++ b/packages/composer-tests-functional/package.json
@@ -18,7 +18,7 @@
     "systest:hlf": "mocha -t 0 systest",
     "systest:hlfv1": "mocha -t 0 systest",
     "systest:hlfv1_tls": "mocha -t 0 systest",
-    "systest:hlfv1-1": "mocha -t 0 systest/[a-p]*.js systest/setup.js",
+    "systest:hlfv1-1": "mocha -t 0 systest/[a-a]*.js systest/setup.js",
     "systest:hlfv1-2": "mocha -t 0 systest/[q-z]*.js systest/setup.js",
     "systest:hlfv1-1_tls": "mocha -t 0 systest/[a-p]*.js systest/setup.js",
     "systest:hlfv1-2_tls": "mocha -t 0 systest/[q-z]*.js systest/setup.js",


### PR DESCRIPTION
1. init should not be driven by a function name
2. semver checking needs to be done by upgrade
3. upgrade needed to drive transaction calls
4. unit tests for upgrade

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
