### PR TITLE
Dropdown in docs does not show the version number of the different version names #3757

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ packages/composer-playground/e2e/downloads/
 
 package-lock.json
 packages/composer-tests-functional/storage
+yarn.lock

--- a/packages/composer-website/jekylldocs/_layouts/default.html
+++ b/packages/composer-website/jekylldocs/_layouts/default.html
@@ -26,11 +26,6 @@ markdown: 0
           </div>
 
           <select id="version" name="version" onchange="location = this.options[this.selectedIndex].value;">
-              <option>Select version</option>
-              <option value="/composer/latest/introduction/introduction.html" title="The most stable version of Composer">Latest</option>
-              <option value="/composer/unstable/introduction/introduction.html" title="The version that will replace Latest">Latest-unstable</option>
-              <option value="/composer/next/introduction/introduction.html" title="The most ready version of the next generation of Composer, new features (possibly breaking) and many fixes">Next</option>
-              <option value="/composer/next-unstable/introduction/introduction.html" title="The closest to the development stream of Composer, expect breaking changes">Next-unstable</option>
           </select>
 
             <div class="search-form">
@@ -136,4 +131,5 @@ markdown: 0
 })(document);
 </script>
 <script src="{{site.baseurl}}/assets/js/nav.js"></script>
+<script src="{{site.baseurl}}/assets/js/version_fetch.js"></script>
 <script src="{{site.baseurl}}/assets/js/search_bar.js"></script>

--- a/packages/composer-website/jekylldocs/assets/js/version_fetch.js
+++ b/packages/composer-website/jekylldocs/assets/js/version_fetch.js
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+$(document).ready(function() {
+    $.ajax({
+        url: 'https://api.github.com/repos/hyperledger/composer/releases',
+        data: {
+           format: 'json'
+        },
+        error: function() {
+           console.log("Uh Oh, Error fetching Versions")
+        },
+        dataType: 'jsonp',
+        success: function(data) {
+           parseVersionResponse(data);
+        },
+        type: 'GET'
+     });
+});
+
+/**
+ * Parses the json response from the GitHubAPI endpoint
+ * and then append the 4 most recent release options
+ * to the #version input
+ *
+ * @param {JSON} JSON object containing information on repo by tag.
+ */
+function parseVersionResponse(response) {
+    var versionArr = response.data;
+
+    // Sorting required due to the possibillity of older versions being revisted, and updated thorwing off response order reliabillity. ex. v0.16.6
+    var sortedArr = versionArr.map(x => x["tag_name"].slice(1)).sort().reverse();
+    for (var i = 0; i < 4; i++) {
+        switch (i) {
+            case 0:
+                $("#version").prepend(
+                    $("<option>").attr(
+                        "value",
+                        "/composer/next-unstable/introduction/introduction.html"
+                    ).attr(
+                        "title",
+                        "The closest to the development stream of Composer, expect breaking changes"
+                    ).text(
+                        "Next-Unstable" + " (v" + sortedArr[0] + ")"
+                    )
+                );
+                break;
+            case 1:
+                $("#version").prepend(
+                    $("<option>").attr(
+                        "value",
+                        "/composer/next/introduction/introduction.html"
+                    ).attr(
+                        "title",
+                        "The most ready version of the next generation of Composer, new features (possibly breaking) and many fixes"
+                    ).text(
+                        "Next" + " (v" + sortedArr[1] + ")"
+                    )
+                );
+                break;
+            case 2:
+                $("#version").prepend(
+                    $("<option>").attr(
+                        "value",
+                        "/composer/unstable/introduction/introduction.html"
+                    ).attr(
+                        "title",
+                        "The version that will replace Latest"
+                    ).text(
+                        "Latest-Unstable" + " (v" + sortedArr[2] + ")"
+                    )
+                );
+                break;
+            case 3:
+                $("#version").prepend(
+                    $("<option>").attr(
+                        "value",
+                        "/composer/latest/introduction/introduction.html"
+                    ).attr(
+                        "title",
+                        "The most stable version of Composer"
+                    ).text(
+                        "Latest" + " (v" + sortedArr[3] + ")"
+                    )
+                );
+                break;
+        }
+    }
+    $("#version").prepend(
+        $("<option  selected disabled hidden>").text(
+            "Select version"
+        )
+    );
+}


### PR DESCRIPTION
Created simple ajax request to hit [GitHub public API's release's endpoint](https://api.github.com/repos/hyperledger/composer/releases) in attempt to resolve [Issue #3757 ](https://github.com/hyperledger/composer/issues/3757) for Hyperledger Composer's site doc's.