### PR TITLE
rewrite and fix query generator for combination operator

### DIFF
--- a/packages/composer-runtime/lib/querycompiler.js
+++ b/packages/composer-runtime/lib/querycompiler.js
@@ -517,7 +517,7 @@ class QueryCompiler {
 
         const eliminateAND = function (lhs, rhs) {
             const combined = {};
-            if(typeof lhs === 'object' && typeof rhs === 'object') {
+            if(typeof lhs === 'object' && typeof rhs === 'object' && !(lhs.hasOwnProperty('$or') && rhs.hasOwnProperty('$or'))) {
                 // put all the selectors in the lhs in the combined selector
                 const leftProperties = Object.getOwnPropertyDescriptors(lhs);
                 const rightProperties = Object.getOwnPropertyDescriptors(rhs);


### PR DESCRIPTION
The implementation of the combination operator in the query compiler has evolved in response to various past issues.  Now is a good time to revisit the underlying algorithm and re-implement the logic.  This also resolves #3771 

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
