### PR TITLE
Support socket closure

### DIFF
--- a/packages/composer-common/lib/idcard.js
+++ b/packages/composer-common/lib/idcard.js
@@ -303,7 +303,7 @@ class IdCard {
      */
     static fromDirectory(cardDirectory, fs) {
         const method = 'fromDirectory';
-        LOG.entry(method, cardDirectory, fs);
+        LOG.entry(method, cardDirectory);
 
         if (!fs) {
             fs = nodeFs;

--- a/packages/composer-connector-proxy/lib/proxyconnection.js
+++ b/packages/composer-connector-proxy/lib/proxyconnection.js
@@ -59,6 +59,7 @@ class ProxyConnection extends Connection {
         })
         .then(() => {
             this.socket.removeListener('events', () => {});
+            this.connectionManager.disconnect(this.connectionID);
             LOG.exit(method);
         });
     }

--- a/packages/composer-connector-proxy/package.json
+++ b/packages/composer-connector-proxy/package.json
@@ -77,7 +77,8 @@
     "watchify": "3.7.0"
   },
   "dependencies": {
-    "socket.io-client": "1.7.3"
+    "socket.io-client": "1.7.3",
+    "uuid": "3.0.1"
   },
   "nyc": {
     "exclude": [

--- a/packages/composer-connector-proxy/test/proxyconnection.js
+++ b/packages/composer-connector-proxy/test/proxyconnection.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const { BusinessNetworkDefinition } = require('composer-common');
-const ConnectionManager = require('composer-common').ConnectionManager;
+const ProxyConnectionManager = require('../lib/proxyconnectionmanager');
 const ProxyConnection = require('../lib/proxyconnection');
 const ProxySecurityContext = require('../lib/proxysecuritycontext');
 const serializerr = require('serializerr');
@@ -42,7 +42,7 @@ describe('ProxyConnection', () => {
     let mockSecurityContext;
 
     beforeEach(() => {
-        mockConnectionManager = sinon.createStubInstance(ConnectionManager);
+        mockConnectionManager = sinon.createStubInstance(ProxyConnectionManager);
         mockSocket = {
             emit: sinon.stub(),
             removeListener: sinon.stub()
@@ -60,6 +60,8 @@ describe('ProxyConnection', () => {
                 .then(() => {
                     sinon.assert.calledOnce(mockSocket.emit);
                     sinon.assert.calledWith(mockSocket.emit, '/api/connectionDisconnect', connectionID, sinon.match.func);
+                    sinon.assert.calledOnce(mockConnectionManager.disconnect);
+                    sinon.assert.calledWith(mockConnectionManager.disconnect, connection.connectionID);
                     mockSocket.removeListener.withArgs('events', sinon.match.func).yield();
                 });
         });

--- a/packages/composer-connector-proxy/test/proxyconnectionmanager.js
+++ b/packages/composer-connector-proxy/test/proxyconnectionmanager.js
@@ -20,7 +20,7 @@ const ProxyConnection = require('../lib/proxyconnection');
 const serializerr = require('serializerr');
 
 const chai = require('chai');
-chai.should();
+const should = chai.should();
 chai.use(require('chai-as-promised'));
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
@@ -48,11 +48,10 @@ describe('ProxyConnectionManager', () => {
         mockSocket = {
             emit: sinon.stub(),
             once: sinon.stub(),
-            on: sinon.stub()
+            on: sinon.stub(),
+            connect: sinon.stub(),
+            close: sinon.stub()
         };
-        // mockSocket.emit.throws(new Error('unexpected call'));
-        // mockSocket.once.throws(new Error('unexpected call'));
-        // mockSocket.on.throws(new Error('unexpected call'));
         mockSocketFactory = sinon.stub().returns(mockSocket);
         ProxyConnectionManager = proxyquire('../lib/proxyconnectionmanager', {
             'socket.io-client': mockSocketFactory
@@ -63,71 +62,127 @@ describe('ProxyConnectionManager', () => {
 
         it('should change the URL used to connect to the connector server', () => {
             ProxyConnectionManager.setConnectorServerURL('http://blah.com:2393');
-            mockSocket.on.withArgs('connect').returns();
-            mockSocket.on.withArgs('disconnect').returns();
-            new ProxyConnectionManager(mockConnectionProfileManager);
+            new ProxyConnectionManager(mockConnectionProfileManager).ensureConnected();
             sinon.assert.calledOnce(mockSocketFactory);
             sinon.assert.calledWith(mockSocketFactory, 'http://blah.com:2393');
         });
 
     });
 
-    describe('#constructor', () => {
-
-        let connectionManager;
-
-        beforeEach(() => {
-            mockSocket.on.withArgs('connect').returns();
-            mockSocket.on.withArgs('disconnect').returns();
-            connectionManager = new ProxyConnectionManager(mockConnectionProfileManager);
+    describe('#setConnectorStrategy', () => {
+        it('should not change the connector strategy if null/undefined/false/0', () => {
+            ProxyConnectionManager.setConnectorStrategy(null);
+            ProxyConnectionManager.getConnectorStrategy.should.not.be.null;
         });
-
-        it('should create a new socket connection and listen for a connect event', () => {
-            sinon.assert.calledOnce(mockSocketFactory);
-            sinon.assert.calledWith(mockSocketFactory, 'http://localhost:15699');
-            // Trigger the connect callback.
-            connectionManager.connected.should.be.false;
-            mockSocket.on.args[0][0].should.equal('connect');
-            mockSocket.on.args[0][1]();
-            connectionManager.connected.should.be.true;
-        });
-
-        it('should create a new socket connection and listen for a disconnect event', () => {
-            sinon.assert.calledOnce(mockSocketFactory);
-            sinon.assert.calledWith(mockSocketFactory, 'http://localhost:15699');
-            // Trigger the disconnect callback.
-            connectionManager.connected = true;
-            mockSocket.on.args[1][0].should.equal('disconnect');
-            mockSocket.on.args[1][1]();
-            connectionManager.connected.should.be.false;
-        });
-
     });
+
+
+    describe('#constructor', () => {
+        it('should create a new ProxyConnectionManager', () => {
+            let connectionManager = new ProxyConnectionManager(mockConnectionProfileManager);
+            connectionManager.connections.size.should.equal(0);
+        });
+    });
+
+    describe('#disconnect', () => {
+        it('should close the socket if connection count reaches zero and default strategy applied', () => {
+            let connectionManager = new ProxyConnectionManager(mockConnectionProfileManager);
+            connectionManager.socket = mockSocket;
+            connectionManager.connections.add('someid');
+            connectionManager.disconnect('someid');
+            connectionManager.connections.size.should.equal(0);
+            sinon.assert.calledOnce(mockSocket.close);
+        });
+
+        it('should not close the socket if connection\'s outstanding', () => {
+            let connectionManager = new ProxyConnectionManager(mockConnectionProfileManager);
+            connectionManager.socket = mockSocket;
+            connectionManager.connections.add('someid1');
+            connectionManager.connections.add('someid2');
+            connectionManager.connections.size.should.equal(2);
+            connectionManager.disconnect('someid1');
+            connectionManager.connections.size.should.equal(1);
+            sinon.assert.notCalled(mockSocket.close);
+        });
+
+        it('should not close the socket if connection strategy defines it', () => {
+            const savedStrategy = ProxyConnectionManager.getConnectorStrategy();
+            ProxyConnectionManager.setConnectorStrategy({
+                closeOnDisconnect: false
+            });
+            let connectionManager = new ProxyConnectionManager(mockConnectionProfileManager);
+            connectionManager.socket = mockSocket;
+            connectionManager.connections.add('someid');
+            connectionManager.disconnect('someid');
+            connectionManager.connections.size.should.equal(0);
+            sinon.assert.notCalled(mockSocket.close);
+            // restore the connector strategy
+            ProxyConnectionManager.setConnectorStrategy(savedStrategy);
+
+        });
+
+        it('should do nothing if connection id not known', () => {
+            let connectionManager = new ProxyConnectionManager(mockConnectionProfileManager);
+            connectionManager.socket = mockSocket;
+            connectionManager.connections.add('someid');
+            connectionManager.disconnect('some-other-id');
+            connectionManager.connections.size.should.equal(1);
+            sinon.assert.notCalled(mockSocket.close);
+        });
+    });
+
 
     describe('#ensureConnected', () => {
 
         let connectionManager;
 
         beforeEach(() => {
-            mockSocket.on.withArgs('connect').returns();
-            mockSocket.on.withArgs('disconnect').returns();
             connectionManager = new ProxyConnectionManager(mockConnectionProfileManager);
         });
 
-        it('should do nothing if already connected', () => {
+        it('should do nothing if already connected', async () => {
             connectionManager.connected = true;
-            return connectionManager.ensureConnected();
+            connectionManager.socket = mockSocket;
+            await connectionManager.ensureConnected();
+            sinon.assert.notCalled(mockSocket.connect);
         });
 
-        it('should wait for a connection if not connected', () => {
+        it('should create a new socket connection if no socket and listen for a connect event', async () => {
             mockSocket.once.withArgs('connect').yields();
-            connectionManager.connected = false;
-            return connectionManager.ensureConnected()
-                .then(() => {
-                    sinon.assert.calledOnce(mockSocket.once);
-                    sinon.assert.calledWith(mockSocket.once, 'connect');
-                });
+            await connectionManager.ensureConnected();
+            sinon.assert.calledOnce(mockSocketFactory);
+            sinon.assert.calledWith(mockSocketFactory, 'http://localhost:15699');
+            // Trigger the connect callback.
+            mockSocket.once.args[1][0].should.equal('connect');
+            mockSocket.once.args[1][1]();
+            //TODO: What can we check here ? check for a log event
         });
+
+        it('should create a new socket connection if no socket and listen for a disconnect event', async () => {
+            mockSocket.once.withArgs('connect').yields();
+            await connectionManager.ensureConnected();
+            sinon.assert.calledOnce(mockSocketFactory);
+            sinon.assert.calledWith(mockSocketFactory, 'http://localhost:15699');
+            // Trigger the disconnect callback.
+            mockSocket.once.args[0][0].should.equal('disconnect');
+            mockSocket.once.args[0][1]();
+            //TODO: What can we check here ? check for a log event
+        });
+
+        it('should create a new socket if socket not connected', async () => {
+            connectionManager.connected = false;
+            connectionManager.socket = mockSocket;
+            mockSocket.once.withArgs('connect').yields();
+            await connectionManager.ensureConnected();
+            sinon.assert.calledOnce(mockSocketFactory);
+            sinon.assert.calledWith(mockSocketFactory, 'http://localhost:15699');
+        });
+
+        it('should handle a connect error', () => {
+            mockSocket.once.withArgs('connect_error').yields('some error');
+            connectionManager.ensureConnected().should.be.rejectedWith('some error');
+        });
+
 
     });
 
@@ -137,20 +192,19 @@ describe('ProxyConnectionManager', () => {
             mockConnection = sinon.createStubInstance(ProxyConnection);
             mockConnection.connectionID = connectionID;
             mockConnection.socket = mockSocket;
-            mockSocket.on.withArgs('connect').returns();
-            mockSocket.on.withArgs('disconnect').returns();
             connectionManager = new ProxyConnectionManager(mockConnectionProfileManager);
-            connectionManager.connected = true;
+            mockSocket.once.withArgs('connect').yields();
         });
 
         it('should send a importIdentity call to the connector server', () => {
+            const disconnectSpy = sinon.spy(connectionManager, 'disconnect');
             mockSocket.emit.withArgs('/api/connectionManagerImportIdentity', connectionProfile, connectionOptions, 'bob1', 'certificate', 'private key', sinon.match.func).yields(null);
             sinon.stub(ProxyConnectionManager, 'createConnection').returns(mockConnection);
             return connectionManager.importIdentity(connectionProfile, connectionOptions, 'bob1', 'certificate', 'private key')
                 .then(() => {
                     sinon.assert.calledOnce(mockSocket.emit);
                     sinon.assert.calledWith(mockSocket.emit, '/api/connectionManagerImportIdentity', connectionProfile, connectionOptions, 'bob1', 'certificate', 'private key', sinon.match.func);
-                    sinon.assert.calledTwice(mockSocket.on);
+                    sinon.assert.calledOnce(disconnectSpy);
                 });
         });
 
@@ -168,20 +222,19 @@ describe('ProxyConnectionManager', () => {
             mockConnection = sinon.createStubInstance(ProxyConnection);
             mockConnection.connectionID = connectionID;
             mockConnection.socket = mockSocket;
-            mockSocket.on.withArgs('connect').returns();
-            mockSocket.on.withArgs('disconnect').returns();
             connectionManager = new ProxyConnectionManager(mockConnectionProfileManager);
-            connectionManager.connected = true;
+            mockSocket.once.withArgs('connect').yields();
         });
 
         it('should send a removeIdentity call to the connector server', () => {
+            const disconnectSpy = sinon.spy(connectionManager, 'disconnect');
             mockSocket.emit.withArgs('/api/connectionManagerRemoveIdentity', connectionProfile, connectionOptions, 'bob1', sinon.match.func).yields(null);
             sinon.stub(ProxyConnectionManager, 'createConnection').returns(mockConnection);
             return connectionManager.removeIdentity(connectionProfile, connectionOptions, 'bob1')
                 .then(() => {
                     sinon.assert.calledOnce(mockSocket.emit);
                     sinon.assert.calledWith(mockSocket.emit, '/api/connectionManagerRemoveIdentity', connectionProfile, connectionOptions, 'bob1', sinon.match.func);
-                    sinon.assert.calledTwice(mockSocket.on);
+                    sinon.assert.calledOnce(disconnectSpy);
                 });
         });
 
@@ -199,10 +252,8 @@ describe('ProxyConnectionManager', () => {
             mockConnection = sinon.createStubInstance(ProxyConnection);
             mockConnection.connectionID = connectionID;
             mockConnection.socket = mockSocket;
-            mockSocket.on.withArgs('connect').returns();
-            mockSocket.on.withArgs('disconnect').returns();
             connectionManager = new ProxyConnectionManager(mockConnectionProfileManager);
-            connectionManager.connected = true;
+            mockSocket.once.withArgs('connect').yields();
         });
 
         it('should send exportIdentity call to connector server', function() {
@@ -230,11 +281,33 @@ describe('ProxyConnectionManager', () => {
             mockConnection = sinon.createStubInstance(ProxyConnection);
             mockConnection.connectionID = connectionID;
             mockConnection.socket = mockSocket;
-            mockSocket.on.withArgs('connect').returns();
-            mockSocket.on.withArgs('disconnect').returns();
             connectionManager = new ProxyConnectionManager(mockConnectionProfileManager);
-            connectionManager.connected = true;
+            mockSocket.once.withArgs('connect').yields();
         });
+
+        it('should store the ids of multiple valid connections', async () => {
+            mockSocket.emit.withArgs('/api/connectionManagerConnect', 'failure', businessNetworkIdentifier, connectionOptions, sinon.match.func).yields(new Error('failed'));
+            const createConnectionStub = sinon.stub(ProxyConnectionManager, 'createConnection');
+            for (let i = 0; i < 4; i++) {
+                let mockConn = sinon.createStubInstance(ProxyConnection);
+                mockConn.connectionID = connectionID + i;
+                mockConn.socket = mockSocket;
+                mockSocket.emit.withArgs('/api/connectionManagerConnect', connectionProfile, businessNetworkIdentifier, connectionOptions, sinon.match.func).onCall(i).yields(null, connectionID + i);
+                createConnectionStub.onCall(i).returns(mockConn);
+            }
+            mockSocket.on.withArgs('events', sinon.match.func).yields(connectionID, [{'event': 'event1'}, {'evnet': 'event2'}]);
+            await connectionManager.connect(connectionProfile, businessNetworkIdentifier, connectionOptions);
+            try {
+                await connectionManager.connect('failure', businessNetworkIdentifier, connectionOptions);
+                should.fail('no error was thrown');
+            } catch(error) {
+                // ignore the expected error
+            }
+            await connectionManager.connect(connectionProfile, businessNetworkIdentifier, connectionOptions);
+            await connectionManager.connect(connectionProfile, businessNetworkIdentifier, connectionOptions);
+            connectionManager.connections.size.should.equal(3);
+        });
+
 
         it('should send a connect call to the connector server', () => {
             mockSocket.emit.withArgs('/api/connectionManagerConnect', connectionProfile, businessNetworkIdentifier, connectionOptions, sinon.match.func).yields(null, connectionID);
@@ -247,7 +320,7 @@ describe('ProxyConnectionManager', () => {
                     connection.should.be.an.instanceOf(ProxyConnection);
                     connection.socket.should.equal(mockSocket);
                     connection.connectionID.should.equal(connectionID);
-                    sinon.assert.calledThrice(mockSocket.on);
+                    connectionManager.connections.size.should.equal(1);
                     sinon.assert.calledWith(mockSocket.on, 'events', sinon.match.func);
                     sinon.assert.calledWith(mockConnection.emit, 'events', [{'event': 'event1'}, {'evnet': 'event2'}]);
                 });
@@ -264,7 +337,6 @@ describe('ProxyConnectionManager', () => {
                     connection.should.be.an.instanceOf(ProxyConnection);
                     connection.socket.should.equal(mockSocket);
                     connection.connectionID.should.equal(connectionID);
-                    sinon.assert.calledThrice(mockSocket.on);
                     sinon.assert.calledWith(mockSocket.on, 'events', sinon.match.func);
                     sinon.assert.notCalled(connection.emit);
                 });

--- a/packages/composer-connector-server/package.json
+++ b/packages/composer-connector-server/package.json
@@ -70,6 +70,7 @@
     "composer-common": "0.19.9",
     "composer-connector-embedded": "0.19.9",
     "composer-connector-hlfv1": "0.19.9",
+    "composer-wallet-filesystem": "0.19.9",
     "serializerr": "1.0.3",
     "socket.io": "1.7.3",
     "uuid": "3.0.1",

--- a/packages/composer-playground-api/scripts/devStart.sh
+++ b/packages/composer-playground-api/scripts/devStart.sh
@@ -26,12 +26,12 @@ packagesDir="$(cd "${scriptDir}/../.." && pwd)"
 if [ `uname` = "Darwin" ]; then
     gateway=docker.for.mac.localhost
 else
-    gateway="$(docker inspect hlfv1_default | grep Gateway | cut -d \" -f4)"
+    gateway="$(docker inspect composer_default | grep Gateway | cut -d \" -f4)"
 fi
 echo "registry=http://${gateway}:4873" > "${NPMRC_FILE}"
 
 # Start the npm proxy
-docker-compose --file "${scriptDir}/docker-compose.yaml" up --detach
+docker-compose -f "${scriptDir}/docker-compose.yaml" up -d
 
 # Publish development versions of packages required at runtime
 for package in composer-common composer-runtime composer-runtime-hlfv1; do
@@ -42,4 +42,4 @@ done
 npm start
 
 # Stop the npm proxy
-docker-compose --file "${scriptDir}/docker-compose.yaml" down
+docker-compose -f "${scriptDir}/docker-compose.yaml" down

--- a/packages/composer-playground/src/app/services/admin.service.ts
+++ b/packages/composer-playground/src/app/services/admin.service.ts
@@ -35,8 +35,11 @@ export class AdminService {
         if (ENV && ENV !== 'development') {
             ProxyConnectionManager.setConnectorServerURL(window.location.origin);
         }
+        // closing and opening the socket owned by the proxyconnectionmanager causes
+        // slowdown in the browser and also causes hangs when switching between the
+        // different registered connection managers.
+        ProxyConnectionManager.setConnectorStrategy({closeOnDisconnect: false});
         ConnectionProfileManager.registerConnectionManager('proxy', ProxyConnectionManager);
-        ConnectionProfileManager.registerConnectionManager('hlf', ProxyConnectionManager);
         ConnectionProfileManager.registerConnectionManager('hlfv1', ProxyConnectionManager);
         ConnectionProfileManager.registerConnectionManager('web', WebConnectionManager);
     }

--- a/packages/composer-wallet-filesystem/package.json
+++ b/packages/composer-wallet-filesystem/package.json
@@ -77,6 +77,7 @@
     }
   },
   "dependencies": {
+    "composer-common": "0.19.9",
     "mkdirp": "0.5.1",
     "rimraf": "2.5.4"
   },

--- a/packages/composer-wallet-inmemory/package.json
+++ b/packages/composer-wallet-inmemory/package.json
@@ -42,6 +42,9 @@
     "nyc": "11.1.0",
     "sinon": "2.3.8"
   },
+  "dependencies": {
+    "composer-common": "0.19.9"
+  },
   "license-check-and-add-config": {
     "folder": ".",
     "license": "LICENSE.txt",

--- a/packages/generator-hyperledger-composer/generators/angular/index.js
+++ b/packages/generator-hyperledger-composer/generators/angular/index.js
@@ -385,6 +385,7 @@ module.exports = yeoman.Base.extend({
             }
         });
         return completedApp.then(() => {
+            // eslint-disable-next-line no-console
             console.log('Completed generation process');
         });
 
@@ -450,6 +451,7 @@ module.exports = yeoman.Base.extend({
                                     'type': property.getType()
                                 });
                             } else {
+                                // eslint-disable-next-line no-console
                                 console.log('Unknown property type: ' + property);
                             }
                         } else if (property.constructor.name === 'RelationshipDeclaration') {
@@ -458,6 +460,7 @@ module.exports = yeoman.Base.extend({
                                 'type': property.getType()
                             });
                         } else {
+                            // eslint-disable-next-line no-console
                             console.log('Unknown property constructor name: ' + property );
                         }
                     });
@@ -526,6 +529,7 @@ module.exports = yeoman.Base.extend({
                                     'type': property.getType()
                                 });
                             } else {
+                                // eslint-disable-next-line no-console
                                 console.log('Unknown property type: ' + property);
                             }
                         } else if (property.constructor.name === 'RelationshipDeclaration') {
@@ -534,6 +538,7 @@ module.exports = yeoman.Base.extend({
                                 'type': property.getType()
                             });
                         } else {
+                            // eslint-disable-next-line no-console
                             console.log('Unknown property constructor name: ' + property );
                         }
                     });
@@ -602,6 +607,7 @@ module.exports = yeoman.Base.extend({
                                 'type': property.getType()
                             });
                         } else {
+                            // eslint-disable-next-line no-console
                             console.log('Unknown property type: ' + property);
                         }
                     } else if (property.constructor.name === 'RelationshipDeclaration') {
@@ -610,6 +616,7 @@ module.exports = yeoman.Base.extend({
                             'type': property.getType()
                         });
                     } else {
+                        // eslint-disable-next-line no-console
                         console.log('Unknown property constructor name: ' + property );
                     }
                 });
@@ -676,6 +683,7 @@ module.exports = yeoman.Base.extend({
                                     'type': property.getType()
                                 });
                             } else {
+                                // eslint-disable-next-line no-console
                                 console.log('Unknown property type: ' + property);
                             }
                         } else if (property.constructor.name === 'RelationshipDeclaration') {
@@ -684,6 +692,7 @@ module.exports = yeoman.Base.extend({
                                 'type': property.getType()
                             });
                         } else {
+                            // eslint-disable-next-line no-console
                             console.log('Unknown property constructor name: ' + property );
                         }
                     });
@@ -889,6 +898,7 @@ module.exports = yeoman.Base.extend({
             resolve();
         });
         return createdApp.then(() => {
+            // eslint-disable-next-line no-console
             console.log('Created application!');
         });
     },
@@ -900,6 +910,7 @@ module.exports = yeoman.Base.extend({
                 npm: true
             });
         } else {
+            // eslint-disable-next-line no-console
             console.log('Skipped installing dependencies');
         }
     },
@@ -938,7 +949,8 @@ module.exports = yeoman.Base.extend({
     },
 
     end: function () {
-        shell.exec('pkill yo');
+        // eslint-disable-next-line no-console
+        console.log('Application generated');
     }
 });
 


### PR DESCRIPTION
The proxy connector creates a single socket to the proxy server shared by all connections. However it never closed that socket which was ok for playground but not much good for anything else.

closes #4097

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>