### PR TITLE
Export for CLI classes added

### DIFF
--- a/packages/composer-cli/index.js
+++ b/packages/composer-cli/index.js
@@ -17,7 +17,7 @@
 module.exports.version = require('./package.json');
 
 /**
- * The command line interface for Hyperledger Composer.
+ * The command line interface for Hyperledger Composer
  * @module composer-cli
  */
 module.exports.Archive = require('./lib/cmds/archive');

--- a/packages/composer-cli/index.js
+++ b/packages/composer-cli/index.js
@@ -17,7 +17,10 @@
 module.exports.version = require('./package.json');
 
 /**
- * The command line interface for Hyperledger Composer
+ * The command line interface for Hyperledger Composer.
+ *
+ * Composer is a framework for creating blockchain backed digital networks and
+ * exchanging assets between participants via processing transactions.
  * @module composer-cli
  */
 module.exports.Archive = require('./lib/cmds/archive');

--- a/packages/composer-cli/index.js
+++ b/packages/composer-cli/index.js
@@ -15,3 +15,16 @@
 'use strict';
 
 module.exports.version = require('./package.json');
+
+/**
+ * The command line interface for Hyperledger Composer. 
+ * @module composer-cli
+ */
+module.exports.Archive = require('./lib/cmds/archive');
+module.exports.Card = require('./lib/cmds/card');
+module.exports.Generator = require('./lib/cmds/generator');
+module.exports.Identity = require('./lib/cmds/identity');
+module.exports.Network = require('./lib/cmds/network');
+module.exports.Participant = require('./lib/cmds/participant');
+module.exports.Report = require('./lib/cmds/report');
+module.exports.Transaction = require('./lib/cmds/transaction');

--- a/packages/composer-cli/index.js
+++ b/packages/composer-cli/index.js
@@ -17,7 +17,7 @@
 module.exports.version = require('./package.json');
 
 /**
- * The command line interface for Hyperledger Composer. 
+ * The command line interface for Hyperledger Composer.
  * @module composer-cli
  */
 module.exports.Archive = require('./lib/cmds/archive');

--- a/packages/composer-cli/lib/cmds/archive.js
+++ b/packages/composer-cli/lib/cmds/archive.js
@@ -22,3 +22,6 @@ exports.builder = function (yargs) {
    .commandDir('archive');
 };
 exports.handler = function (argv) {};
+
+module.exports.Create = require('./archive/lib/create');
+module.exports.List = require('./archive/lib/list');

--- a/packages/composer-cli/lib/cmds/card.js
+++ b/packages/composer-cli/lib/cmds/card.js
@@ -22,3 +22,9 @@ exports.builder = function (yargs) {
    .commandDir('card');
 };
 exports.handler = function (argv) {};
+
+module.exports.Create = require('./card/lib/create');
+module.exports.Delete = require('./card/lib/delete');
+module.exports.Export = require('./card/lib/export');
+module.exports.Import = require('./card/lib/import');
+module.exports.List = require('./card/lib/list');

--- a/packages/composer-cli/lib/cmds/generator.js
+++ b/packages/composer-cli/lib/cmds/generator.js
@@ -22,3 +22,5 @@ exports.builder = function (yargs) {
    .commandDir('generator');
 };
 exports.handler = function (argv) {};
+
+module.exports.Create = require('./generator/lib/createCode');

--- a/packages/composer-cli/lib/cmds/identity.js
+++ b/packages/composer-cli/lib/cmds/identity.js
@@ -22,3 +22,9 @@ exports.builder = function (yargs) {
    .commandDir('identity');
 };
 exports.handler = function (argv) {};
+
+module.exports.Bind = require('./identity/lib/bind');
+module.exports.Issue = require('./identity/lib/issue');
+module.exports.List = require('./identity/lib/list');
+module.exports.Request = require('./identity/lib/request');
+module.exports.Revoke = require('./identity/lib/revoke');

--- a/packages/composer-cli/lib/cmds/network.js
+++ b/packages/composer-cli/lib/cmds/network.js
@@ -21,6 +21,13 @@ exports.builder = function (yargs) {
     return yargs.demandCommand(1, 'Incorrect command. Please see the list of commands above, or enter "composer network --help".')
         .commandDir('network');
 };
-exports.handler = function (argv) {
+exports.handler = function (argv) {};
 
-};
+module.exports.Download = require('./network/lib/download');
+module.exports.Install = require('./network/lib/install');
+module.exports.List = require('./network/lib/list');
+module.exports.LogLevel = require('./network/lib/loglevel');
+module.exports.Ping = require('./network/lib/ping');
+module.exports.Reset = require('./network/lib/reset');
+module.exports.Start = require('./network/lib/start');
+module.exports.Upgrade = require('./network/lib/upgrade');

--- a/packages/composer-cli/lib/cmds/participant.js
+++ b/packages/composer-cli/lib/cmds/participant.js
@@ -22,3 +22,5 @@ exports.builder = function (yargs) {
    .commandDir('participant');
 };
 exports.handler = function (argv) {};
+
+module.exports.Add = require('./participant/lib/add');

--- a/packages/composer-cli/lib/cmds/report.js
+++ b/packages/composer-cli/lib/cmds/report.js
@@ -21,3 +21,5 @@ exports.desc = 'Command for creating a report of the current Composer environmen
 exports.handler = function (argv) {
     return argv.thePromise = Report.handler(argv);
 };
+
+module.exports.Report = require('./report/lib/report');

--- a/packages/composer-cli/lib/cmds/transaction.js
+++ b/packages/composer-cli/lib/cmds/transaction.js
@@ -22,3 +22,5 @@ exports.builder = function (yargs) {
    .commandDir('transaction');
 };
 exports.handler = function (argv) {};
+
+module.exports.Submit = require('./transaction/lib/submit');


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->
As discussed [here](https://chat.hyperledger.org/channel/composer-contributors?msg=Ha9Ryh99HoXt6GW2e), it could be useful to export the classes that are in the composer-cli package in order to use it in a JS library.
I didn't add any documentation about those available classes but let me know if it would be useful.

With this PR, it will be possible to use this for instance :
``` js
const CardCreate = require('./packages/composer-cli').Card.Create;

let options = {
  file: "conga.card",
  businessNetworkName: "penguin-network",
  connectionProfileFile: "connection.json",
  user: "conga",
  enrollSecret: "supersecret"
};

CardCreate.handler(options);
```