### PR TITLE
extend docker npm deps to include module composer deps

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -68,7 +68,7 @@ set-up-ssh --key "$encrypted_17b59ce72ad7_key" \
 export ALL_NPM_MODULES="composer-admin composer-cli composer-client composer-common composer-connector-embedded composer-connector-hlfv1 composer-connector-proxy composer-connector-server composer-connector-web composer-cucumber-steps composer-documentation composer-playground composer-playground-api composer-report composer-rest-server composer-runtime composer-runtime-embedded composer-runtime-hlfv1 composer-runtime-pouchdb composer-runtime-web composer-wallet-filesystem composer-wallet-inmemory generator-hyperledger-composer loopback-connector-composer"
 
 # This is the list of npm modules required by docker images
-export DOCKER_NPM_MODULES="composer-admin composer-client composer-cli composer-common composer-report composer-playground composer-playground-api composer-rest-server loopback-connector-composer"
+export DOCKER_NPM_MODULES="composer-admin composer-client composer-cli composer-common composer-report composer-playground composer-playground-api composer-rest-server loopback-connector-composer composer-wallet-filesystem composer-wallet-inmemory composer-connector-server composer-documentation composer-connector-hlfv1 composer-connector-proxy"
 
 # This is the array of Docker images to build and publish.
 export ALL_DOCKER_IMAGES=("composer-playground" "composer-rest-server" "composer-cli")


### PR DESCRIPTION
Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>

There was a recent build failure due to an npm module not being able to find a composer dependancy.

This PR extends the DOCKER_NPM_MODULES list that is checked before proceeding to include the first layer of module dependancies for each main package required