### PR TITLE
change composer cli example to one that works

### DIFF
--- a/packages/composer-cli/cli.js
+++ b/packages/composer-cli/cli.js
@@ -25,7 +25,7 @@ const version = 'v' +require('./package.json').version;
 let results = yargs
     .commandDir('./lib/cmds')
     .help()
-    .example('composer archive create\ncomposer identity issue\ncomposer network deploy\ncomposer participant add\ncomposer transaction submit')
+    .example('composer archive create\ncomposer identity issue\ncomposer network install\ncomposer participant add\ncomposer transaction submit')
     .demand(1)
     .wrap(null)
     .strict()


### PR DESCRIPTION
The command `composer` when invoked with no args returns help text with some examples.  One example is `composer network deploy`, which is no longer relevant.
This PR replaces this with `composer network install`

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
