### PR TITLE
stop e2e being published to composer-playground

### DIFF
--- a/packages/composer-playground/.npmignore
+++ b/packages/composer-playground/.npmignore
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
@@ -77,3 +77,6 @@ npm-debug.log
 # IDE #
 .idea/
 *.swp
+
+# test
+/e2e


### PR DESCRIPTION
e2e dir is shipped with playground node module

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
