### PR TITLE
Reduce jobQueue polling to 500ms

### DIFF
--- a/packages/composer-common/lib/introspect/loaders/jobqueue.js
+++ b/packages/composer-common/lib/introspect/loaders/jobqueue.js
@@ -115,7 +115,7 @@ class JobQueue extends EventEmitter {
         // If a job is running, or we are waiting on a startDelay, just retry later
         if (this.jobRunning || this.timer) {
 
-            setTimeout(() => this.processQueue(), 10000);
+            setTimeout(() => this.processQueue(), 500);
             return;
         }
 


### PR DESCRIPTION
When a ModelFileLoader downloads multiple files, processing the JobQueue introduces a pause of roughly 10 seconds. When using the composer-common dependency in a short-lived node app, such as Cicero CLI, this behaviour is exposed as a 'hang' before the process exits. See: accordproject/cicero#119

## Issue/User story
Fixes https://github.com/hyperledger/composer/issues/4116

## Steps to Reproduce
See https://github.com/hyperledger/composer/issues/4116

## Design of the fix
The value of the timeout can be debated. Also, ideally we would avoid polling altogether but not clear how to do this.
