### PR TITLE
Further doc fixes

### DIFF
--- a/packages/composer-website/jekylldocs/applications/web.md
+++ b/packages/composer-website/jekylldocs/applications/web.md
@@ -52,7 +52,7 @@ composer card list
 
 ### 2. Prepare the {{site.data.conrefs.hlf_full}} peers
 
-In order to install the Business Network Archive onto the {{site.data.conrefs.hlf_full}} network you need to prepare the peers with the underlying Composer runtime.
+In order to install the Business Network Archive onto the {{site.data.conrefs.hlf_full}} network you need to install the business network onto the peers. It is recommended you start with a clean directory. Move your BNA into that directory and change your terminal directory to it.
 
 You will need to have the Business Network archive to do this, below you can see an example with `tutorial-network` along with the 'PeerAdmin' card for your deployment.
 
@@ -62,7 +62,7 @@ composer network install --card PeerAdmin@hlfv1 --archiveFile tutorial-network@0
 
 ### 3. Start your Business Network on your {{site.data.conrefs.hlf_full}}
 
-It is recommended you start with a clean directory. Move your BNA into that directory and change your terminal directory to it.
+
 
 We will use the `composer network start` command to start the business network, we will need to use our `PeerAdmin` card to do this. We will also need to create a user on our network, we will use an "Admin" username and password to get started.
 

--- a/packages/composer-website/jekylldocs/applications/web.md
+++ b/packages/composer-website/jekylldocs/applications/web.md
@@ -62,8 +62,6 @@ composer network install --card PeerAdmin@hlfv1 --archiveFile tutorial-network@0
 
 ### 3. Start your Business Network on your {{site.data.conrefs.hlf_full}}
 
-
-
 We will use the `composer network start` command to start the business network, we will need to use our `PeerAdmin` card to do this. We will also need to create a user on our network, we will use an "Admin" username and password to get started.
 
 Below is an example using a `tutorial-network` BNA.

--- a/packages/composer-website/jekylldocs/business-network/cloud-wallets.md
+++ b/packages/composer-website/jekylldocs/business-network/cloud-wallets.md
@@ -45,7 +45,7 @@ The following configuration file uses the Redis format as an example:
 {
   "composer": {
     "wallet": {
-      "type": "@ampretia/composer-wallet-redis",
+      "type": "composer-wallet-redis",
       "desc": "Uses a local redis instance,
       "options": {
 
@@ -67,7 +67,7 @@ Specifying the details of a custom wallet on the command line via environment va
 The following environment variable example uses the same format and data as the preceding configuration file.
 
 ```
-export NODE_CONFIG={"composer":{"wallet":{"type":"@ampretia/composer-wallet-redis","desc":"Uses  a local redis instance,"options":{}}}}
+export NODE_CONFIG={"composer":{"wallet":{"type":"composer-wallet-redis","desc":"Uses  a local redis instance,"options":{}}}}
 ```
 
 Any application that is in this shell will use the cloud wallets.

--- a/packages/composer-website/jekylldocs/managing/identity-list.md
+++ b/packages/composer-website/jekylldocs/managing/identity-list.md
@@ -4,7 +4,7 @@ title: Listing all identities in a business network
 category: tasks
 section: managing
 sidebar: sidebars/accordion-toc0.md
-excerpt: "[**Identities issued or bound to a participant creates a mapping**](../managing/identity-List.html). In order to perform identity management operations in a deployed business network, you will need to list and review the set of identities in the identity registry."
+excerpt: "[**Identities issued or bound to a participant creates a mapping**](../managing/identity-list.html). In order to perform identity management operations in a deployed business network, you will need to list and review the set of identities in the identity registry."
 index-order: 806
 ---
 

--- a/packages/composer-website/jekylldocs/managing/identity-list.md
+++ b/packages/composer-website/jekylldocs/managing/identity-list.md
@@ -4,7 +4,7 @@ title: Listing all identities in a business network
 category: tasks
 section: managing
 sidebar: sidebars/accordion-toc0.md
-excerpt: "[**A new identity can be issued to a participant using either the API or the command line**](../managing/identity-issue.html). Once a new identity has been issued, the identity can then be used by the participant to interact with the business network in the context of that participant."
+excerpt: "[**Identities issued or bound to a participant creates a mapping**](../managing/identity-List.html). In order to perform identity management operations in a deployed business network, you will need to list and review the set of identities in the identity registry."
 index-order: 806
 ---
 

--- a/packages/composer-website/jekylldocs/reference/commands.md
+++ b/packages/composer-website/jekylldocs/reference/commands.md
@@ -56,11 +56,11 @@ Lists all cards currently in your wallet: [composer card list](./composer.card.l
 
 `composer network install`
 
-Install a business network archive to a {{site.data.conrefs.hlf_full}} peer: [composer network install](./composer.network.install.html)
+Install a business network archive to an organization's {{site.data.conrefs.hlf_full}} peer(s): [composer network install](./composer.network.install.html)
 
 `composer network start`
 
-Start a business network on a {{site.data.conrefs.hlf_full}} peer that already has the business network installed: [composer network start](./composer.network.start.html)
+Start an already installed business network: [composer network start](./composer.network.start.html)
 
 `composer network list`
 

--- a/packages/composer-website/jekylldocs/reference/js_scripts.md
+++ b/packages/composer-website/jekylldocs/reference/js_scripts.md
@@ -289,7 +289,7 @@ async function sampleTransaction(tx) {
 
 To call the {{site.data.conrefs.hlf_full}} API in a transaction processor function, the function `getNativeAPI` must be called, followed by a function from the {{site.data.conrefs.hlf_full}} API. Using the {{site.data.conrefs.hlf_full}} API gives you access to functionality which is not available in the {{site.data.conrefs.composer_full}} API.
 
-*Please note: The `getState` and `putState` {{site.data.conrefs.hlf_full}} API functions will bypass the {{site.data.conrefs.composer_full}} access control rules.*
+**IMPORTANT: Using the {{site.data.conrefs.hlf_full}} API such as `getState`, `putState`, `deleteState`, `getStateByPartialCompositeKey`, `getQueryResult` functions will bypass the {{site.data.conrefs.composer_full}} access control rules (ACLs).**
 
 In the example below, the {{site.data.conrefs.hlf_full}} API function `getHistoryForKey` is called, which returns the history of a specified asset as an iterator. The transaction processor function then stores the returned data in an array.
 

--- a/packages/composer-website/jekylldocs/tutorials/deploy-to-fabric-multi-org.md
+++ b/packages/composer-website/jekylldocs/tutorials/deploy-to-fabric-multi-org.md
@@ -479,7 +479,7 @@ Run the `composer card import` command to import the business network card for `
 
 If the command works successfully, a business network card called `PeerAdmin@byfn-network-org2` will have been imported into the wallet.
 
-<h2 class='alice'>Step Eleven: Installing the {{site.data.conrefs.composer_full}} runtime onto the {{site.data.conrefs.hlf_full}} peer nodes for Org1</h2>
+<h2 class='alice'>Step Eleven: Installing the business network onto the {{site.data.conrefs.hlf_full}} peer nodes for Org1</h2>
 
 Run the `composer network install` command to install the business network onto all of the {{site.data.conrefs.hlf_full}} peer nodes for `Org1` that you specified in the connection profile file you created in 'Step Three':
 
@@ -487,9 +487,11 @@ Run the `composer network install` command to install the business network onto 
 
 As you can see from the above, we are using a {{site.data.conrefs.composer_full}} business network called `trade-network` to test our multi-org environment. You will need a file `trade-network.bna` (business network archive, from our sample networks) to do the test. If you don't have this, just go to https://composer-playground.mybluemix.net/ and deploy the `trade-network` sample in the online Playground, then 'connect' to the business network as 'admin', change the version number to `0.1.14` in the lower left, and export it to the current directory as `trade-network.bna`. The business network has a *version* property specified in a `package.json` file. That version must be specified when the business network is started using the `composer start` command in Step Seventeen. If you are using the `trade-network` sample network, the version is `0.1.14`. (Note: If you are planning on using a different network, such as the Composer tutorial network `tutorial-network` as your business network,  you would need to specify that file in the `network install` command above and thereafter, as the business network archive in this tutorial, as well as the correct version number for this business network).
 
-<h2 class='bob'>Step Twelve: Installing the {{site.data.conrefs.composer_full}} runtime onto the {{site.data.conrefs.hlf_full}} peer nodes for Org2</h2>
+A useful feature of the `network install` command is that it will output the name of the business network and the version number that has just been installed and you can note these down for use in 'Step Seventeen' later.
 
-Run the `composer network install` command to install the {{site.data.conrefs.composer_full}} runtime onto all of the {{site.data.conrefs.hlf_full}} peer nodes for `Org2` that you specified in the connection profile file you created in step four:
+<h2 class='bob'>Step Twelve: Installing the business network onto the {{site.data.conrefs.hlf_full}} peer nodes for Org2</h2>
+
+Run the `composer network install` command to install the business network onto all of the {{site.data.conrefs.hlf_full}} peer nodes for `Org2` that you specified in the connection profile file you created in step four:
 
     composer network install --card PeerAdmin@byfn-network-org2 --archiveFile trade-network.bna
 

--- a/packages/composer-website/jekylldocs/tutorials/deploy-to-fabric-single-org.md
+++ b/packages/composer-website/jekylldocs/tutorials/deploy-to-fabric-single-org.md
@@ -10,7 +10,7 @@ excerpt: "This tutorial will walk you through the steps required to configure Co
 
 # Deploying a {{site.data.conrefs.composer_full}} blockchain business network to {{site.data.conrefs.hlf_full}} for a single organization
 
-In the [development environment](../installing/development-tools.html), a simple {{site.data.conrefs.hlf_full}} network is created for you (`fabric-dev-servers`), along with all of the {{site.data.conrefs.composer_full}} configuration that you need in order to deploy a blockchain business network.
+In the [development environment](../installing/development-tools.html), a simple development only {{site.data.conrefs.hlf_full}} single organization, single peer network is created for you (`fabric-dev-servers`), along with all of the {{site.data.conrefs.composer_full}} configuration that you need in order to deploy a blockchain business network.
 
 This tutorial will demonstrate the steps that an administrator needs to take in order to deploy a blockchain business network to an instance of {{site.data.conrefs.hlf_full}} for a single organization, including how to generate the necessary {{site.data.conrefs.composer_full}} configuration. A subsequent tutorial will demonstrate how to deploy a blockchain business network to an instance of {{site.data.conrefs.hlf_full}} for multiple organizations.
 
@@ -24,7 +24,7 @@ During this tutorial, you may wish to refer to the [{{site.data.conrefs.hlf_full
 
 In order to follow this tutorial, you must start a {{site.data.conrefs.hlf_full}} network. You can use the simple {{site.data.conrefs.hlf_full}} network provided in the development environment, or you can use your own {{site.data.conrefs.hlf_full}} network that you have built by following the {{site.data.conrefs.hlf_full}} documentation.
 
-The tutorial will assume that you use the simple {{site.data.conrefs.hlf_full}} network provided in the development environment. If you use your own {{site.data.conrefs.hlf_full}} network, then you must map between the configuration detailed below and your own configuration.
+The tutorial will assume that you use the simple {{site.data.conrefs.hlf_full}} network provided in the development environment. If you use your own {{site.data.conrefs.hlf_full}} network, then you must map between the configuration detailed below and your own configuration and it should be a single organization network.
 
 1. Start a clean {{site.data.conrefs.hlf_full}} by running the following commands:
 
@@ -340,7 +340,7 @@ This is the path to the private key file for the user `Admin@org1.example.com` t
 
     -r PeerAdmin -r ChannelAdmin
 
-Here, we specify which roles the user has. This information is required so that {{site.data.conrefs.composer_full}} knows which users are able to perform which operations. The user `Admin@org1.example.com` is an administrator for the {{site.data.conrefs.hlf_full}} network, and has the roles `PeerAdmin` (ability to install chaincode) and `ChannelAdmin` (ability to instantiate chaincode).
+Here, we specify which roles the user has. This information is required so that {{site.data.conrefs.composer_full}} playground knows which users are able to perform which operations. The user `Admin@org1.example.com` is an administrator for the {{site.data.conrefs.hlf_full}} network, and has the roles `PeerAdmin` (ability to install chaincode) and `ChannelAdmin` (ability to instantiate chaincode).
 
 ## Step Six: Importing the business network card for the {{site.data.conrefs.hlf_full}} administrator
 
@@ -362,11 +362,9 @@ We are going to deploy the blockchain business network `tutorial-network` that i
 
 ## Step Seven: Installing the {{site.data.conrefs.composer_full}} business network onto the {{site.data.conrefs.hlf_full}} peer nodes
 
-{{site.data.conrefs.composer_full}} includes a component called the {{site.data.conrefs.composer_full}} runtime that provides all of the functionality to host and support a business network archive, for example data validation, error handling, transaction processor function execution, and access control. In {{site.data.conrefs.hlf_full}} terms, the {{site.data.conrefs.composer_full}} runtime is a standard chaincode.
+In this step, you will install your blockchain business network onto all of your organizations {{site.data.conrefs.hlf_full}} peer nodes. In {{site.data.conrefs.hlf_full}} terms, this is a chaincode install operation.
 
-In this step, you will install the {{site.data.conrefs.composer_full}} runtime onto all of the {{site.data.conrefs.hlf_full}} peer nodes. In {{site.data.conrefs.hlf_full}} terms, this is a chaincode install operation.
-
-Run the `composer network install` command to install the {{site.data.conrefs.composer_full}} runtime onto all of the {{site.data.conrefs.hlf_full}} peer nodes that you specified in the connection profile file you created in step three:
+Run the `composer network install` command to install the {{site.data.conrefs.composer_full}} runtime onto the {{site.data.conrefs.hlf_full}} peer nodes that you specified in the connection profile file you created in step three:
 
     composer network install -c PeerAdmin@fabric-network -a tutorial-network@0.0.1.bna
 

--- a/packages/composer-website/jekylldocs/tutorials/google_oauth2_rest.md
+++ b/packages/composer-website/jekylldocs/tutorials/google_oauth2_rest.md
@@ -147,15 +147,19 @@ The first line indicates the name of the business network card we will start the
 
 1. From the same directory as the `envvars.txt` file you created containing the environment variables, run the following command:
 
+```
      source envvars.txt
+```
 
 INFO	No output from command? - this is expected. If you did have a syntax error in your `envvars.txt` file then this will be indicated by an error, after running this command.
 
 2. Let’s now confirm that environment variables are indeed set by checking a couple of them using “echo” command as shown below
 
+```
     echo $COMPOSER_CARD
 
     echo $COMPOSER_PROVIDERS
+```
 
 <h2 class='everybody'> Step 5: Deploy the sample Commodities Trading Business network to query from REST client </h2>
 
@@ -169,10 +173,11 @@ INFO	No output from command? - this is expected. If you did have a syntax error 
 
 3. To deploy it, run the following sequence:
 
+```
     composer network install --card PeerAdmin@hlfv1 --archiveFile trade-network.bna
 
     composer network start --card PeerAdmin@hlfv1 --networkName trade-network --networkVersion **version** --networkAdmin admin --networkAdminEnrollSecret adminpw --file networkadmin.card
-
+```
 
 ![Deploy Business Network](../assets/img/tutorials/auth/deploy-network.png)
 
@@ -181,9 +186,11 @@ You should get confirmation that the Commodities Trading Business Network has be
 
 4. Next, import the business network card, and connect with the card to download the certs to the wallet:
 
+```
     composer card import -f networkadmin.card
 
     composer network ping -c admin@trade-network
+```
 
 You should get confirmation that the connectivity was successfully tested. We're now ready to work with the deployed business network.
 
@@ -193,16 +200,19 @@ You should get confirmation that the connectivity was successfully tested. We're
 
 1. Create a REST Adninistrator identity `restadmin` and an associated business network card (used to launch the REST server later).
 
+```
     composer participant add -c admin@trade-network -d '{"$class":"org.hyperledger.composer.system.NetworkAdmin", "participantId":"restadmin"}'
 
-     composer identity issue -c admin@trade-network -f restadmin.card -u restadmin -a "resource:org.hyperledger.composer.system.NetworkAdmin#restadmin"
+    composer identity issue -c admin@trade-network -f restadmin.card -u restadmin -a "resource:org.hyperledger.composer.system.NetworkAdmin#restadmin"
+```
 
 2. Import and test the card:
 
+```
     composer card import -f  restadmin.card
 
     composer network ping -c restadmin@trade-network
-
+```
 
 3. Because we are hosting our REST server in another location with its own specific network IP information, we need to update the connection.json - so that the docker hostnames (from within the persistent REST server instance) can resolve each other's IP addresses.
 
@@ -215,6 +225,7 @@ The one liner below will substitute the 'localhost' addresses with docker hostna
 
 1. Run the following docker command to launch a REST server instance (with the `restadmin` business network card)    
 
+```
     docker run \
     -d \
     -e COMPOSER_CARD=${COMPOSER_CARD} \
@@ -228,7 +239,7 @@ The one liner below will substitute the 'localhost' addresses with docker hostna
     --network composer_default \
     -p 3000:3000 \
     myorg/composer-rest-server
-
+```
 
 
 
@@ -236,10 +247,11 @@ This will output the ID of the Docker container eg . `690f2a5f10776c15c11d9def91
 
 2. Check that all is ok with our ocontainer - you can see that it is running using the following commands:
 
+```
     docker ps |grep rest
 
     docker logs rest
-
+```
 
 <h2 class='everybody'> Step 8:  Test the REST APIs are protected and require authorization   </h2>
 
@@ -264,22 +276,29 @@ You should get an Authorized error and that is because we have configured a Goog
 
 1. You need to create a set participant and identities for testing you can interact with the business network. This is because the REST server can handle multiple REST clients in multi-user mode. We will be using the composer CLI commands to add participants and identities as follows - first name is **Jo Doe**:
 
+```
     composer participant add -c admin@trade-network -d '{"$class":"org.acme.trading.Trader","tradeId":"trader1", "firstName":"Jo","lastName":"Doe"}'
 
     composer identity issue -c admin@trade-network -f jdoe.card -u jdoe -a "resource:org.acme.trading.Trader#trader1"
 
     composer card import -f jdoe.card
+```
 
 2. Once again, because we will use this identity to test inside the persistent REST docker container - we will need to change the hostnames to represent the docker resolvable hostnames - once again run this one-liner to carry out those changes quickly:
 
+```
     sed -e 's/localhost:/orderer.example.com:/' -e 's/localhost:/peer0.org1.example.com:/' -e 's/localhost:/peer0.org1.example.com:/' -e 's/localhost:/ca.org1.example.com:/'  < $HOME/.composer/cards/jdoe@trade-network/connection.json  > /tmp/connection.json && cp -p /tmp/connection.json $HOME/.composer/cards/jdoe@trade-network
+```
 
 3. We need to export the card to a file - to use for importing elsewhere  - ie the card that we will use to import to the wallet in our browser client - and therefore at this point, we can discard the initial business network card file for `jdoe`.
 
+```
      composer card export -f jdoe_exp.card -c jdoe@trade-network ; rm jdoe.card
+```
 
 4. Repeat the above steps for participant **Ken Coe** (`kcoe`) - creating a `trader2` participant and issuing the identity `kcoe` - the sequence of commands are:
 
+```
     composer participant add -c admin@trade-network -d '{"$class":"org.acme.trading.Trader","tradeId":"trader2", "firstName":"Ken","lastName":"Coe"}'
 
     composer identity issue -c admin@trade-network -f kcoe.card -u kcoe -a "resource:org.acme.trading.Trader#trader2"
@@ -289,6 +308,7 @@ You should get an Authorized error and that is because we have configured a Goog
     sed -e 's/localhost:/orderer.example.com:/' -e 's/localhost:/peer0.org1.example.com:/' -e 's/localhost:/peer0.org1.example.com:/' -e 's/localhost:/ca.org1.example.com:/'  < $HOME/.composer/cards/kcoe@trade-network/connection.json  > /tmp/connection.json && cp -p /tmp/connection.json $HOME/.composer/cards/kcoe@trade-network
 
     composer card export -f kcoe_exp.card -n kcoe@trade-network ; rm kcoe.card
+```
 
 These cards can now be imported, then used into the REST client (ie the browser) in the next section.
 
@@ -300,8 +320,8 @@ These cards can now be imported, then used into the REST client (ie the browser)
 
 2. Login using the following credentials: (example - as advised, you should set up your own per the instructions in the appendix section of this tutorial):
 
-Email: composeruser01@gmail.com
-Password: composer00
+- Email: composeruser01@gmail.com
+- Password: composer00
 
 3. You will be authenticated by Google and be redirected back to the REST server (http://localhost:3000/explorer) which shows the access token message in the top left-hand corner - click on 'Show' to view the token.
 

--- a/packages/composer-website/jekylldocs/tutorials/tutorials.md
+++ b/packages/composer-website/jekylldocs/tutorials/tutorials.md
@@ -12,7 +12,7 @@ excerpt: Tutorials
 
 ---
 
-We have four basic tutorial options, and two more advanced tutorials:
+We have several basic and advanced tutorials:
 
 ## Playground Tutorial
 


### PR DESCRIPTION
- identity list excerpt was wrong it was a copy of identity issue
- the tutorial count was wrong
- ACL bypassing needs to be highlighted more as it is a very important consideration
- redis cloud wallet not pointing to the correct npm module
- single org step 7 description incorrect
- outh2 tutorlal formatting was a mismatch of formatted and non formatted examples
- multi-org step 11,12 titles and description incorrect

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
