### PR TITLE
Register for events on connection login, not first invoke

### DIFF
--- a/packages/composer-common/.gitignore
+++ b/packages/composer-common/.gitignore
@@ -51,3 +51,4 @@ lib/introspect/parser.js
 lib/query/parser.js
 index.d.ts
 lib/systemmodel.js
+composer-*.tgz

--- a/packages/composer-runtime-hlfv1/.gitignore
+++ b/packages/composer-runtime-hlfv1/.gitignore
@@ -46,6 +46,7 @@ out
 *.swp
 
 # Build generated files should be ignored by git, but not by npm.
+composer-*.tgz
 
 # ignore this for now as it there shouldn't be one
 .npmrc

--- a/packages/composer-runtime/.gitignore
+++ b/packages/composer-runtime/.gitignore
@@ -47,3 +47,4 @@ out
 
 # Build generated files should be ignored by git, but not by npm.
 index.d.ts
+composer-*.tgz

--- a/packages/composer-tests-functional/systest/events.js
+++ b/packages/composer-tests-functional/systest/events.js
@@ -14,11 +14,10 @@
 
 'use strict';
 
+const BusinessNetworkConnection = require('composer-client').BusinessNetworkConnection;
 const BusinessNetworkDefinition = require('composer-admin').BusinessNetworkDefinition;
-
 const fs = require('fs');
 const path = require('path');
-
 const TestUtil = require('./testutil');
 
 const chai = require('chai');
@@ -104,7 +103,7 @@ describe('Event system tests', function() {
         }
     });
 
-    it('should emit a valid SimpleEvent', () => {
+    it('should emit an event in a transaction that contains primitive properties', async () => {
         this.timeout(1000);
         let emitted = 0;
         let factory = client.getBusinessNetwork().getFactory();
@@ -119,13 +118,11 @@ describe('Event system tests', function() {
                 resolve();
             });
         });
-        return client.submitTransaction(transaction)
-            .then(() => {
-                return promise;
-            });
+        await client.submitTransaction(transaction);
+        await promise;
     });
 
-    it('should emit a valid ComplexEvent', () => {
+    it('should emit an event in a transaction that contains complex properties', async () => {
         this.timeout(1000); // Delay to prevent transaction failing
         let emitted = 0;
         let factory = client.getBusinessNetwork().getFactory();
@@ -140,13 +137,11 @@ describe('Event system tests', function() {
                 resolve();
             });
         });
-        return client.submitTransaction(transaction)
-            .then(() => {
-                return promise;
-            });
+        await client.submitTransaction(transaction);
+        await promise;
     });
 
-    it('should emit two valid SimpleEvents', () => {
+    it('should emit two events in a single transaction', async () => {
         this.timeout(1000); // Delay to prevent transaction failing
         let counts = [1, 2];
         let emitted = 0;
@@ -164,18 +159,39 @@ describe('Event system tests', function() {
                 }
             });
         });
-        return client.submitTransaction(transaction)
-            .then(() => {
-                return promise;
-            });
+        await client.submitTransaction(transaction);
+        await promise;
     });
 
 
     if (TestUtil.isHyperledgerFabricV1()) {
 
+        // This test only works on a real fabric, because the embedded and web connectors are
+        // currently broken with regards to multiple connections to the same business network.
+        it('should subscribe for events without submitting a transaction', async () => {
+            this.timeout(1000); // Delay to prevent transaction failing
+            let emitted = 0;
+            let factory = client.getBusinessNetwork().getFactory();
+            let transaction = factory.newTransaction('systest.events', 'EmitSimpleEvent');
+
+            // Listen for the event using a second business network connection
+            const listenOnlyClient = new BusinessNetworkConnection({cardStore});
+            await listenOnlyClient.connect('admincard');
+            const promise = new Promise((resolve, reject) => {
+                listenOnlyClient.on('event', (ev) => {
+                    validateEvent(ev, emitted);
+                    emitted++;
+                    emitted.should.equal(1);
+                    resolve();
+                });
+            });
+            await client.submitTransaction(transaction);
+            await promise;
+        });
+
         // This test can only work on a real fabric where a r/w set from 2 different organisations
         // are returned and they disagree on the simulation results.
-        it('should not emit an Event if tx not committed', async () => {
+        it('should not emit an event if a transaction is not committed', async () => {
             this.timeout(1000);
             let emitted = 0;
             let factory = client.getBusinessNetwork().getFactory();


### PR DESCRIPTION
Signed-off-by: Simon Stone <sstone1@uk.ibm.com>

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->
Can not listen to events if a transaction has not been submitted before #3669

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
