### PR TITLE
Improve card integration tests

### DIFF
--- a/packages/composer-tests-integration/features/cli-cards.feature
+++ b/packages/composer-tests-integration/features/cli-cards.feature
@@ -15,9 +15,6 @@
 @cli @cli-cards
 Feature: CLI cards steps
 
-    Background:
-        Given I have admin business cards available
-
     Scenario: Using the CLI, I can create a business network card using a connection profile and certificates
         Given I have the following items
             | ../hlfv1/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts |
@@ -54,27 +51,14 @@ Feature: CLI cards steps
             """
             composer card list
             """
-        Then The stdout information should strictly contain the following text block
-        """
-        The following Business Network Cards are available:
-
-        Connection Profile: hlfv1
-        ┌────────────────────┬────────────────────┬──────────────────┐
-        │ Card Name          │ UserId             │ Business Network │
-        ├────────────────────┼────────────────────┼──────────────────┤
-        │ PeerAdmin@hlfv1    │ PeerAdmin          │                  │
-        ├────────────────────┼────────────────────┼──────────────────┤
-        │ TestPeerAdmin@org1 │ TestPeerAdmin@org1 │                  │
-        ├────────────────────┼────────────────────┼──────────────────┤
-        │ TestPeerAdmin@org2 │ TestPeerAdmin@org2 │                  │
-        └────────────────────┴────────────────────┴──────────────────┘
-
-
-        Issue composer card list --card <Card Name> to get details a specific card
-
-        Command succeeded
-
-        """
+        Then The stdout information should include text matching /The following Business Network Cards are available:/
+        And The stdout information should include text matching /Connection Profile: hlfv1/
+        And The stdout information should include text matching /┌─+┬─+┬─+┐/
+        And The stdout information should include text matching /│ Card Name\s+│ UserId\s+│ Business Network\s+│/
+        And The stdout information should include text matching /├─+┼─+┼─+┤/
+        And The stdout information should include text matching /│ PeerAdmin@hlfv1\s+│ PeerAdmin\s+│\s+│/
+        And The stdout information should include text matching /└─+┴─+┴─+┘/
+        And The stdout information should include text matching /Command succeeded/
 
     Scenario: When using the CLI, I can see the details of the card that I just imported
         When I run the following expected pass CLI command

--- a/packages/composer-tests-integration/features/cli-cards.redis.feature
+++ b/packages/composer-tests-integration/features/cli-cards.redis.feature
@@ -16,9 +16,7 @@
 Feature: CLI cards steps using redis
 
     Background:
-        Given I have admin business cards available
-        
-        
+        Given I have setup a redis card wallet environment
 
     Scenario: Using the CLI, I can create a business network card using a connection profile and certificates
         Given I have the following items
@@ -42,7 +40,6 @@ Feature: CLI cards steps using redis
     Scenario: Using the CLI, I can import a business network card
         Given I have the following files
             | ../tmp/PeerAdmin.card |
-        And I have setup a redis card wallet environment
         When I run the following expected pass CLI command
             """
             composer card import --file ./tmp/PeerAdmin.card
@@ -51,9 +48,13 @@ Feature: CLI cards steps using redis
         And The stdout information should include text matching /Card file: ./tmp/PeerAdmin.card/
         And The stdout information should include text matching /Card name: PeerAdmin@hlfv1/
         And The stdout information should include text matching /Command succeeded/
+        And I run the following expected pass CLI command
+            """
+            docker exec composer-wallet-redis redis-cli keys "cards/*"
+            """
+        And The stdout information should include text strictly matching /cards\/PeerAdmin@hlfv1/
 
     Scenario: Using the CLI, I can see the card that I just imported in the list of cards
-        Given I have setup a redis card wallet environment
         When I run the following expected pass CLI command
             """
             composer card list
@@ -68,7 +69,6 @@ Feature: CLI cards steps using redis
         And The stdout information should include text matching /Command succeeded/
 
     Scenario: When using the CLI, I can see the details of the card that I just imported
-        Given I have setup a redis card wallet environment
         When I run the following expected pass CLI command
             """
             composer card list -c PeerAdmin@hlfv1
@@ -86,7 +86,6 @@ Feature: CLI cards steps using redis
         And The stdout information should include text matching /Command succeeded/
 
     Scenario: Using the CLI, I should get an error if I try to delete a card which doesn't exist
-        Given I have setup a redis card wallet environment
         When I run the following expected fail CLI command
             """
             composer card delete -c nobody@penguin
@@ -94,7 +93,6 @@ Feature: CLI cards steps using redis
         Then The stdout information should include text matching /Command failed/
 
     Scenario: Using the CLI, I can export a card that exists in my wallet
-        Given I have setup a redis card wallet environment
         When I run the following expected pass CLI command
             """
             composer card export --card PeerAdmin@hlfv1 --file ./tmp/ExportedPeerAdmin.card
@@ -104,15 +102,13 @@ Feature: CLI cards steps using redis
             | ../tmp/PeerAdmin.card |
 
     Scenario: Using the CLI, I can delete a named card that exists
-        Given I have setup a redis card wallet environment
         When I run the following expected pass CLI command
             """
             composer card delete --card PeerAdmin@hlfv1
             """
         Then The stdout information should include text matching /Command succeeded/
 
-    Scenario: Using the CLI, I get a relevant message when I import a card that has invalid name format created from an invalid common connection profile.
-        Given I have setup a redis card wallet environment
+    Scenario: Using the CLI, I get a relevant message when I import a card that has invalid name format created from an invalid common connection profile
         And I have the following files
             | ../resources/cards/PeerAdminInvalidName@hlfv1.card |
         When I run the following expected fail CLI command

--- a/packages/composer-tests-integration/lib/composer.js
+++ b/packages/composer-tests-integration/lib/composer.js
@@ -425,7 +425,7 @@ class Composer {
             let command = cmd;
             let stdout = '';
             let stderr = '';
-            let env = process.env;
+            let env = Object.create( process.env );
             if (this.jsonConfig){
                 env.NODE_CONFIG=this.jsonConfig;
             } else {
@@ -434,7 +434,10 @@ class Composer {
 
             return new Promise( (resolve, reject) => {
 
-                let childCliProcess = childProcess.exec(command,{env});
+                const options = {
+                    env: env
+                };
+                let childCliProcess = childProcess.exec(command, options);
 
                 childCliProcess.stdout.setEncoding('utf8');
                 childCliProcess.stderr.setEncoding('utf8');


### PR DESCRIPTION
Testing exact output of `composer card list` is too brittle. Also
updates redis card test to check if the card really did end up in
redis

Fixed while working on #3787

Signed-off-by: James Taylor <jamest@uk.ibm.com>
