### PR TITLE
Removing extra slash in search result links (Issue 2863)

### DIFF
--- a/packages/composer-website/jekylldocs/search/search.html
+++ b/packages/composer-website/jekylldocs/search/search.html
@@ -30,7 +30,7 @@ excerpt: Search
         "author": "{{ post.author | xml_escape }}",
         "category": "{{ post.category | xml_escape }}",
         "content": {{ post.content | strip_html | strip_newlines | jsonify }},
-        "url": "{{site.baseurl}}/{{ post.url | xml_escape }}"
+        "url": "{{site.baseurl}}{{ post.url | xml_escape }}"
       }
       {% unless forloop.last %},{% endunless %}
     {% endfor %}


### PR DESCRIPTION
Fixes #2863 

Removed extra slash in links from search results to ensure that navbar is updated when using them to navigate