### PR TITLE
Replace acme namespace in playground

### DIFF
--- a/packages/composer-playground/src/app/deploy/deploy.component.ts
+++ b/packages/composer-playground/src/app/deploy/deploy.component.ts
@@ -234,7 +234,7 @@ rule NetworkAdminSystem {
  * limitations under the License.
  */
 
-namespace org.acme.empty
+namespace org.example.empty
 `;
 
         this.currentBusinessNetworkPromise = Promise.resolve().then(() => {

--- a/packages/composer-playground/src/app/editor/add-file/add-file.component.spec.ts
+++ b/packages/composer-playground/src/app/editor/add-file/add-file.component.spec.ts
@@ -412,7 +412,7 @@ This business network defines:
 
             component.fileType.should.equal('cto');
             component.currentFile.should.equal(mockModelFile);
-            component.currentFileName.should.equal('models/org.acme.model.cto');
+            component.currentFileName.should.equal('models/org.example.model.cto');
         }));
 
         it('should append the file number to the cto file name and namespace', fakeAsync(inject([FileService], (fileService: FileService) => {
@@ -420,7 +420,7 @@ This business network defines:
             tick();
 
             let existingModelFile = sinon.createStubInstance(ModelFile);
-            existingModelFile.getNamespace.returns('org.acme.model');
+            existingModelFile.getNamespace.returns('org.example.model');
             mockFileService.getModelFiles.returns([existingModelFile]);
 
             let modelRadioElement = addFileElement.query(By.css('#file-type-cto'));
@@ -430,10 +430,10 @@ This business network defines:
             fixture.detectChanges();
             tick();
 
-            mockFileService.createModelFile.should.have.been.calledWith(sinon.match(/namespace org.acme.model0/), 'models/org.acme.model0.cto');
+            mockFileService.createModelFile.should.have.been.calledWith(sinon.match(/namespace org.example.model0/), 'models/org.example.model0.cto');
             component.fileType.should.equal('cto');
             component.currentFile.should.equal(mockModelFile);
-            component.currentFileName.should.equal('models/org.acme.model0.cto');
+            component.currentFileName.should.equal('models/org.example.model0.cto');
         })));
 
         it('should change current file to a query file upon calling createQueryFile', fakeAsync(() => {

--- a/packages/composer-playground/src/app/editor/add-file/add-file.component.ts
+++ b/packages/composer-playground/src/app/editor/add-file/add-file.component.ts
@@ -34,7 +34,7 @@ export class AddFileComponent {
     maxFileSize: number = 5242880;
     supportedFileTypes: string[] = ['.js', '.cto', '.md', '.acl', '.qry'];
 
-    addModelNamespace: string = 'org.acme.model';
+    addModelNamespace: string = 'org.example.model';
     addModelPath: string = 'models/';
     addModelFileExtension: string = '.cto';
     addScriptFileName: string = 'lib/script';

--- a/packages/composer-playground/src/app/editor/editor.component.ts
+++ b/packages/composer-playground/src/app/editor/editor.component.ts
@@ -56,7 +56,7 @@ export class EditorComponent implements OnInit, OnDestroy {
     private currentFile: any = null;
     private deletableFile: boolean = false;
 
-    private addModelNamespace: string = 'models/org.acme.model';
+    private addModelNamespace: string = 'models/org.example.model';
     private addScriptFileName: string = 'lib/script';
     private addScriptFileExtension: string = '.js';
     private addModelFileExtension: string = '.cto';


### PR DESCRIPTION
The empty business network and new model files should now
use org.example instead of org.acme

Related to #2662
Closes #3994

Signed-off-by: James Taylor <jamest@uk.ibm.com>