### PR TITLE
enable smart publishing of npm and docker items during release build

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -47,6 +47,12 @@ if [ "${DOCS}" != "" ]; then
   _exit "Run the docs build" $?
 fi
 
+# Required function for checking Docker image existence
+function exists() {
+    docker pull hyperledger/$*;
+    return $?
+}
+
 ## Start of release process
 
 # Set the NPM access token we will use to publish.
@@ -58,8 +64,14 @@ set-up-ssh --key "$encrypted_17b59ce72ad7_key" \
            --iv "$encrypted_17b59ce72ad7_iv" \
            --path-encrypted-key ".travis/github_deploy_key.enc"
 
+# This is the list of all npm modules for composer to be published
+export ALL_NPM_MODULES="composer-admin composer-cli composer-client composer-common composer-connector-embedded composer-connector-hlfv1 composer-connector-proxy composer-connector-server composer-connector-web composer-cucumber-steps composer-documentation composer-playground composer-playground-api composer-report composer-rest-server composer-runtime composer-runtime-embedded composer-runtime-hlfv1 composer-runtime-pouchdb composer-runtime-web composer-wallet-filesystem composer-wallet-inmemory generator-hyperledger-composer loopback-connector-composer"
+
 # This is the list of npm modules required by docker images
-export NPM_MODULES="composer-admin composer-client composer-cli composer-common composer-report composer-playground composer-playground-api composer-rest-server loopback-connector-composer"
+export DOCKER_NPM_MODULES="composer-admin composer-client composer-cli composer-common composer-report composer-playground composer-playground-api composer-rest-server loopback-connector-composer"
+
+# This is the list of Docker images to build and publish.
+export ALL_DOCKER_IMAGES="composer-playground composer-rest-server composer-cli"
 
 # Change from HTTPS to SSH.
 ./.travis/fix_github_https_repo.sh
@@ -69,9 +81,6 @@ git ls-remote
 
 # Log in to Docker Hub.
 docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
-
-# This is the list of Docker images to build.
-export DOCKER_IMAGES="composer-playground composer-rest-server composer-cli"
 
 # Determine the details of the suffixes for playground and NPM/docker tags
 if [[ "${BUILD_RELEASE}" == "unstable" ]]; then
@@ -107,30 +116,61 @@ fi
 # Hold onto the version number
 export VERSION=$(node -e "console.log(require('${DIR}/package.json').version)")
 
+# Determine which npm modules to ignore on the publish
+export IGNORE="composer-tests-integration|composer-tests-functional|composer-website"
+for m in ${ALL_NPM_MODULES}; do
+    echo "Checking for existence of npm module ${m}"
+    if npm view ${m}@${VERSION} | grep dist-tags > /dev/null 2>&1; then
+        echo "-module ${m} exists, will ignore in publish"
+        IGNORE+="|${m}"
+    fi
+done
+
 # Publish with tag
 echo "Pushing with tag ${TAG}"
-lerna exec --ignore '@(composer-tests-integration|composer-tests-functional|composer-website)' -- npm publish --tag="${TAG}" 2>&1
+lerna exec --ignore '@('${IGNORE}')' -- npm publish --tag="${TAG}" 2>&1
 
 # Check that all required modules have been published to npm and are retrievable
-for j in ${NPM_MODULES}; do
+for j in ${DOCKER_NPM_MODULES}; do
     # check the next in the list
     while ! npm view ${j}@${VERSION} | grep dist-tags > /dev/null 2>&1; do
         sleep 10
     done
 done
 
-# Build, tag, and publish Docker images.
-for i in ${DOCKER_IMAGES}; do
-
-    # Build the image and tag it with the version and unstable.
-    docker build --build-arg VERSION=${VERSION} -t hyperledger/${i}:${VERSION} ${DIR}/packages/${i}/docker
-    docker tag hyperledger/${i}:${VERSION} hyperledger/${i}:"${TAG}"
-
-    # Push both the version and unstable.
-    docker push hyperledger/${i}:${VERSION}
-    docker push hyperledger/${i}:${TAG}
-
+# Check which Docker images to publish, we need to temporarily disable the 'e' flag here as we rely on a failure
+set +e
+echo "Checking for Docker images with version ${VERSION}"
+export PUBLISH_DOCKER=""
+for i in ${ALL_DOCKER_IMAGES}; do
+    echo "Checking for existence of Docker image ${i}"
+    # Perform a pull on the version, it will fail if it does not exist
+    if exists "${i}:${VERSION}" ; then
+        echo "-image ${i}:${VERSION} exists, will not publish"
+    else
+        PUBLISH_DOCKER+="${i} "
+    fi
 done
+set -e
+
+# Now remove trailing whitespace character in the above list
+PUBLISH_DOCKER="${PUBLISH_DOCKER%"${PUBLISH_DOCKER##*[![:space:]]}"}"
+
+# Conditionally build, tag, and publish Docker images
+if ${#PUBLISH_DOCKER}; then
+    for i in ${PUBLISH_DOCKER}; do
+
+        # Build the image and tag it with the version and unstable.
+        docker build --build-arg VERSION=${VERSION} -t hyperledger/${i}:${VERSION} ${DIR}/packages/${i}/docker
+        docker tag hyperledger/${i}:${VERSION} hyperledger/${i}:"${TAG}"
+
+        # Push both the version and unstable.
+        docker push hyperledger/${i}:${VERSION}
+        docker push hyperledger/${i}:${TAG}
+    done
+else
+    echo "All images published; skipping publish phase"
+fi
 
 # Push to public Bluemix for stable and unstable, latest and next release builds
 if [[ "${BUILD_FOCUS}" != "v0.16" ]]; then
@@ -144,10 +184,8 @@ if [[ "${BUILD_FOCUS}" != "v0.16" ]]; then
 fi
 
 
-
 ## Stable releases only; both latest and next then clean up git, and bump version number
 if [[ "${BUILD_RELEASE}" = "stable" ]]; then
-
 
     # Configure the Git repository and clean any untracked and unignored build files.
     git config user.name "${GH_USER_NAME}"


### PR DESCRIPTION
Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>
Closes #3986 

- Check for any existing npm modules before publishing, and during publish phase use an augmented list of 'ignore items'
- Check for any existing docker images that already exist, and only publish those that do not already exist. Completely skip publish phase if all docker images exist.

Intentionally left the Playground conditionality out- we can spin the script to the point where playground is published, and a version bump is a trivial manual process that can be performed by anyone.
