### PR TITLE
Improve model validation

### DIFF
--- a/packages/composer-common/lib/introspect/classdeclaration.js
+++ b/packages/composer-common/lib/introspect/classdeclaration.js
@@ -189,8 +189,8 @@ class ClassDeclaration extends Decorated {
         }
 
         if(this.idField) {
-            const field = this.getProperty(this.idField);
-            if(!field) {
+            const idField = this.getProperty(this.idField);
+            if(!idField) {
                 let formatter = Globalize('en').messageFormatter('classdeclaration-validate-identifiernotproperty');
                 throw new IllegalModelException(formatter({
                     'class': this.name,
@@ -199,7 +199,7 @@ class ClassDeclaration extends Decorated {
             }
             else {
                 // check that identifiers are strings
-                if(field.getType() !== 'String') {
+                if(idField.getType() !== 'String') {
                     let formatter = Globalize('en').messageFormatter('classdeclaration-validate-identifiernotstring');
                     throw new IllegalModelException( formatter({
                         'class': this.name,
@@ -207,13 +207,20 @@ class ClassDeclaration extends Decorated {
                     }),this.modelFile, this.ast.location);
                 }
 
-                if(field.isOptional()) {
+                if(idField.isOptional()) {
                     throw new IllegalModelException('Identifying fields cannot be optional.',this.modelFile, this.ast.location);
                 }
-                if(this.getSuperType()){
-                    if(field.getName() === this.getModelFile().getType(this.superType).getIdentifierFieldName()){
-                        throw new IllegalModelException('Identifier cannot extend from super type.');
+                if(this.getSuperType()) {
+                    // check this class doesn't declare the identifying field as a property.
+                    if(idField.getName() === this.getModelFile().getType(this.superType).getIdentifierFieldName()) {
+                        throw new IllegalModelException('Identifier from super class cannot be redeclared.', this.modelFile, this.ast.location);
                     }
+
+                    // TODO: This has been disabled pending major version bump and/or confirmation that this is illegal
+                    // As this class has an idField declared, check the superclass doesn't
+                    //if (this.getModelFile().getType(this.superType).getIdentifierFieldName()) {
+                    //    throw new IllegalModelException('Identifier defined in super class, identifiers cannot be overridden', this.modelFile, this.ast.location);
+                    //}
                 }
             }
         }

--- a/packages/composer-common/lib/introspect/eventdeclaration.js
+++ b/packages/composer-common/lib/introspect/eventdeclaration.js
@@ -53,8 +53,6 @@ class EventDeclaration extends ClassDeclaration {
      * @private
      */
     validate() {
-        super.validate();
-
         if(!this.isSystemType() && this.getName() === 'Event') {
             throw new IllegalModelException('Event is a reserved type name.', this.modelFile, this.ast.location);
         }
@@ -71,6 +69,9 @@ class EventDeclaration extends ClassDeclaration {
         if (!this.isSystemType() && this.idField && systemTypeDeclared) {
             throw new IllegalModelException('Event should not specify an identifying field.', this.modelFile, this.ast.location);
         }
+
+        // do generic validation after specific validation
+        super.validate();
     }
 
      /**

--- a/packages/composer-common/lib/introspect/transactiondeclaration.js
+++ b/packages/composer-common/lib/introspect/transactiondeclaration.js
@@ -55,8 +55,6 @@ class TransactionDeclaration extends ClassDeclaration {
      * @private
      */
     validate() {
-        super.validate();
-
         if(!this.isSystemType() && this.getName() === 'Transaction') {
             throw new IllegalModelException('Transaction is a reserved type name.', this.modelFile, this.ast.location);
         }
@@ -73,6 +71,9 @@ class TransactionDeclaration extends ClassDeclaration {
         if (!this.isSystemType() && this.idField && systemTypeDeclared) {
             throw new IllegalModelException('Transaction should not specify an identifying field.', this.modelFile, this.ast.location);
         }
+
+        // perform general validation after specific validation.
+        super.validate();
     }
 }
 

--- a/packages/composer-common/test/data/parser/classdeclaration.classoverridesidentifier.cto
+++ b/packages/composer-common/test/data/parser/classdeclaration.classoverridesidentifier.cto
@@ -14,5 +14,9 @@
 
 namespace com.testing
 
-asset someAsset {
+abstract asset p1 identified by a1 {
+o String a1
+}
+asset p2 identified by a2 extends p1 {
+o String a2
 }

--- a/packages/composer-common/test/data/parser/transactiondeclaration.definesidentifier.cto
+++ b/packages/composer-common/test/data/parser/transactiondeclaration.definesidentifier.cto
@@ -14,5 +14,6 @@
 
 namespace com.testing
 
-asset someAsset {
+transaction t1 identified by i1 {
+    o String i1
 }

--- a/packages/composer-common/test/introspect/introspectutils.js
+++ b/packages/composer-common/test/introspect/introspectutils.js
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+const ModelFile = require('../../lib/introspect/modelfile');
+const ModelManager = require('../../lib/modelmanager');
+const fs = require('fs');
+
+/**
+ * Some useful utils
+ *
+ * @class IntrospectUtils
+ */
+class IntrospectUtils {
+
+    /**
+     * Creates an instance of IntrospectUtils.
+     * @param {ModelManager} modelManager optional modelManager
+     */
+    constructor(modelManager) {
+        if (!modelManager) {
+            this.modelManager = new ModelManager();
+        } else {
+            this.modelManager = modelManager;
+        }
+    }
+
+    /**
+     * Load an arbitrary number of model files.
+     * @param {String[]} modelFileNames array of model file names.
+     * @param {ModelManager} modelManager the model manager to which the created model files will be registered.
+     * @return {ModelFile[]} array of loaded model files, matching the supplied arguments.
+     */
+    loadModelFiles(modelFileNames) {
+        const modelFiles = [];
+        for (let modelFileName of modelFileNames) {
+            const modelDefinitions = fs.readFileSync(modelFileName, 'utf8');
+            const modelFile = new ModelFile(this.modelManager, modelDefinitions);
+            modelFiles.push(modelFile);
+        }
+        return modelFiles;
+    }
+
+    /**
+     * load a specific model file
+     * @param {String} modelFileName the name of te model file
+     * @returns {ModelFile} a model file
+     */
+    loadModelFile(modelFileName) {
+        return this.loadModelFiles([modelFileName], this.modelManager)[0];
+    }
+
+    /**
+     * load the last declaration in a model file
+     * @param {String} modelFileName the name of the model file
+     * @param {type} type the type of declaration
+     * @returns {type} the declaration
+     */
+    loadLastDeclaration(modelFileName, type) {
+        const modelFile = this.loadModelFile(modelFileName);
+        const declarations = modelFile.getDeclarations(type);
+        return declarations[declarations.length - 1];
+    }
+}
+module.exports = IntrospectUtils;

--- a/packages/composer-common/test/introspect/transactiondeclaration.js
+++ b/packages/composer-common/test/introspect/transactiondeclaration.js
@@ -18,6 +18,7 @@ const TransactionDeclaration = require('../../lib/introspect/transactiondeclarat
 const ClassDeclaration = require('../../lib/introspect/classdeclaration');
 const ModelFile = require('../../lib/introspect/modelfile');
 const ModelManager = require('../../lib/modelmanager');
+const IntrospectUtils = require('./introspectutils');
 
 require('chai').should();
 const sinon = require('sinon');
@@ -87,6 +88,15 @@ describe('TransactionDeclaration', () => {
                 td.validate();
             }).should.throw(/Transaction should not specify an identifying field./);
         });
+
+        it('should throw if transaction specifies and identifying field', () => {
+            const introspectUtils = new IntrospectUtils();
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/transactiondeclaration.definesidentifier.cto', TransactionDeclaration);
+            (() => {
+                asset.validate();
+            }).should.throw(/Transaction should not specify an identifying field./);
+        });
+
     });
 
 });


### PR DESCRIPTION
This improves the error message when you try to redeclare and identifier field
Also ensures that you get the transaction specific error rather than the generic class error
Provides a commented out block of code for more validation which is awaiting feedback and a major version bump.

closes #2973

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>