### PR TITLE
extend exemptions

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,6 +5,10 @@ daysUntilClose: 14
 # Issues with these labels will never be considered stale
 exemptLabels:
   - good first issue
+  - epic
+  - debt
+  - qa
+  - top10
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>

extends stale bot exemptions to include more tags.

Closes #3921 