### PR TITLE
Enable generated app to accept REST server URLs for multiple business networks

### DIFF
--- a/packages/generator-hyperledger-composer/generators/angular/index.js
+++ b/packages/generator-hyperledger-composer/generators/angular/index.js
@@ -28,6 +28,8 @@ const { URL } = require('url');
 
 let businessNetworkConnection;
 let businessNetworkDefinition;
+let businessNetworkName;
+let businessNetworkVersion;
 let businessNetworkIdentifier;
 let modelManager;
 let assetList = [];
@@ -384,6 +386,8 @@ module.exports = yeoman.Base.extend({
 
         let createdApp = new Promise((resolve, reject) => {
 
+            businessNetworkName = businessNetworkDefinition.getName();
+            businessNetworkVersion = businessNetworkDefinition.getVersion();
             businessNetworkIdentifier = businessNetworkDefinition.getIdentifier();
             introspector = businessNetworkDefinition.getIntrospector();
 
@@ -899,6 +903,8 @@ module.exports = yeoman.Base.extend({
             authorName: this.authorName,
             authorEmail: this.authorEmail,
             license: this.license,
+            businessNetworkName: businessNetworkName,
+            businessNetworkVersion: businessNetworkVersion,
             businessNetworkIdentifier: businessNetworkIdentifier,
             assetList: assetList,
             assetServiceNames: assetServiceNames,

--- a/packages/generator-hyperledger-composer/generators/angular/templates/proxy.conf.js
+++ b/packages/generator-hyperledger-composer/generators/angular/templates/proxy.conf.js
@@ -12,14 +12,31 @@
  * limitations under the License.
  */
 
+function getTarget() {
+    if (process.env.REST_SERVER_URLS) {
+        const restServerURLs = JSON.parse(process.env.REST_SERVER_URLS);
+        const restServerURL = restServerURLs['<%= businessNetworkName %>'];
+        if (restServerURL) {
+            return restServerURL;
+        }
+    }
+    if (process.env.REST_SERVER_URL) {
+        const restServerURL = process.env.REST_SERVER_URL;
+        return restServerURL;
+    }
+    return '<%= apiURL %>';
+}
+
+const target = getTarget();
+
 module.exports = [{
     context: ['/auth', '/api'],
-    target: process.env.REST_SERVER_URL || '<%= apiURL %>',
+    target,
     secure: true,
     changeOrigin: true
 }, {
     context: '/',
-    target: process.env.REST_SERVER_URL || '<%= apiURL %>',
+    target,
     secure: true,
     changeOrigin: true,
     ws: true,

--- a/packages/generator-hyperledger-composer/test/angular-network.js
+++ b/packages/generator-hyperledger-composer/test/angular-network.js
@@ -77,6 +77,16 @@ describe('hyperledger-composer:angular for digitalPropertyNetwork running agains
 
     });
 
+    beforeEach(() => {
+        delete process.env.REST_SERVER_URL;
+        delete process.env.REST_SERVER_URLS;
+    });
+
+    afterEach(() => {
+        delete process.env.REST_SERVER_URL;
+        delete process.env.REST_SERVER_URLS;
+    });
+
     it('creates typescript classes', function(){
         assert.file(tmpDir+'/digitalPropertyNetwork/src/app/net.biz.digitalPropertyNetwork.ts');
     });
@@ -230,6 +240,92 @@ describe('hyperledger-composer:angular for digitalPropertyNetwork running agains
 
     it('should create a suitable proxy.conf.js file', () => {
         const filePath = tmpDir + '/digitalPropertyNetwork/proxy.conf.js';
+        delete require.cache[require.resolve(filePath)];
+        const proxyConfig = require(filePath);
+        assert(typeof proxyConfig[1].bypass === 'function', 'no bypass function');
+        delete proxyConfig[1].bypass;
+        assert.deepStrictEqual(proxyConfig, [
+            {
+                changeOrigin: true,
+                context: [
+                    '/auth',
+                    '/api'
+                ],
+                secure: true,
+                target: 'http://localhost:3000'
+            },
+            {
+                changeOrigin: true,
+                context: '/',
+                secure: true,
+                target: 'http://localhost:3000',
+                ws: true
+            }
+        ], 'proxy configuration is wrong');
+    });
+
+    it('should create a suitable proxy.conf.js file that uses a REST server URL from the environment', () => {
+        process.env.REST_SERVER_URL = 'https://doges-other-rest-server.dogecorp.com:9999';
+        const filePath = tmpDir + '/digitalPropertyNetwork/proxy.conf.js';
+        delete require.cache[require.resolve(filePath)];
+        const proxyConfig = require(filePath);
+        assert(typeof proxyConfig[1].bypass === 'function', 'no bypass function');
+        delete proxyConfig[1].bypass;
+        assert.deepStrictEqual(proxyConfig, [
+            {
+                changeOrigin: true,
+                context: [
+                    '/auth',
+                    '/api'
+                ],
+                secure: true,
+                target: 'https://doges-other-rest-server.dogecorp.com:9999'
+            },
+            {
+                changeOrigin: true,
+                context: '/',
+                secure: true,
+                target: 'https://doges-other-rest-server.dogecorp.com:9999',
+                ws: true
+            }
+        ], 'proxy configuration is wrong');
+    });
+
+    it('should create a suitable proxy.conf.js file that uses a REST server URL from the environment for this business network', () => {
+        process.env.REST_SERVER_URLS = JSON.stringify({
+            'digitalproperty-network': 'https://doges-other-rest-server.dogecorp.com:9999'
+        });
+        const filePath = tmpDir + '/digitalPropertyNetwork/proxy.conf.js';
+        delete require.cache[require.resolve(filePath)];
+        const proxyConfig = require(filePath);
+        assert(typeof proxyConfig[1].bypass === 'function', 'no bypass function');
+        delete proxyConfig[1].bypass;
+        assert.deepStrictEqual(proxyConfig, [
+            {
+                changeOrigin: true,
+                context: [
+                    '/auth',
+                    '/api'
+                ],
+                secure: true,
+                target: 'https://doges-other-rest-server.dogecorp.com:9999'
+            },
+            {
+                changeOrigin: true,
+                context: '/',
+                secure: true,
+                target: 'https://doges-other-rest-server.dogecorp.com:9999',
+                ws: true
+            }
+        ], 'proxy configuration is wrong');
+    });
+
+    it('should create a suitable proxy.conf.js file that ignores a REST server URL from the environment for another business network', () => {
+        process.env.REST_SERVER_URLS = JSON.stringify({
+            'someother-network': 'https://doges-other-rest-server.dogecorp.com:9999'
+        });
+        const filePath = tmpDir + '/digitalPropertyNetwork/proxy.conf.js';
+        delete require.cache[require.resolve(filePath)];
         const proxyConfig = require(filePath);
         assert(typeof proxyConfig[1].bypass === 'function', 'no bypass function');
         delete proxyConfig[1].bypass;


### PR DESCRIPTION
https://github.com/hyperledger/composer/issues/3802

Allow proxy configuration to accept an override for the REST server URL in two environments:

## REST_SERVER_URL

This went in the first drop - a single URL override.

Example:
```
export REST_SERVER_URL=https://dogecorp.com:3000
```

## REST_SERVER_URLS

This is new in this PR - a JSON string containing business network name to URL mappings for multiple business networks - useful for generic deployment scripts. The application knows which business network that it should look for.

Example: 
```
export REST_SERVER_URLS='{
    "basic-sample-network": "https://basic-sample-network.dogecorp.com",
    "vehicle-manufacture-network": "https://vehicle-manufacture-network.simoncorp.com"
}'
```