### PR TITLE
address node-sdk returning connect error

### DIFF
--- a/packages/composer-connector-hlfv1/lib/hlfqueryhandler.js
+++ b/packages/composer-connector-hlfv1/lib/hlfqueryhandler.js
@@ -147,8 +147,9 @@ class HLFQueryHandler {
         }
         const payload = payloads[0];
 
-        // assume that if it isn't an UNAVAILABLE entry then it was an error from the chaincode itself
-        if (payload instanceof Error && payload.message.includes('UNAVAILABLE')) {
+        // if it has a code value is 14, means unavailable, so throw that error
+        // code 2 looks like it is a chaincode response that was an error.
+        if (payload instanceof Error && payload.code && payload.code === 14) {
             throw payload;
         }
 

--- a/packages/composer-connector-hlfv1/lib/hlfqueryhandler.js
+++ b/packages/composer-connector-hlfv1/lib/hlfqueryhandler.js
@@ -87,7 +87,6 @@ class HLFQueryHandler {
             // peer to query.
             let failedPeer = this.queryPeerIndex;  // could be -1 if first attempt
             this.queryPeerIndex = -1;
-            //for (let i in this.allQueryPeers) {  // i is a string
             for (let i = 0; i < this.allQueryPeers.length && !success; i++) {
                 if (i === failedPeer) {
                     continue;
@@ -147,6 +146,12 @@ class HLFQueryHandler {
             throw new Error('No payloads were returned from the query request:' + functionName);
         }
         const payload = payloads[0];
+
+        // assume that if it isn't an UNAVAILABLE entry then it was an error from the chaincode itself
+        if (payload instanceof Error && payload.message.includes('UNAVAILABLE')) {
+            throw payload;
+        }
+
         LOG.exit(method, payload);
         return payload;
 

--- a/packages/composer-connector-hlfv1/test/hlfqueryhandler.js
+++ b/packages/composer-connector-hlfv1/test/hlfqueryhandler.js
@@ -212,8 +212,9 @@ describe('HLFQueryHandler', () => {
             result.message.should.equal('such error');
         });
 
-        it('should throw any responses that are errors and UNAVAILABLE', () => {
+        it('should throw any responses that are errors and code 14 being unavailable.', () => {
             const response = new Error('14 UNAVAILABLE: Connect Failed');
+            response.code = 14;
             mockChannel.queryByChaincode.resolves([response]);
             mockConnection.businessNetworkIdentifier = 'org-acme-biznet';
             return queryHandler.querySinglePeer(mockPeer2, 'txid', 'myfunc', ['arg1', 'arg2'])


### PR DESCRIPTION
node-sdk returns an error in the payload if connect fails and was not always been recognised as such
Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
