### PR TITLE
Move couchdb index generator to composer-common 

### DIFF
--- a/packages/composer-common/api.txt
+++ b/packages/composer-common/api.txt
@@ -61,6 +61,9 @@ class IdCard {
    + Promise fromDirectory(String,undefined) 
    + Promise toDirectory(String,undefined) 
 }
+class IndexCompiler {
+   + String compile(QueryManager) 
+}
 class AssetDeclaration extends ClassDeclaration {
    + void constructor(ModelFile,Object) throws IllegalModelException
    + boolean isRelationshipTarget() 

--- a/packages/composer-common/changelog.txt
+++ b/packages/composer-common/changelog.txt
@@ -11,6 +11,9 @@
 #
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
+Version 0.18.2 {354087f4e85b14e02e7c8284cca2583f} 2018-03-20
+- Add CouchDB index compiler
+
 Version 0.18.0 {fe7cf822029dc013cdf3c272bd9d2a59} 2018-02-28
 - Updates for cloud wallets
 - File system and Memory cardstore gone as explicit externals

--- a/packages/composer-common/index.js
+++ b/packages/composer-common/index.js
@@ -77,6 +77,7 @@ module.exports.NetworkCardStoreManager = require('./lib/cardstore/networkcardsto
 module.exports.FunctionDeclaration = require('./lib/introspect/functiondeclaration');
 module.exports.Globalize = require('./lib/globalize');
 module.exports.IdCard = require('./lib/idcard');
+module.exports.IndexCompiler = require('./lib/indexcompiler');
 module.exports.Introspector = require('./lib/introspect/introspector');
 module.exports.Limit = require('./lib/query/limit');
 module.exports.Logger = require('./lib/log/logger');

--- a/packages/composer-common/test/indexcompiler.js
+++ b/packages/composer-common/test/indexcompiler.js
@@ -14,9 +14,10 @@
 
 'use strict';
 
-const ModelManager = require('composer-common').ModelManager;
+const ModelManager = require('../lib/modelmanager');
+const QueryManager = require('../lib/querymanager');
 const IndexCompiler = require('../lib/indexcompiler');
-const QueryFile = require('composer-common').QueryFile;
+const QueryFile = require('../lib/query/queryfile');
 
 const chai = require('chai');
 chai.should();
@@ -28,6 +29,7 @@ describe('IndexCompiler', () => {
     let modelManager;
     let queryFile1;
     let queries;
+    let queryManager;
 
     beforeEach(() => {
         indexCompiler = new IndexCompiler();
@@ -201,107 +203,142 @@ describe('IndexCompiler', () => {
             const name = query.getName();
             queries[name] = query;
         });
+        queryManager = new QueryManager(modelManager);
+        queryManager.setQueryFile(queryFile1);
+    });
+
+    describe('#compile', () => {
+
+        it('should index all of the queries in the specified query manager', () => {
+            const indexes = indexCompiler.compile(queryManager);
+            indexes.should.be.an('array');
+            indexes.should.have.lengthOf(20);
+            indexes.should.all.have.property('name');
+            indexes.should.all.have.property('ddoc');
+            indexes.should.all.have.property('index');
+        });
+
+    });
+
+    describe('#visitQueryManager', () => {
+
+        it('should index all queries in the query manager', () => {
+            const indexes = indexCompiler.visitQueryManager(queryManager);
+            indexes.should.be.an('array');
+            indexes.should.have.lengthOf(20);
+            indexes.should.all.have.property('name');
+            indexes.should.all.have.property('ddoc');
+            indexes.should.all.have.property('index');
+        });
+
+        it('should handle no queries in the query manager', () => {
+            queryManager.queryFile = null;
+            const indexes = indexCompiler.visitQueryManager(queryManager);
+            indexes.should.be.an('array');
+            indexes.should.have.lengthOf(0);
+        });
+
     });
 
     describe('generate query indexes', () => {
         it('should generate index for Q1', () => {
-            const index = indexCompiler.compile(queries.Q1);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId","value"]},"name":"Q1","ddoc":"Q1Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q1);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId','value']},'name':'Q1','ddoc':'Q1Doc','type':'json'});
         });
 
         it('should generate index for Q2', () => {
-            const index = indexCompiler.compile(queries.Q2);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId"]},"name":"Q2","ddoc":"Q2Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q2);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId']},'name':'Q2','ddoc':'Q2Doc','type':'json'});
         });
 
         it('should generate index for Q3', () => {
-            const index = indexCompiler.compile(queries.Q3);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId"]},"name":"Q3","ddoc":"Q3Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q3);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId']},'name':'Q3','ddoc':'Q3Doc','type':'json'});
         });
 
         it('should generate index for Q4', () => {
-            const index = indexCompiler.compile(queries.Q4);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId"]},"name":"Q4","ddoc":"Q4Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q4);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId']},'name':'Q4','ddoc':'Q4Doc','type':'json'});
         });
 
         it('should generate index for Q5', () => {
-            const index = indexCompiler.compile(queries.Q5);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId"]},"name":"Q5","ddoc":"Q5Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q5);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId']},'name':'Q5','ddoc':'Q5Doc','type':'json'});
         });
 
         it('should generate index for Q6', () => {
-            const index = indexCompiler.compile(queries.Q6);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId"]},"name":"Q6","ddoc":"Q6Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q6);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId']},'name':'Q6','ddoc':'Q6Doc','type':'json'});
         });
 
         it('should generate index for Q7', () => {
-            const index = indexCompiler.compile(queries.Q7);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId"]},"name":"Q7","ddoc":"Q7Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q7);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId']},'name':'Q7','ddoc':'Q7Doc','type':'json'});
         });
 
         it('should generate index for Q8', () => {
-            const index = indexCompiler.compile(queries.Q8);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId","value"]},"name":"Q8","ddoc":"Q8Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q8);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId','value']},'name':'Q8','ddoc':'Q8Doc','type':'json'});
         });
 
         it('should generate index for Q9', () => {
-            const index = indexCompiler.compile(queries.Q9);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId"]},"name":"Q9","ddoc":"Q9Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q9);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId']},'name':'Q9','ddoc':'Q9Doc','type':'json'});
         });
 
         it('should generate index for Q10', () => {
-            const index = indexCompiler.compile(queries.Q10);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId"]},"name":"Q10","ddoc":"Q10Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q10);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId']},'name':'Q10','ddoc':'Q10Doc','type':'json'});
         });
 
         it('should generate index for Q11', () => {
-            const index = indexCompiler.compile(queries.Q11);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId"]},"name":"Q11","ddoc":"Q11Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q11);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId']},'name':'Q11','ddoc':'Q11Doc','type':'json'});
         });
 
         it('should generate index for Q12', () => {
-            const index = indexCompiler.compile(queries.Q12);
-            index.should.equal('{"index":{"fields":[{"\\\\$class":"desc"},{"\\\\$registryType":"desc"},{"\\\\$registryId":"desc"},{"foo":"desc"}]},"name":"Q12","ddoc":"Q12Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q12);
+            index.should.deep.equal({'index':{'fields':[{'\\$class':'desc'},{'\\$registryType':'desc'},{'\\$registryId':'desc'},{'foo':'desc'}]},'name':'Q12','ddoc':'Q12Doc','type':'json'});
         });
 
         it('should generate index for Q13', () => {
-            const index = indexCompiler.compile(queries.Q13);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId",{"foo":"asc"},{"bar":"asc"}]},"name":"Q13","ddoc":"Q13Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q13);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId',{'foo':'asc'},{'bar':'asc'}]},'name':'Q13','ddoc':'Q13Doc','type':'json'});
         });
 
         it('should generate index for Q14', () => {
-            const index = indexCompiler.compile(queries.Q14);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId","baa.moo.neigh.meow.woof"]},"name":"Q14","ddoc":"Q14Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q14);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId','baa.moo.neigh.meow.woof']},'name':'Q14','ddoc':'Q14Doc','type':'json'});
         });
 
         it('should generate index for Q15', () => {
-            const index = indexCompiler.compile(queries.Q15);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId"]},"name":"Q15","ddoc":"Q15Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q15);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId']},'name':'Q15','ddoc':'Q15Doc','type':'json'});
         });
 
         it('should generate index for Q16', () => {
-            const index = indexCompiler.compile(queries.Q16);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId","noises"]},"name":"Q16","ddoc":"Q16Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q16);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId','noises']},'name':'Q16','ddoc':'Q16Doc','type':'json'});
         });
 
         it('should generate index for Q17', () => {
-            const index = indexCompiler.compile(queries.Q17);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId","noises"]},"name":"Q17","ddoc":"Q17Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q17);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId','noises']},'name':'Q17','ddoc':'Q17Doc','type':'json'});
         });
 
         it('should generate index for Q18', () => {
-            const index = indexCompiler.compile(queries.Q18);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId","meows","woof"]},"name":"Q18","ddoc":"Q18Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q18);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId','meows','woof']},'name':'Q18','ddoc':'Q18Doc','type':'json'});
         });
 
         it('should generate index for Q19', () => {
-            const index = indexCompiler.compile(queries.Q19);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId","meows","woof"]},"name":"Q19","ddoc":"Q19Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q19);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId','meows','woof']},'name':'Q19','ddoc':'Q19Doc','type':'json'});
         });
 
         it('should generate index for Q20', () => {
-            const index = indexCompiler.compile(queries.Q20);
-            index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId","meows","woof","tweet"]},"name":"Q20","ddoc":"Q20Doc","type":"json"}');
+            const index = indexCompiler.visitQuery(queries.Q20);
+            index.should.deep.equal({'index':{'fields':['\\$class','\\$registryType','\\$registryId','meows','woof','tweet']},'name':'Q20','ddoc':'Q20Doc','type':'json'});
         });
 
     });
@@ -309,7 +346,7 @@ describe('IndexCompiler', () => {
     describe('error handlers', () => {
         it('should throw error for unrecognised AST node', () => {
             (() => {
-                indexCompiler.compile({'type': 'unknown'});
+                indexCompiler.visit({'type': 'unknown'});
             }).should.throw('Unrecognised type: object, value: {"type":"unknown"}');
         });
 

--- a/packages/composer-connector-hlfv1/lib/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/lib/hlfconnection.js
@@ -30,7 +30,7 @@ const User = require('fabric-client/lib/User.js');
 const TransactionID = require('fabric-client/lib/TransactionID');
 const FABRIC_CONSTANTS = require('fabric-client/lib/Constants');
 
-const QueryCompiler = require('composer-runtime').QueryCompiler;
+const IndexCompiler = require('composer-common').IndexCompiler;
 
 const LOG = Logger.getLog('HLFConnection');
 
@@ -418,8 +418,8 @@ class HLFConnection extends Connection {
 
         // write the query indexes to statedb/couchdb/indexes
         const queryManager = businessNetworkDefinition.getQueryManager();
-        const queryCompiler = new QueryCompiler();
-        const queries = queryCompiler.compile(queryManager);
+        const indexCompiler = new IndexCompiler();
+        const indexes = indexCompiler.compile(queryManager);
         let indexDir = path.join(installDir, 'statedb');
         fs.mkdirSync(indexDir);
         indexDir = path.join(indexDir, 'couchdb');
@@ -427,11 +427,11 @@ class HLFConnection extends Connection {
         indexDir = path.join(indexDir, 'indexes');
         fs.mkdirSync(indexDir);
 
-        queries.compiledQueries.forEach(query => {
-            const json = JSON.parse(query.index);
+        indexes.forEach(index => {
+            const json = index;
             const designDoc = json.ddoc + '.json';
             const indexFile = path.resolve(indexDir, designDoc);
-            this.fs.writeFileSync(indexFile, query.index);
+            this.fs.writeFileSync(indexFile, JSON.stringify(index));
         });
 
         // copy over a .npmrc file, should be part of the business network definition.

--- a/packages/composer-connector-hlfv1/package.json
+++ b/packages/composer-connector-hlfv1/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "composer-common": "0.18.2",
-    "composer-runtime": "0.18.2",
     "fabric-ca-client": "1.1.0",
     "fabric-client": "1.1.0",
     "fs-extra": "1.0.0",

--- a/packages/composer-runtime/lib/querycompiler.js
+++ b/packages/composer-runtime/lib/querycompiler.js
@@ -28,7 +28,6 @@ const Select = require('composer-common').Select;
 const Skip = require('composer-common').Skip;
 const TransactionDeclaration = require('composer-common').TransactionDeclaration;
 const Where = require('composer-common').Where;
-const IndexCompiler = require('./indexcompiler');
 
 const LOG = Logger.getLog('QueryCompiler');
 
@@ -175,7 +174,6 @@ class QueryCompiler {
 
         // Generate a hash for the query.
         const hash = this.generateQueryHash(query);
-        const indexCompiler = new IndexCompiler();
 
         // Generate a result object containing all the data.
         const result = {
@@ -183,7 +181,6 @@ class QueryCompiler {
             text: select.getText(),
             hash: hash,
             generator: compiledQueryGenerator,
-            index: indexCompiler.compile(query)
         };
 
         LOG.exit(method, result);

--- a/packages/composer-runtime/test/querycompiler.js
+++ b/packages/composer-runtime/test/querycompiler.js
@@ -225,7 +225,6 @@ describe('QueryCompiler', () => {
             compiledQueryBundle.compiledQueries.should.all.have.property('name');
             compiledQueryBundle.compiledQueries.should.all.have.property('hash');
             compiledQueryBundle.compiledQueries.should.all.have.property('generator');
-            compiledQueryBundle.compiledQueries.should.all.have.property('index');
         });
 
     });
@@ -239,7 +238,6 @@ describe('QueryCompiler', () => {
             compiled.should.all.have.property('name');
             compiled.should.all.have.property('hash');
             compiled.should.all.have.property('generator');
-            compiled.should.all.have.property('index');
         });
 
         it('should throw if something invalid is visited', () => {
@@ -259,7 +257,6 @@ describe('QueryCompiler', () => {
             compiled.should.all.have.property('name');
             compiled.should.all.have.property('hash');
             compiled.should.all.have.property('generator');
-            compiled.should.all.have.property('index');
         });
 
         it('should handle no queries in the query manager', () => {
@@ -280,7 +277,6 @@ describe('QueryCompiler', () => {
             compiled.should.all.have.property('name');
             compiled.should.all.have.property('hash');
             compiled.should.all.have.property('generator');
-            compiled.should.all.have.property('index');
         });
 
     });
@@ -293,7 +289,6 @@ describe('QueryCompiler', () => {
             compiled.hash.should.equal('d35890cac366631b31745dc6376e5d8414ef441ff66c606505f6bed898d9700c');
             compiled.generator.should.be.a('function');
             compiled.generator({}).should.equal('{"selector":{"\\\\$class":"org.acme.sample.SampleAsset","\\\\$registryType":"Asset","\\\\$registryId":"org.acme.sample.SampleAsset","value":{"$eq":"Green hat"}}}');
-            compiled.index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId","value"]},"name":"Q1","ddoc":"Q1Doc","type":"json"}');
         });
 
         it('should compile a query with parameters', () => {
@@ -302,7 +297,6 @@ describe('QueryCompiler', () => {
             compiled.hash.should.equal('c4a085154080078b7a2a1f572f92a28bc679b1e40526343aed4460fc62757a9b');
             compiled.generator.should.be.a('function');
             compiled.generator({ foo: 'Green hat' }).should.equal('{"selector":{"\\\\$class":"org.acme.sample.SampleAsset","\\\\$registryType":"Asset","\\\\$registryId":"org.acme.sample.SampleAsset","value":{"$eq":"Green hat"}}}');
-            compiled.index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId","value"]},"name":"Q8","ddoc":"Q8Doc","type":"json"}');
         });
 
         it('should compile a query with parameters that be can changed for each execution', () => {
@@ -313,7 +307,6 @@ describe('QueryCompiler', () => {
             compiled.generator({ foo: 'Green hat' }).should.equal('{"selector":{"\\\\$class":"org.acme.sample.SampleAsset","\\\\$registryType":"Asset","\\\\$registryId":"org.acme.sample.SampleAsset","value":{"$eq":"Green hat"}}}');
             compiled.generator({ foo: 'Black hat' }).should.equal('{"selector":{"\\\\$class":"org.acme.sample.SampleAsset","\\\\$registryType":"Asset","\\\\$registryId":"org.acme.sample.SampleAsset","value":{"$eq":"Black hat"}}}');
             compiled.generator({ foo: 'Red hat' }).should.equal('{"selector":{"\\\\$class":"org.acme.sample.SampleAsset","\\\\$registryType":"Asset","\\\\$registryId":"org.acme.sample.SampleAsset","value":{"$eq":"Red hat"}}}');
-            compiled.index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId","value"]},"name":"Q8","ddoc":"Q8Doc","type":"json"}');
         });
 
         it('should compile a query with nested parameters', () => {
@@ -322,7 +315,6 @@ describe('QueryCompiler', () => {
             compiled.hash.should.equal('951f2465d94148ffbe2e4c081fe6c8f73f95056ccdb8be3dcb8180ba6f3d9098');
             compiled.generator.should.be.a('function');
             compiled.generator({ animalNoise: 'ribbet' }).should.equal('{"selector":{"\\\\$class":"org.acme.sample.SampleAsset","\\\\$registryType":"Asset","\\\\$registryId":"org.acme.sample.SampleAsset","baa.moo.neigh.meow.woof":{"$eq":"ribbet"}}}');
-            compiled.index.should.equal('{"index":{"fields":["\\\\$class","\\\\$registryType","\\\\$registryId","baa.moo.neigh.meow.woof"]},"name":"Q14","ddoc":"Q14Doc","type":"json"}');
         });
 
     });


### PR DESCRIPTION
Move couchdb index generator to composer-common.
This allows composer-connector-hlfv1 to remove its dependency on composer-runtime

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
