### PR TITLE
Fix version of tar that composer report cli command requires

### DIFF
--- a/packages/composer-cli/package.json
+++ b/packages/composer-cli/package.json
@@ -62,7 +62,7 @@
     "prettyjson": "1.2.1",
     "prompt": "1.0.0",
     "sanitize-filename": "1.6.1",
-    "tar": "3.1.5",
+    "tar": "4.3.0",
     "valid-url": "1.0.9",
     "yargs": "10.0.3"
   },

--- a/packages/composer-playground-api/package.json
+++ b/packages/composer-playground-api/package.json
@@ -68,7 +68,7 @@
     "request": "2.81.0",
     "semver": "5.3.0",
     "socket.io": "1.7.3",
-    "tar": "3.1.5"
+    "tar": "4.3.0"
   },
   "nyc": {
     "exclude": [

--- a/packages/composer-report/package.json
+++ b/packages/composer-report/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "moment": "2.19.3",
     "node-report": "2.2.1",
-    "tar": "3.1.5"
+    "tar": "4.3.0"
   },
   "license-check-config": {
     "src": [


### PR DESCRIPTION
Fix the version of tar that composer report cli command requires in the package.json for the composer-report module

Resolves #3614 

Signed-off-by: Sam Smith <smithsj@uk.ibm.com>

