### PR TITLE
Fixes reference to connector specific info in docs

### DIFF
--- a/packages/composer-website/jekylldocs/managing/connector-information.md
+++ b/packages/composer-website/jekylldocs/managing/connector-information.md
@@ -50,7 +50,7 @@ Supply the fully qualified filename as part of an install command, for example i
 in your /home/user1/config directory:
 
 ```
-composer network install -c PeerAdmin@hlfv1 -n digitalproperty-network -o npmrcFile=/home/user1/config/npmConfig
+composer network install --c PeerAdmin@hlfv1 --a tutorial-network@0.0.1.bna -o npmrcFile=/home/user1/config/npmConfig
 ```
 
 The file contents can be anything that permitted in the `.npmrc` configuration files of npm.

--- a/packages/composer-website/jekylldocs/reference/composer.identity.issue.md
+++ b/packages/composer-website/jekylldocs/reference/composer.identity.issue.md
@@ -59,3 +59,5 @@ Example: `resource:net.biz.tutorial-network.Person#DanSelman@biznet.org`
 
 `--issuer, -x`
 Whether the new identity will be able to issue other new identities.
+
+Please refer to [Connector specific information](../managing/connector-information.html) for more information about connecting to {{site.data.conrefs.hlf_full}} {{site.data.conrefs.hlf_latest}}.

--- a/packages/composer-website/jekylldocs/reference/composer.network.install.md
+++ b/packages/composer-website/jekylldocs/reference/composer.network.install.md
@@ -28,3 +28,5 @@ Options:
   --option, -o       Options that are specific specific to connection. Multiple options are specified by repeating this option  [string]
   --optionsFile, -O  A file containing options that are specific to connection  [string]  
 ```
+
+Please refer to [Connector specific information](../managing/connector-information.html) for more information about connecting to {{site.data.conrefs.hlf_full}} {{site.data.conrefs.hlf_latest}}.

--- a/packages/composer-website/jekylldocs/reference/composer.network.start.md
+++ b/packages/composer-website/jekylldocs/reference/composer.network.start.md
@@ -39,5 +39,4 @@ Options:
   --card, -c                         The cardname to use to start the network  [string] [required]
   --file, -f                         File name of the card to be created  [string]
   ```
-Please refer to [Connector specific information](../managing/connector-information.html) for more information about connector specific options.
-
+Please refer to [Connector specific information](../managing/connector-information.html) for more information about connecting to {{site.data.conrefs.hlf_full}} {{site.data.conrefs.hlf_latest}}.

--- a/packages/composer-website/jekylldocs/reference/composer.network.upgrade.md
+++ b/packages/composer-website/jekylldocs/reference/composer.network.upgrade.md
@@ -33,4 +33,4 @@ Options:
   --optionsFile, -O          A file containing options that are specific to connection  [string]
 ```
 
-Please refer to [Connector specific information](../managing/connector-information.html) for more information about connector specific options.
+Please refer to [Connector specific information](../managing/connector-information.html) for more information about connecting to {{site.data.conrefs.hlf_full}} {{site.data.conrefs.hlf_latest}}.


### PR DESCRIPTION
closes #3845
closes #3824

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
