### PR TITLE
Stand up Verdaccio for local testing of composer-playground-api

### DIFF
--- a/packages/composer-playground-api/.gitignore
+++ b/packages/composer-playground-api/.gitignore
@@ -46,3 +46,6 @@ out
 *.swp
 
 # Build generated files should be ignored by git, but not by npm.
+
+scripts/storage
+.pm2

--- a/packages/composer-playground-api/package.json
+++ b/packages/composer-playground-api/package.json
@@ -53,7 +53,8 @@
     "mocha": "3.4.2",
     "nyc": "11.1.0",
     "proxyquire": "1.7.11",
-    "sinon": "2.3.8"
+    "sinon": "2.3.8",
+    "verdaccio": "2.6.4"
   },
   "dependencies": {
     "async": "2.5.0",

--- a/packages/composer-playground-api/scripts/config.yaml
+++ b/packages/composer-playground-api/scripts/config.yaml
@@ -1,0 +1,40 @@
+#
+# This is the default config file. It allows all users to do anything,
+# so don't use it on production systems.
+#
+# Look here for more config file examples:
+# https://github.com/verdaccio/verdaccio/tree/master/conf
+#
+# path to a directory with all packages
+storage: ./storage
+auth:
+  htpasswd:
+    file: ./htpasswd
+    # Maximum amount of users allowed to register, defaults to "+inf".
+    # You can set this to -1 to disable registration.
+    #max_users: 1000
+# a list of other known repositories we can talk to
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    max_fails: 1000
+packages:
+  '@*/*':
+    # scoped packages
+    access: $all
+    publish: $all
+    proxy: npmjs
+  '**':
+    # allow all users (including non-authenticated users) to read and
+    # publish all packages
+    access: $all
+    # allow all known users to publish packages
+    publish: $all
+    # if package is not available locally, proxy requests to 'npmjs' registry
+    proxy: npmjs
+# log settings
+logs:
+  - {type: stdout, format: pretty, level: http}
+  #- {type: file, path: verdaccio.log, level: info}
+listen:
+ - localhost:4873            # default value

--- a/packages/composer-playground-api/scripts/start.sh
+++ b/packages/composer-playground-api/scripts/start.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Exit on first error, print all commands
+set -ev
+
+# Environment vaiable directs Playground (connector server) to an npmrc to supply to network install
+export NPMRC_FILE=/tmp/npmrc
+
+# Switch to package root directory
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# Delete any existing configuration
+rm -rf ./scripts/storage
+
+# Create the npmrc for use by Playground
+if [ `uname` = "Darwin" ]; then
+    export GATEWAY=docker.for.mac.localhost
+else
+    export GATEWAY="$(docker inspect hlfv1_default | grep Gateway | cut -d \" -f4)"
+fi
+echo "registry=http://${GATEWAY}:4873" > ${NPMRC_FILE}
+
+# Start the npm proxy
+./node_modules/.bin/verdaccio --listen '0.0.0.0:4873' --config scripts/config.yaml &
+verdaccio_pid=$!
+
+# Publish development versions of packages required at runtime
+for package in composer-common composer-runtime composer-runtime-hlfv1; do
+    npm publish --registry 'http://localhost:4873' "../${package}"
+done
+
+# Start the Playground API
+npm start
+
+# Stop the npm proxy
+kill ${verdaccio_pid}
+
+# Wipe out configuration
+rm -rf ./scripts/storage


### PR DESCRIPTION
Added scripts/start.sh to handle start/stop and configuration of Verdaccio.
This can be used instead of `npm start`.

Contributes to #3160 
