### PR TITLE
added network download & network reset to cli integration tests

### DIFF
--- a/packages/composer-tests-integration/features/cli-network.feature
+++ b/packages/composer-tests-integration/features/cli-network.feature
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
@@ -114,10 +114,38 @@ Feature: Cli network steps
         And The stdout information should include text matching /owner:    resource:org.hyperledger_composer.marbles.Player#bob/
         And The stdout information should include text matching /Command succeeded/
 
+    Scenario: Using the CLI, I can count the number of marbles
+        When I run the following expected pass CLI command
+            """
+            composer network list --card admin@marbles-network -r org.hyperledger_composer.marbles.NewMarble |grep 'marbleId:'|wc -l
+            """
+        Then The stdout information should include text matching /1/
+
+    Scenario: Using the CLI, I can reset the network to remove all assets
+        When I run the following expected pass CLI command
+            """
+            composer network reset -c admin@marbles-network
+            """
+
+    Scenario: Using the CLI, I can count the number of marbles
+        When I run the following expected pass CLI command
+            """
+            composer network list --card admin@marbles-network -r org.hyperledger_composer.marbles.NewMarble |grep 'marbleId:'|wc -l
+            """
+        Then The stdout information should include text matching /0/
+
+    Scenario: Using the CLI, I can download the BNA file for the running network
+        When I run the following expected pass CLI command
+            """
+            composer network download -c admin@marbles-network -a ./tmp/downloaded-marbles.bna
+            """
+        Then I have the following files
+            | ../tmp/downloaded-marbles.bna |
+
     Scenario: Using the CLI, I can create get back the log level of the running network
         When I run the following expected pass CLI command
             """
-            composer network loglevel --card admin@marbles-network 
+            composer network loglevel --card admin@marbles-network
             """
         Then The stdout information should include text matching /composer\[error\]:*/
         And The stdout information should include text matching /Command succeeded/
@@ -128,4 +156,4 @@ Feature: Cli network steps
             composer network loglevel --card admin@marbles-network --newlevel 'composer[debug]:acls'
             """
         Then The stdout information should include text matching /composer\[debug\]:acls/
-        And The stdout information should include text matching /Command succeeded/        
+        And The stdout information should include text matching /Command succeeded/


### PR DESCRIPTION
New integration tests to improve coverage of `composer network` sub-commands:
- `composer network download`
- `composer network reset`

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
