### PR TITLE
introduce registry cache to prevent unnecessary lookups

### DIFF
--- a/packages/composer-runtime/lib/registry.js
+++ b/packages/composer-runtime/lib/registry.js
@@ -30,21 +30,6 @@ const baseDefaultOptions = {
 class Registry extends EventEmitter {
 
     /**
-     * Remove any internal properties to the specified JSON object before
-     * reinflating it back into a resource.
-     * @param {Object} json The JSON object.
-     * @return {Object} The JSON object.
-     */
-    static removeInternalProperties(json) {
-        if (!json || typeof json !== 'object' || Array.isArray(json)) {
-            throw new Error('Can only add properties to JSON objects');
-        }
-        delete json.$registryType;
-        delete json.$registryId;
-        return json;
-    }
-
-    /**
      * Constructor.
      * @param {string} dataCollection The data collection to use.
      * @param {Serializer} serializer The serializer to use.
@@ -63,6 +48,22 @@ class Registry extends EventEmitter {
         this.id = id;
         this.name = name;
         this.system = system;
+        this.resourceMap = new Map();
+    }
+
+    /**
+     * Remove any internal properties to the specified JSON object before
+     * reinflating it back into a resource.
+     * @param {Object} json The JSON object.
+     * @return {Object} The JSON object.
+     */
+    static removeInternalProperties(json) {
+        if (!json || typeof json !== 'object' || Array.isArray(json)) {
+            throw new Error('Can only add properties to JSON objects');
+        }
+        delete json.$registryType;
+        delete json.$registryId;
+        return json;
     }
 
     /**
@@ -79,6 +80,7 @@ class Registry extends EventEmitter {
                 const resource = this.serializer.fromJSON(object);
                 await this.accessController.check(resource, 'READ');
                 resources.push(resource);
+                this.resourceMap.set(resource.getIdentifier(), resource);
             } catch (error) {
                 // Ignore the error; we don't have access.
             }
@@ -93,14 +95,19 @@ class Registry extends EventEmitter {
      * object when complete, or rejected with an error.
      */
     async get(id) {
-        let object = await this.dataCollection.get(id);
-        object = Registry.removeInternalProperties(object);
-        try {
-            const resource = this.serializer.fromJSON(object);
-            await this.accessController.check(resource, 'READ');
-            return resource;
-        } catch (error) {
-            throw new Error(`Object with ID '${id}' in collection with ID '${this.type}:${this.id}' does not exist`);
+        if (this.resourceMap.has(id)) {
+            return this.resourceMap.get(id);
+        } else {
+            let object = await this.dataCollection.get(id);
+            object = Registry.removeInternalProperties(object);
+            try {
+                const resource = this.serializer.fromJSON(object);
+                await this.accessController.check(resource, 'READ');
+                this.resourceMap.set(id, resource);
+                return resource;
+            } catch (error) {
+                throw new Error(`Object with ID '${id}' in collection with ID '${this.type}:${this.id}' does not exist`);
+            }
         }
     }
 
@@ -115,14 +122,20 @@ class Registry extends EventEmitter {
         if (!exists) {
             return false;
         }
-        let object = await this.dataCollection.get(id);
-        object = Registry.removeInternalProperties(object);
-        try {
-            const resource = this.serializer.fromJSON(object);
-            await this.accessController.check(resource, 'READ');
+
+        if (this.resourceMap.has(id)) {
             return true;
-        } catch (error) {
-            return false;
+        } else {
+            let object = await this.dataCollection.get(id);
+            object = Registry.removeInternalProperties(object);
+            try {
+                const resource = this.serializer.fromJSON(object);
+                await this.accessController.check(resource, 'READ');
+                this.resourceMap.set(id, resource);
+                return true;
+            } catch (error) {
+                return false;
+            }
         }
     }
 
@@ -200,7 +213,7 @@ class Registry extends EventEmitter {
         }
     }
 
-    /**
+     /**
      * An event signalling that a resource has been updated in this registry.
      * @event Registry#resourceupdated
      * @protected
@@ -240,11 +253,24 @@ class Registry extends EventEmitter {
         options = Object.assign({}, baseDefaultOptions, options);
         let object = this.serializer.toJSON(resource, options);
         object = this.addInternalProperties(object);
-        const oldObject = await this.dataCollection.get(id);
-        const oldResource = this.serializer.fromJSON(oldObject);
+
+        let oldResource;
+        if (this.resourceMap.has(id)) {
+            oldResource = this.resourceMap.get(id);
+        } else {
+            let oldObject = await this.dataCollection.get(id);
+            oldResource = this.serializer.fromJSON(oldObject);
+        }
+
         // We must perform access control checks on the old version of the resource!
         await this.accessController.check(oldResource, 'UPDATE');
         await this.dataCollection.update(id, object);
+
+        // If is within resourceMap cache, update may have changed the ability to READ item, so remove it
+        if (this.resourceMap.has(id)) {
+            this.resourceMap.delete(id);
+        }
+
         this.emit('resourceupdated', {
             registry: this,
             oldResource: oldResource,
@@ -281,13 +307,23 @@ class Registry extends EventEmitter {
             // the resource using its ID from the registry. We need to
             // do this to figure out the type of the resource for
             // access control.
-            let object = await this.dataCollection.get(resource);
-            object = Registry.removeInternalProperties(object);
-            resource = this.serializer.fromJSON(object);
+            if (this.resourceMap.has(resource)) {
+                resource = this.resourceMap.get(resource);
+            } else {
+                let object = await this.dataCollection.get(resource);
+                object = Registry.removeInternalProperties(object);
+                resource = this.serializer.fromJSON(object);
+            }
         }
         const id = resource.getIdentifier();
         await this.accessController.check(resource, 'DELETE');
         await this.dataCollection.remove(id);
+
+        // Remove from cache if present
+        if (this.resourceMap.has(id)) {
+            this.resourceMap.delete(id);
+        }
+
         this.emit('resourceremoved', {
             registry: this,
             resourceID: id


### PR DESCRIPTION
Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>

closes #4076 by introduction of a registry cache within the transaction. Basic rules of the cache:
1) Nobody talks about the cache
2) If required item is not in the cache, a lookup is performed to retrieve, and it is put into the cache
3) If an item is in the cache, that item is used
4) If an item is removed from the data collection, it is removed from the cache
5) If an item is updated in the data collection, it is removed from the cache

