### PR TITLE
update the package version scripts to include the peerDependencies

### DIFF
--- a/packages/composer-runtime-embedded/package.json
+++ b/packages/composer-runtime-embedded/package.json
@@ -73,7 +73,7 @@
     }
   },
   "peerDependencies": {
-    "composer-common": "0.19.3"
+    "composer-common": "0.19.5"
   },
   "dependencies": {
     "composer-runtime": "0.19.5",

--- a/packages/composer-wallet-filesystem/package.json
+++ b/packages/composer-wallet-filesystem/package.json
@@ -77,7 +77,7 @@
     }
   },
   "peerDependencies": {
-    "composer-common": "0.19.3"
+    "composer-common": "0.19.5"
   },
   "dependencies": {
     "mkdirp": "0.5.1",

--- a/packages/composer-wallet-inmemory/package.json
+++ b/packages/composer-wallet-inmemory/package.json
@@ -77,7 +77,7 @@
     }
   },
   "peerDependencies": {
-    "composer-common": "0.19.3"
+    "composer-common": "0.19.5"
   },
   "nyc": {
     "exclude": [

--- a/scripts/depcheck.js
+++ b/scripts/depcheck.js
@@ -62,6 +62,9 @@ for (const packageIndex in packages) {
     for (const dependency in currentPackage.devDependencies) {
         checkValue(packageIndex, dependency, currentPackage.devDependencies[dependency]);
     }
+    for (const dependency in currentPackage.peerDependencies) {
+        checkValue(packageIndex, dependency, currentPackage.peerDependencies[dependency]);
+    }    
 }
 
 if (Object.keys(badDependencies).length > 0) {

--- a/scripts/pkgcheck.js
+++ b/scripts/pkgcheck.js
@@ -86,6 +86,18 @@ for (const i in packages) {
                 }
             }
         }
+        for (const dependency in currentPackage.peerDependencies) {
+            const currentValue = currentPackage.peerDependencies[dependency];
+            if (dependency === otherPackage.name) {
+                if (currentValue !== targetDependency) {
+                    if (!badDependencies[i]) {
+                        badDependencies[i] = [];
+                    }
+                    badDependencies[i].push({ dependency: dependency, currentValue: currentValue });
+                    mismatch = true;
+                }
+            }
+        }        
     }
 }
 

--- a/scripts/pkgstamp.js
+++ b/scripts/pkgstamp.js
@@ -60,6 +60,12 @@ for (const i in packages) {
                 currentPackage.devDependencies[dependency] = targetVersion;
             }
         }
+        for (const dependency in currentPackage.peerDependencies) {
+            const currentValue = currentPackage.peerDependencies[dependency];
+            if (dependency === otherPackage.name) {
+                currentPackage.peerDependencies[dependency] = targetVersion;
+            }
+        }        
     }
     const packageFile = path.resolve(packagesDirectory, i, 'package.json');
     fs.writeFileSync(packageFile, JSON.stringify(currentPackage, null, 2), 'utf8');


### PR DESCRIPTION
Adding peer dependencies to the package check scripts.
Behaviour is exactly the same as for the other dependencies. 

