### PR TITLE
Reinstate composer report tests

### DIFF
--- a/packages/composer-tests-integration/features/cli-report.feature
+++ b/packages/composer-tests-integration/features/cli-report.feature
@@ -13,10 +13,17 @@
 #
 
 @cli @cli-report
-Feature: Cli steps
+Feature: CLI report steps
 
     Background:
         Given I have admin business cards available
+
+    Scenario: Using the CLI, I should get an error if I try and provide any command line arguments
+    When I run the following expected fail CLI command
+        """
+        composer report -idonotknowwhatiamdoing
+        """
+    Then The stderr information should include text matching /Unknown arguments/
 
     Scenario: Using the CLI, I can run a composer report command to create a file about the current environment
         When I run the following expected pass CLI command

--- a/packages/composer-tests-integration/package.json
+++ b/packages/composer-tests-integration/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint .",
     "test": "exit 0",
     "test-tagged": "cucumber-js --fail-fast --tags @cli-generate",
-    "test-inner": "cucumber-js  --fail-fast --tags 'not @cli-report'",
+    "test-inner": "cucumber-js  --fail-fast",
     "test-inner-nohsm": "cucumber-js --fail-fast --tags 'not @hsm'",
     "setup": "npm run pretest && npm run lint && npm run start_verdaccio && node ./scripts/npm_serve",
     "int-test": "npm run setup && npm run test-inner && npm run stop_verdaccio",


### PR DESCRIPTION
Also adds a 'bad' command test

Contributes to 3787

Signed-off-by: James Taylor <jamest@uk.ibm.com>
