### PR TITLE
Dropdown in docs does not show the version number of the different version names #3757

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ packages/composer-playground/e2e/downloads/
 
 package-lock.json
 packages/composer-tests-functional/storage
+yarn.lock

--- a/packages/composer-website/jekylldocs/_layouts/default.html
+++ b/packages/composer-website/jekylldocs/_layouts/default.html
@@ -26,11 +26,6 @@ markdown: 0
           </div>
 
           <select id="version" name="version" onchange="location = this.options[this.selectedIndex].value;">
-              <option>Select version</option>
-              <option value="/composer/latest/introduction/introduction.html" title="The most stable version of Composer">Latest</option>
-              <option value="/composer/unstable/introduction/introduction.html" title="The version that will replace Latest">Latest-unstable</option>
-              <option value="/composer/next/introduction/introduction.html" title="The most ready version of the next generation of Composer, new features (possibly breaking) and many fixes">Next</option>
-              <option value="/composer/next-unstable/introduction/introduction.html" title="The closest to the development stream of Composer, expect breaking changes">Next-unstable</option>
           </select>
 
             <div class="search-form">
@@ -135,5 +130,7 @@ markdown: 0
     });
 })(document);
 </script>
+
 <script src="{{site.baseurl}}/assets/js/nav.js"></script>
+<script src="{{site.baseurl}}/assets/js/version_fetch.js"></script>
 <script src="{{site.baseurl}}/assets/js/search_bar.js"></script>

--- a/packages/composer-website/jekylldocs/assets/js/version_fetch.js
+++ b/packages/composer-website/jekylldocs/assets/js/version_fetch.js
@@ -1,0 +1,36 @@
+$.ajax({
+    url: 'https://api.github.com/repos/hyperledger/composer/releases',
+    data: {
+       format: 'json'
+    },
+    error: function() {
+       console.log("Uh Oh, Error fetching Versions")
+    },
+    dataType: 'jsonp',
+    success: function(data) {
+        var should = require('chai').should() //actually call the function
+        , foo = data.data';
+    },
+    type: 'GET'
+ });
+
+describe('Array', function() {
+  it('should start empty', function() {
+    var arr = [];
+    $.ajax({
+        url: 'https://api.github.com/repos/hyperledger/composer/releases',
+        data: {
+           format: 'json'
+        },
+        error: function() {
+           console.log("Uh Oh, Error fetching Versions")
+        },
+        dataType: 'jsonp',
+        success: function(data) {
+           arr = data.data;
+        },
+        type: 'GET'
+     });
+    assert.equal(arr.length, 0);
+  });
+});


### PR DESCRIPTION
Simple on page load jQuery Ajax function that calls [GitHub's Public API Release's Endpoint](https://api.github.com/repos/hyperledger/composer/releases), and parses the json response, appending the 4 most recent release (in order of release number). Attempt to resolve [Issue #3757 ](https://github.com/hyperledger/composer/issues/3757) .