### PR TITLE
Add stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,20 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - good first issue
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  any recent activity. It will be closed if no further activity occurs in
+  the next 14 days. Thank you for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because no further activity
+  occurred. If you believe the issue is still relevant, please
+  either reopen this issue, open a new issue, or contact one of the
+  [project maintainers](MAINTAINERS.md)


### PR DESCRIPTION
Initial stale.yml to mark issues as stale after 60 days, and
subsequently close 14 days later

Signed-off-by: James Taylor <jamest@uk.ibm.com>