### PR TITLE
prevent calling get() and cache resources (#4003)

### DIFF
--- a/packages/composer-runtime-hlfv1/lib/nodedataservice.js
+++ b/packages/composer-runtime-hlfv1/lib/nodedataservice.js
@@ -116,24 +116,32 @@ class NodeDataService extends DataService {
    /**
     * Get the collection with the specified ID.
     * @param {string} id The ID of the collection.
+    * @param {Boolean} bypass bypass existence check
     * @return {Promise} A promise that will be resolved with a {@link DataCollection}
     * when complete, or rejected with an error.
     */
-    async getCollection(id) {
+    async getCollection(id, bypass) {
         const method = 'getCollection';
         LOG.entry(method, id);
         const t0 = Date.now();
 
-        let key = this.stub.createCompositeKey(collectionObjectType, [id]);
-        let value = await this.stub.getState(key);
-        if (value.length === 0) {
+        if (bypass) {
+            let retVal = new NodeDataCollection(this, this.stub, id);
+            LOG.exit(method, retVal);
             LOG.debug('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
-            throw new Error(`Collection with ID ${id} does not exist`);
+            return retVal;
+        } else {
+            let key = this.stub.createCompositeKey(collectionObjectType, [id]);
+            let value = await this.stub.getState(key);
+            if (value.length === 0) {
+                LOG.debug('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                throw new Error(`Collection with ID ${id} does not exist`);
+            }
+            let retVal = new NodeDataCollection(this, this.stub, id);
+            LOG.exit(method, retVal);
+            LOG.debug('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            return retVal;
         }
-        let retVal = new NodeDataCollection(this, this.stub, id);
-        LOG.exit(method, retVal);
-        LOG.debug('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
-        return retVal;
     }
 
    /**

--- a/packages/composer-runtime-pouchdb/lib/pouchdbdataservice.js
+++ b/packages/composer-runtime-pouchdb/lib/pouchdbdataservice.js
@@ -150,22 +150,28 @@ class PouchDBDataService extends DataService {
    /**
     * Get the collection with the specified ID.
     * @param {string} id The ID of the collection.
+    * @param {Boolean} bypass bypass existence check
     * @return {Promise} A promise that will be resolved with a {@link DataCollection}
     * when complete, or rejected with an error.
     */
-    getCollection(id) {
+    async getCollection(id, bypass) {
         const method = 'getCollection';
         LOG.entry(method, id);
-        const key = pouchCollate.toIndexableString([collectionObjectType, id]);
-        return PouchDBUtils.getDocument(this.db, key)
-            .then((doc) => {
-                if (!doc) {
-                    throw new Error(`Collection with ID '${id}' does not exist`);
-                }
-                let result = new PouchDBDataCollection(this, this.db, id);
-                LOG.exit(method, result);
-                return result;
-            });
+
+        if (bypass) {
+            let result = new PouchDBDataCollection(this, this.db, id);
+            LOG.exit(method, result);
+            return result;
+        } else {
+            const key = pouchCollate.toIndexableString([collectionObjectType, id]);
+            let doc = await PouchDBUtils.getDocument(this.db, key);
+            if (!doc) {
+                throw new Error(`Collection with ID '${id}' does not exist`);
+            }
+            let result = new PouchDBDataCollection(this, this.db, id);
+            LOG.exit(method, result);
+            return result;
+        }
     }
 
    /**

--- a/packages/composer-runtime-pouchdb/test/pouchdbdataservice.js
+++ b/packages/composer-runtime-pouchdb/test/pouchdbdataservice.js
@@ -212,8 +212,49 @@ describe('PouchDBDataService', () => {
                 .should.be.rejectedWith(/Collection with ID .* does not exist/);
         });
 
-        it('should return an existing collection', () => {
+        it('should not perform a retrieve via getDocument() if passed a boolean true bypass parameter', () => {
+            let bypass = true;
+            return dataService.getCollection('doges1', bypass)
+                .then((result) => {
+                    pouchCollate.toIndexableString.should.not.have.been.called;
+                });
+        });
+
+        it('should perform a retrieve via getDocument() if passed a boolean false bypass parameter', () => {
+            let bypass = false;
+            return dataService.getCollection('doges1', bypass)
+                .then((result) => {
+                    pouchCollate.toIndexableString.should.have.been.called;
+                });
+        });
+
+        it('should perform a retrieve via getDocument() if not passed a bypass parameter', () => {
             return dataService.getCollection('doges1')
+                .then((result) => {
+                    pouchCollate.toIndexableString.should.have.been.called;
+                });
+        });
+
+        it('should return an existing collection if no bypass flags are passed', () => {
+            return dataService.getCollection('doges1')
+                .then((result) => {
+                    result.should.be.an.instanceOf(PouchDBDataCollection);
+                    result.db.should.equal(dataService.db);
+                    result.collectionId.should.equal('doges1');
+                });
+        });
+
+        it('should return an existing collection when retrieving', () => {
+            return dataService.getCollection('doges1', false)
+                .then((result) => {
+                    result.should.be.an.instanceOf(PouchDBDataCollection);
+                    result.db.should.equal(dataService.db);
+                    result.collectionId.should.equal('doges1');
+                });
+        });
+
+        it('should return an existing collection when bypassing retrieve', () => {
+            return dataService.getCollection('doges1', true)
                 .then((result) => {
                     result.should.be.an.instanceOf(PouchDBDataCollection);
                     result.db.should.equal(dataService.db);

--- a/packages/composer-runtime/lib/dataservice.js
+++ b/packages/composer-runtime/lib/dataservice.js
@@ -54,10 +54,11 @@ class DataService extends Service {
     * Get the collection with the specified ID.
     * @abstract
     * @param {string} id The ID of the collection.
+    * @param {Boolean} bypass bypass existence check
     * @return {Promise} A promise that will be resolved with a {@link DataCollection}
     * when complete, or rejected with an error.
     */
-    async getCollection(id) {
+    async getCollection(id, bypass) {
         throw new Error('abstract function called');
     }
 


### PR DESCRIPTION
Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>

Closes #4026 

RegistryManager
- add method to determine if a Composer generated type
- if a Composer generated type and not being called by an 'ensure' method, then use a factory to generate the Asset in order to perform an ACL check, retrieve dataCollection using a 'bypass' flag. Cache the resulting Asset (registry)
- if either non-composer, or being called by an `ensure` method, follow the previous route and perform explicit `get` operations on the sysregistry and dataCollection.

DataService
- add flag to `getCollection` to enable optional bypass of explicit `get` for known types

PR comes complete with enhanced unit tests 👍 