### PR TITLE
Add failure scenarios to invoking other chaincode

### DIFF
--- a/packages/composer-tests-functional/systest/data/common-network/transactions.cto
+++ b/packages/composer-tests-functional/systest/data/common-network/transactions.cto
@@ -182,3 +182,9 @@ transaction AdvancedInvokeChainCodeTransaction {
     o String expectedValue
 }
 
+transaction AdvancedInvokeChainCodeError {
+    o String channel
+    o String chainCodeName
+}
+
+

--- a/packages/composer-tests-functional/systest/data/common-network/transactions.js
+++ b/packages/composer-tests-functional/systest/data/common-network/transactions.js
@@ -502,3 +502,39 @@ async function AdvancedInvokeChainCodeTransaction (transaction) {
 
     assertEqual('string value', asset.stringValue, expectedValue);
 }
+
+/**
+ * handle function with native api
+ * @param {systest.transactions.AdvancedInvokeChainCodeError} transaction The transaction
+ * @transaction
+ * @return {Promise} A promise that is resolved when complete.
+ */
+async function AdvancedInvokeChainCodeError (transaction) {
+    const channel = transaction.channel;
+    const chainCodeName = transaction.chainCodeName;
+
+    // 0 = ok, 1 = wrong error message, 2 = no error message
+    let resultOfTest = 2;
+    let error;
+    try {
+        await getNativeAPI().invokeChaincode(chainCodeName, ['getResourceInRegistry', 'Asset', 'systest.transactions.assets.SimpleStringAsset'], channel);
+    } catch(err) {
+        resultOfTest = 0;
+        if (err.message.match(/Invalid arguments .* to function .*, expecting/) === null) {
+            error = err;
+            resultOfTest = 1;
+        }
+    }
+
+    switch(resultOfTest) {
+    case 1:
+        throw new Error('unexpected error received: ' + error.message);
+    case 2:
+        throw new Error('expected an error to be thrown, but no error was thrown');
+    case 0:
+        break;
+    default:
+        throw new Error('ok, this should never have happened.');
+    }
+
+}

--- a/packages/composer-tests-functional/systest/testutil.js
+++ b/packages/composer-tests-functional/systest/testutil.js
@@ -28,7 +28,7 @@ let currentCp;
 let connectionProfileOrg1, connectionProfileOrg2, otherConnectionProfileOrg1, otherConnectionProfileOrg2;
 let docker;
 let forceDeploy = false;
-let testRetries = 4;
+let testRetries = 0;
 
 let io;
 

--- a/packages/composer-tests-functional/systest/transactions.native.js
+++ b/packages/composer-tests-functional/systest/transactions.native.js
@@ -228,7 +228,6 @@ describe('Native API', function () {
 
                 // test invocation of chaincode that does throw an error
                 transaction = factory.newTransaction('systest.transactions', 'AdvancedInvokeChainCodeError');
-                transaction.assetId = 'assetOnDifferentNetwork';
                 transaction.channel = 'composerchannel';
                 transaction.chainCodeName = 'systest-other-network';
                 await client.submitTransaction(transaction);
@@ -280,7 +279,6 @@ describe('Native API', function () {
 
                 // test invocation of chaincode that does throw an eror
                 transaction = factory.newTransaction('systest.transactions', 'AdvancedInvokeChainCodeError');
-                transaction.assetId = 'assetOnDifferentNetwork';
                 transaction.channel = 'othercomposerchannel';
                 transaction.chainCodeName = 'systest-other-channel-network';
                 await client.submitTransaction(transaction);

--- a/packages/composer-tests-functional/systest/transactions.native.js
+++ b/packages/composer-tests-functional/systest/transactions.native.js
@@ -217,12 +217,20 @@ describe('Native API', function () {
                 await otherNewClient.ping();
 
                 let factory = client.getBusinessNetwork().getFactory();
+
+                // test invocation of chaincode the doesn't throw an error
                 let transaction = factory.newTransaction('systest.transactions', 'AdvancedInvokeChainCodeTransaction');
                 transaction.assetId = 'assetOnDifferentNetwork';
                 transaction.channel = 'composerchannel';
                 transaction.expectedValue = 'hello new world';
                 transaction.chainCodeName = 'systest-other-network';
+                await client.submitTransaction(transaction);
 
+                // test invocation of chaincode that does throw an error
+                transaction = factory.newTransaction('systest.transactions', 'AdvancedInvokeChainCodeError');
+                transaction.assetId = 'assetOnDifferentNetwork';
+                transaction.channel = 'composerchannel';
+                transaction.chainCodeName = 'systest-other-network';
                 await client.submitTransaction(transaction);
             }
         });
@@ -261,13 +269,22 @@ describe('Native API', function () {
                 await otherNewClient.ping();
 
                 let factory = client.getBusinessNetwork().getFactory();
+
+                // test invocation of chaincode that doesn't throw an error
                 let transaction = factory.newTransaction('systest.transactions', 'AdvancedInvokeChainCodeTransaction');
                 transaction.assetId = 'assetOnDifferentNetwork';
                 transaction.channel = 'othercomposerchannel';
                 transaction.expectedValue = 'hello new world channel';
                 transaction.chainCodeName = 'systest-other-channel-network';
-
                 await client.submitTransaction(transaction);
+
+                // test invocation of chaincode that does throw an eror
+                transaction = factory.newTransaction('systest.transactions', 'AdvancedInvokeChainCodeError');
+                transaction.assetId = 'assetOnDifferentNetwork';
+                transaction.channel = 'othercomposerchannel';
+                transaction.chainCodeName = 'systest-other-channel-network';
+                await client.submitTransaction(transaction);
+
             }
         });
     });


### PR DESCRIPTION
Adds tests to show that errors returned from chaincode invocation are received.
closes #3415
Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
