### PR TITLE
move response compare to within catch block

### DIFF
--- a/packages/composer-connector-hlfv1/test/hlftxeventhandler.js
+++ b/packages/composer-connector-hlfv1/test/hlftxeventhandler.js
@@ -23,9 +23,6 @@ const chai = require('chai');
 const should = chai.should();
 chai.use(require('chai-as-promised'));
 
-
-
-
 describe('HLFTxEventHandler', () => {
 
     let sandbox, logWarnSpy;


### PR DESCRIPTION
Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>

closes #4040

Moved the inspection of the peer responses to within a catch block. Also renamed the internal method `_sendTransactionForProposal` to `_sendTransaction` to better represent the code action.