### PR TITLE
Change suggested dir name for fabric dev servers

### DIFF
--- a/packages/composer-website/jekylldocs/applications/web.md
+++ b/packages/composer-website/jekylldocs/applications/web.md
@@ -34,10 +34,10 @@ If you already have a Business Network Archive and would like to build a skeleto
 
 If you have already installed the development tools you will have {{site.data.conrefs.hlf_full}} already installed.
 
-Head to the `fabric-tools` directory and start {{site.data.conrefs.hlf_full}}. The following code is an example if you have used our development tools install guide:
+Head to the `fabric-dev-servers` directory and start {{site.data.conrefs.hlf_full}}. The following code is an example if you have used our development tools install guide:
 
 ```bash
-cd ~/fabric-tools
+cd ~/fabric-dev-servers
 ./startFabric.sh
 ./createPeerAdminCard.sh
 ```

--- a/packages/composer-website/jekylldocs/installing/development-tools.md
+++ b/packages/composer-website/jekylldocs/installing/development-tools.md
@@ -60,9 +60,9 @@ Whilst the browser app _can_ be used to work on your Business Network code, most
 ### Step 4: Install {{site.data.conrefs.hlf_full}}
 This step gives you a local {{site.data.conrefs.hlf_full}} runtime to deploy your business networks to.
 
-8. In a directory of your choice (we will assume `~/fabric-tools`), get the `.tar.gz` file that contains the tools to install {{site.data.conrefs.hlf_full}}:
+8. In a directory of your choice (we will assume `~/fabric-dev-servers`), get the `.tar.gz` file that contains the tools to install {{site.data.conrefs.hlf_full}}:
 
-        mkdir ~/fabric-tools && cd ~/fabric-tools
+        mkdir ~/fabric-dev-servers && cd ~/fabric-dev-servers
 
         curl -O https://raw.githubusercontent.com/hyperledger/composer-tools/master/packages/fabric-dev-servers/fabric-dev-servers.tar.gz
         tar -xvf fabric-dev-servers.tar.gz
@@ -72,7 +72,7 @@ This step gives you a local {{site.data.conrefs.hlf_full}} runtime to deploy you
 
 9. Use the scripts you just downloaded and extracted to download a local {{site.data.conrefs.hlf_full}} runtime:
 
-        cd ~/fabric-tools
+        cd ~/fabric-dev-servers
         ./downloadFabric.sh
 
 > Congratulations, you've now installed everything required for the typical Developer Environment.
@@ -81,17 +81,17 @@ Read on to learn some of the most common things you'll do with this environment 
 # Controlling your dev environment
 
 ## Starting and stopping {{site.data.conrefs.hlf_full}}
-You control your runtime using a set of scripts which you'll find in `~/fabric-tools` if you followed the suggested defaults.  
+You control your runtime using a set of scripts which you'll find in `~/fabric-dev-servers` if you followed the suggested defaults.  
 
 The first time you start up a new runtime, you'll need to run the start script, then generate a PeerAdmin card:
 
-        cd ~/fabric-tools
+        cd ~/fabric-dev-servers
         ./startFabric.sh
         ./createPeerAdminCard.sh
 
-You can start and stop your runtime using `~/fabric-tools/stopFabric.sh`, and start it again with `~/fabric-tools/startFabric.sh`.
+You can start and stop your runtime using `~/fabric-dev-servers/stopFabric.sh`, and start it again with `~/fabric-dev-servers/startFabric.sh`.
 
-At the end of your development session, you run `~/fabric-tools/stopFabric.sh` and then `~/fabric-tools/teardownFabric.sh`.  Note that if you've run the teardown script, the next time you start the runtime, you'll need to create a new PeerAdmin card just like you did on first time startup.
+At the end of your development session, you run `~/fabric-dev-servers/stopFabric.sh` and then `~/fabric-dev-servers/teardownFabric.sh`.  Note that if you've run the teardown script, the next time you start the runtime, you'll need to create a new PeerAdmin card just like you did on first time startup.
 
 > The local runtime is intended to be frequently started, stopped and torn down, for development use.  If you're looking for a runtime with more persistent state, you'll want to run one outside of the dev environment, and deploy Business Networks to it.  Examples of this include running it via Kubernetes, or on a managed platform such as IBM Cloud.
 

--- a/packages/composer-website/jekylldocs/tutorials/deploy-to-fabric-multi-org.md
+++ b/packages/composer-website/jekylldocs/tutorials/deploy-to-fabric-multi-org.md
@@ -41,7 +41,7 @@ Let's get started!
 
 If you have previously installed the Composer development environment, you will need to first tear down the {{site.data.conrefs.hlf_full}} containers provided by the development environment:
 
-    cd ~/fabric-tools
+    cd ~/fabric-dev-servers
     ./stopFabric.sh
     ./teardownFabric.sh
 

--- a/packages/composer-website/jekylldocs/tutorials/deploy-to-fabric-single-org.md
+++ b/packages/composer-website/jekylldocs/tutorials/deploy-to-fabric-single-org.md
@@ -28,7 +28,7 @@ The tutorial will assume that you use the simple {{site.data.conrefs.hlf_full}} 
 
 1. Start a clean {{site.data.conrefs.hlf_full}} by running the following commands:
 
-        cd ~/fabric-tools
+        cd ~/fabric-dev-servers
         ./stopFabric.sh
         ./teardownFabric.sh
         ./downloadFabric.sh
@@ -53,11 +53,11 @@ The simple {{site.data.conrefs.hlf_full}} network provided in the development en
 
 The configuration for `cryptogen` is stored in the file:
 
-    ~/fabric-tools/fabric-scripts/hlfv11/composer/crypto-config.yaml
+    ~/fabric-dev-servers/fabric-scripts/hlfv11/composer/crypto-config.yaml
 
 The configuration for `configtxgen` is stored in the file:
 
-    ~/fabric-tools/fabric-scripts/hlfv11/composer/configtx.yaml
+    ~/fabric-dev-servers/fabric-scripts/hlfv11/composer/configtx.yaml
 
 You can find more information about these configuration tools, what they do, and how to use them by reading the {{site.data.conrefs.hlf_full}} documentation.
 
@@ -87,7 +87,7 @@ The organization `Org1` is configured with a user named `Admin@org1.example.com`
 
 The user `Admin@org1.example.com` has a set of certificates and private key files stored in the directory:
 
-    ~/fabric-tools/fabric-scripts/hlfv11/composer/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
+    ~/fabric-dev-servers/fabric-scripts/hlfv11/composer/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
 
 You will use some of these files later on to interact with the {{site.data.conrefs.hlf_full}} network.
 
@@ -281,7 +281,7 @@ In order to deploy a blockchain business network to this {{site.data.conrefs.hlf
 
 The administrator for our {{site.data.conrefs.hlf_full}} network is a user called `Admin@org1.example.com`. The certificates and private key files for this user are stored in the directory:
 
-    ~/fabric-tools/fabric-scripts/hlfv11/composer/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
+    ~/fabric-dev-servers/fabric-scripts/hlfv11/composer/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
 
 You must first locate the certificate file for this user. The certificate is the public part of the identity. The certificate file can be found in the `signcerts` subdirectory and is named `Admin@org1.example.com-cert.pem`. If you look at the contents of this file, then you will find a PEM encoded certificate similar to the following:
 

--- a/packages/composer-website/jekylldocs/tutorials/invoke-composer-network.md
+++ b/packages/composer-website/jekylldocs/tutorials/invoke-composer-network.md
@@ -24,7 +24,7 @@ The tutorial will assume that you use the simple {{site.data.conrefs.hlf_full}} 
 
 1. Start a clean {{site.data.conrefs.hlf_full}} by running the following commands:
 
-        cd ~/fabric-tools
+        cd ~/fabric-dev-servers
         ./stopFabric.sh
         ./teardownFabric.sh
         ./downloadFabric.sh


### PR DESCRIPTION
Replaced fabric-tools with fabric-dev-servers in documentation

Closes #3296

Signed-off-by: James Taylor <jamest@uk.ibm.com>