### PR TITLE
Playground support for connection delegation

### DIFF
--- a/packages/composer-common/lib/connectionprofilemanager.js
+++ b/packages/composer-common/lib/connectionprofilemanager.js
@@ -65,7 +65,7 @@ class ConnectionProfileManager {
     /**
      * Retrieves the ConnectionManager for the given connection type.
      *
-     * @param {String} connectionType The connection type
+     * @param {String} connectionType The connection type, eg hlfv1, embedded, embedded@proxy
      * @return {Promise} A promise that is resolved with a {@link ConnectionManager}
      * object once the connection is established, or rejected with a connection error.
      */
@@ -91,7 +91,8 @@ class ConnectionProfileManager {
                     try {
                         // Check for the connection manager class registered using
                         // registerConnectionManager (used by the web connector).
-                        let connectionManagerClass = connectionManagerClasses[connectionType];
+                        const actualType = delegateTypeIndex !== -1 && delegateTypeIndex < connectionType.length - 1 ? connectionType.substring(delegateTypeIndex + 1) : connectionType;
+                        const connectionManagerClass = connectionManagerClasses[actualType];
                         if (connectionManagerClass) {
                             connectionManager = new (connectionManagerClass)(this);
                         } else {

--- a/packages/composer-common/test/connectionprofilemanager.js
+++ b/packages/composer-common/test/connectionprofilemanager.js
@@ -91,6 +91,16 @@ describe('ConnectionProfileManager', () => {
             return cpm.getConnectionManagerByType( 'foo' ).should.eventually.be.an.instanceOf(TestConnectionManager);
         });
 
+        it('should use a registered delegated connection manager', () => {
+            /** test class */
+            class TestProxyConnectionManager extends ConnectionManager { }
+            ConnectionProfileManager.registerConnectionManager('testproxy', TestProxyConnectionManager);
+            let cpm = new ConnectionProfileManager();
+            cpm.should.not.be.null;
+            return cpm.getConnectionManagerByType( 'foo@testproxy' ).should.eventually.be.an.instanceOf(TestProxyConnectionManager);
+        });
+
+
         it('should handle a type of foo@ as foo@ when dynamically loading', () => {
             /** test class */
             class TestConnectionManager extends ConnectionManager { }

--- a/packages/composer-connector-embedded/lib/embeddedconnectionmanager.js
+++ b/packages/composer-connector-embedded/lib/embeddedconnectionmanager.js
@@ -55,10 +55,13 @@ class EmbeddedConnectionManager extends ConnectionManager {
         const name = certificateObj.getName();
         const issuer = certificateObj.getIssuer();
         let secret = uuid.v4().substring(0, 8);
+        let options = {};
 
         // Allow an existing identity to be replaced in the connector wallet.
         if (await identities.exists(id)) {
-            secret = (await identities.get(id)).secret;
+            const curid = await identities.get(id);
+            secret = curid.secret;
+            options = curid.options;
             await identities.remove(id);
         }
         const identity = {
@@ -70,7 +73,7 @@ class EmbeddedConnectionManager extends ConnectionManager {
             publicKey,
             privateKey,
             imported: true,
-            options: {}
+            options
         };
 
         await identities.add(id, identity);

--- a/packages/composer-connector-embedded/test/embeddedconnectionmanager.js
+++ b/packages/composer-connector-embedded/test/embeddedconnectionmanager.js
@@ -65,7 +65,6 @@ describe('EmbeddedConnectionManager', () => {
             mockIdentitiesDataCollection.add.withArgs('doge').resolves();
             await connectionManager.importIdentity('devFabric1', { connect: 'options' }, 'doge', testCertificate, testPrivateKey);
             sinon.assert.calledOnce(mockIdentitiesDataCollection.add);
-            //const adminIdentityIdentifier = mockIdentitiesDataCollection.add.getCall(1).args[0];
             const adminIdentity1 = mockIdentitiesDataCollection.add.getCall(0).args[1];
             const adminIdentityIdentifier = adminIdentity1.identifier;
             const certificateObj = new Certificate(adminIdentity1.certificate);
@@ -78,14 +77,11 @@ describe('EmbeddedConnectionManager', () => {
             adminIdentity1.name.should.equal('doge');
             adminIdentity1.secret.should.equal('f892c30a');
             adminIdentity1.imported.should.be.true;
-            //const adminIdentity2 = mockIdentitiesDataCollection.add.getCall(1).args[1];
-            //adminIdentity1.should.deep.equal(adminIdentity2);
         });
 
         it('should replace existing identity with new identity if the identity exists', async () => {
-            //sandbox.stub(uuid, 'v4').returns('f892c30a-7799-4eac-8377-06da53600e5');
             mockIdentitiesDataCollection.exists.withArgs('doge').resolves(true);
-            mockIdentitiesDataCollection.get.withArgs('doge').resolves({secret: 'orgSecret'});
+            mockIdentitiesDataCollection.get.withArgs('doge').resolves({secret: 'orgSecret', options : {issuer: true}});
             mockIdentitiesDataCollection.add.withArgs('doge').resolves();
 
             await connectionManager.importIdentity('devFabric1', { connect: 'options' }, 'doge', testCertificate, testPrivateKey);
@@ -94,9 +90,6 @@ describe('EmbeddedConnectionManager', () => {
 
             sinon.assert.calledOnce(mockIdentitiesDataCollection.add);
             const adminIdentity1 = mockIdentitiesDataCollection.add.getCall(0).args[1];
-            //const adminIdentityIdentifier = mockIdentitiesDataCollection.add.getCall(1).args[0];
-            //const adminIdentity2 = mockIdentitiesDataCollection.add.getCall(1).args[1];
-            //adminIdentity1.should.deep.equal(adminIdentity2);
             const adminIdentityIdentifier = adminIdentity1.identifier;
             const certificateObj = new Certificate(adminIdentity1.certificate);
             certificateObj.getIdentifier().should.equal(adminIdentityIdentifier);
@@ -107,6 +100,7 @@ describe('EmbeddedConnectionManager', () => {
             adminIdentity1.issuer.should.equal('a3e3a2d42f1c55e1485c4d06ba8b5c64f83f697939346687b32bacaae5e38c8f');
             adminIdentity1.name.should.equal('doge');
             adminIdentity1.secret.should.equal('orgSecret');
+            adminIdentity1.options.issuer.should.equal(true);
             adminIdentity1.imported.should.be.true;
         });
 
@@ -199,7 +193,6 @@ describe('EmbeddedConnectionManager', () => {
             result.should.be.true;
             sinon.assert.calledOnce(mockIdentitiesDataCollection.update);
             sinon.assert.calledWith(mockIdentitiesDataCollection.update.firstCall, 'doge', notImportedIdentity);
-            //sinon.assert.calledWith(mockIdentitiesDataCollection.update.secondCall, notImportedIdentity.identifier, notImportedIdentity);
         });
 
         it('should do nothing if identity not imported', async () => {

--- a/packages/composer-playground/src/app/services/admin.service.ts
+++ b/packages/composer-playground/src/app/services/admin.service.ts
@@ -36,7 +36,7 @@ export class AdminService {
         if (ENV && ENV !== 'development') {
             ProxyConnectionManager.setConnectorServerURL(window.location.origin);
         }
-
+        ConnectionProfileManager.registerConnectionManager('proxy', ProxyConnectionManager);
         ConnectionProfileManager.registerConnectionManager('hlf', ProxyConnectionManager);
         ConnectionProfileManager.registerConnectionManager('hlfv1', ProxyConnectionManager);
         ConnectionProfileManager.registerConnectionManager('web', WebConnectionManager);

--- a/packages/composer-tests-integration/features/cli-cards.feature
+++ b/packages/composer-tests-integration/features/cli-cards.feature
@@ -91,7 +91,7 @@ Feature: CLI cards steps
             """
         Then The stdout information should include text matching /Command succeeded/
         And I have the following files
-            | ../tmp/PeerAdmin.card |
+            | ../tmp/ExportedPeerAdmin.card |
 
     Scenario: Using the CLI, I can delete a named card that exists
         When I run the following expected pass CLI command

--- a/packages/composer-tests-integration/scripts/run-integration-tests.sh
+++ b/packages/composer-tests-integration/scripts/run-integration-tests.sh
@@ -44,6 +44,8 @@ rm -rf ${HOME}/.composer/cards/ange*
 rm -rf ${HOME}/.composer/client-data/ange*
 rm -rf ${HOME}/.composer/cards/charlie*
 rm -rf ${HOME}/.composer/client-data/charlie*
+rm -rf ${HOME}/.composer/cards/yaml*
+rm -rf ${HOME}/.composer/client-data/yaml*
 rm -rf ./tmp/*           # temp folder for BNA files that are generated
 rm -rf ./my-empty-bus-net      # a business network created from generator
 rm -rf ./my-bus-net      # a business network created from generator


### PR DESCRIPTION
Also fix issue with embedded connector where re-imported identity loses issuer authority.

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
