### PR TITLE
Add networkAdminPrivateKeyFile option to `composer network start`

### DIFF
--- a/packages/composer-admin/lib/adminconnection.js
+++ b/packages/composer-admin/lib/adminconnection.js
@@ -433,7 +433,7 @@ class AdminConnection {
      * @param {String} networkName - Name of the business network to start
      * @param {String} networkVersion - Version of the business network to start
      * @param {Object} [startOptions] connector specific start options
-     *                  networkAdmins:   [ { userName, certificate } , { userName, enrollmentSecret  }]
+     *                  networkAdmins:   [ { userName, certificate, privateKey } , { userName, enrollmentSecret  }]
      *
      * @return {Promise} A promise that will be fufilled when the business network has been
      * deployed - with a MAP of cards key is name
@@ -463,22 +463,30 @@ class AdminConnection {
                 if (networkAdmins){
                     networkAdmins.forEach( (networkAdmin) =>{
 
-                        let metadata= {
+                        const metadata = {
                             version : 1,
                             userName : networkAdmin.userName,
                             businessNetwork : networkName
                         };
 
-                        let newCard;
-                        if (networkAdmin.enrollmentSecret ){
-                            metadata.enrollmentSecret = networkAdmin.enrollmentSecret ;
-                            newCard = new IdCard(metadata,connectionProfile);
-                        } else {
-                            newCard = new IdCard(metadata,connectionProfile);
-                            newCard.setCredentials({ certificate : networkAdmin.certificate });
+                        const enrollmentSecret = networkAdmin.enrollmentSecret;
+                        if (enrollmentSecret) {
+                            metadata.enrollmentSecret = enrollmentSecret;
                         }
-                        createdCards.set(networkAdmin.userName,newCard);
 
+                        const newCard = new IdCard(metadata, connectionProfile);
+
+                        const certificate = networkAdmin.certificate;
+                        if (certificate) {
+                            const credentials = { certificate: certificate };
+                            const privateKey = networkAdmin.privateKey;
+                            if (privateKey) {
+                                credentials.privateKey = privateKey;
+                            }
+                            newCard.setCredentials(credentials);
+                        }
+
+                        createdCards.set(networkAdmin.userName,newCard);
                     });
                 }
                 LOG.exit(method);

--- a/packages/composer-cli/lib/cmds/network/startCommand.js
+++ b/packages/composer-cli/lib/cmds/network/startCommand.js
@@ -28,12 +28,13 @@ module.exports.builder = function (yargs) {
         optionsFile: { alias: 'O', required: false, describe: 'A file containing options that are specific to connection', type: 'string' },
         networkAdmin: { alias: 'A', required: true, description: 'The identity name of the business network administrator', type: 'string' },
         networkAdminCertificateFile: { alias: 'C', required: false, description: 'The certificate of the business network administrator', type: 'string' },
+        networkAdminPrivateKeyFile: { alias: 'K', required: false, description: 'The private key of the business network administrator', type: 'string' },
         networkAdminEnrollSecret: { alias: 'S', required: false, description: 'The enrollment secret for the business network administrator', type: 'string', default: undefined },
         file: { alias: 'f', required: false, description: 'File name of the card to be created', type: 'string'}
     });
 
     // enforce the option after these options
-    yargs.requiresArg(['file','networkName','networkVersion','networkAdmin','networkAdminCertificateFile','networkAdminEnrollSecret','card']);
+    yargs.requiresArg(['file','networkName','networkVersion','networkAdmin','networkAdminCertificateFile','networkAdminPrivateKeyFile','networkAdminEnrollSecret','card']);
 
     yargs.conflicts('C','S');
 

--- a/packages/composer-cli/lib/cmds/utils/cmdutils.js
+++ b/packages/composer-cli/lib/cmds/utils/cmdutils.js
@@ -99,22 +99,28 @@ class CmdUtil {
     /**
      * Parse the business network administrators which have been specified using certificate files.
      * @param {string[]} networkAdmins Identity names for the business network administrators.
-     * @param {string[]} networkAdminCertificateFiles Certificate files for the business network administrators.
+     * @param {string[]} certificateFiles Certificate files for the business network administrators.
+     * @param {string[]} privateKeyFiles Private key files for the business network administrators.
      * @return {Object[]} The business network administrators.
      */
-    static parseNetworkAdminsWithCertificateFiles(networkAdmins, networkAdminCertificateFiles) {
+    static parseNetworkAdminsWithCertificateFiles(networkAdmins, certificateFiles, privateKeyFiles) {
 
         // Go through each network admin.
         return networkAdmins.map((networkAdmin, index) => {
 
             // Load the specified certificate for the network admin.
-            const certificateFile = networkAdminCertificateFiles[index];
-            const certificate = fs.readFileSync(certificateFile, { encoding: 'utf8' });
-            return {
+            const certificate = fs.readFileSync(certificateFiles[index], { encoding: 'utf8' });
+            const networkAdminInfo = {
                 userName: networkAdmin,
-                certificate
+                certificate: certificate
             };
 
+            const privateKeyFile = privateKeyFiles[index];
+            if (privateKeyFile) {
+                networkAdminInfo.privateKey = fs.readFileSync(privateKeyFile, { encoding: 'utf8' });
+            }
+
+            return networkAdminInfo;
         });
 
     }
@@ -151,6 +157,7 @@ class CmdUtil {
         // Convert the arguments into arrays.
         const networkAdmins = CmdUtil.arrayify(argv.networkAdmin);
         const networkAdminCertificateFiles = CmdUtil.arrayify(argv.networkAdminCertificateFile);
+        const networkAdminPrivateKeyFiles = CmdUtil.arrayify(argv.networkAdminPrivateKeyFile);
         const networkAdminEnrollSecrets = CmdUtil.arrayify(argv.networkAdminEnrollSecret);
         const files = CmdUtil.arrayify(argv.file);
 
@@ -167,7 +174,7 @@ class CmdUtil {
         // Check that enough certificate files have been specified.
         let result;
         if (networkAdmins.length === networkAdminCertificateFiles.length) {
-            result = CmdUtil.parseNetworkAdminsWithCertificateFiles(networkAdmins, networkAdminCertificateFiles);
+            result = CmdUtil.parseNetworkAdminsWithCertificateFiles(networkAdmins, networkAdminCertificateFiles, networkAdminPrivateKeyFiles);
         }
 
         // Check that enough enrollment secrets have been specified.

--- a/packages/composer-cli/test/network/start.js
+++ b/packages/composer-cli/test/network/start.js
@@ -96,15 +96,21 @@ describe('composer start network CLI unit tests', function () {
         });
 
         it('should correctly execute with all required parameters and certificate file', function () {
+            const readFileSyncStub = sandbox.stub(fs,'readFileSync');
+
             const certificate = 'this-is-a-certificate-honest-guv';
-            sandbox.stub(fs,'readFileSync').withArgs('certificate-file').returns(certificate);
+            readFileSyncStub.withArgs('certificate-file').returns(certificate);
+
+            const privateKey = 'this-is-a-private-key-honest-guv';
+            readFileSyncStub.withArgs('private-key-file').returns(privateKey);
 
             let argv = {
                 card: 'cardname',
                 networkName: networkName,
                 networkVersion: networkVersion,
                 networkAdmin: 'admin',
-                networkAdminCertificateFile: 'certificate-file'
+                networkAdminCertificateFile: 'certificate-file',
+                networkAdminPrivateKeyFile: 'private-key-file'
             };
             return StartCmd.handler(argv).then(result => {
                 argv.thePromise.should.be.a('promise');
@@ -113,7 +119,7 @@ describe('composer start network CLI unit tests', function () {
                 sinon.assert.calledOnce(mockAdminConnection.start);
                 sinon.assert.calledWith(mockAdminConnection.start, networkName, networkVersion,
                     {
-                        networkAdmins: [{ certificate: certificate, userName: 'admin' }]
+                        networkAdmins: [{ certificate: certificate, privateKey: privateKey, userName: 'admin' }]
                     });
             });
         });

--- a/packages/composer-website/jekylldocs/reference/composer.network.start.md
+++ b/packages/composer-website/jekylldocs/reference/composer.network.start.md
@@ -35,6 +35,7 @@ Options:
   --optionsFile, -O                  A file containing options that are specific to connection  [string]
   --networkAdmin, -A                 The identity name of the business network administrator  [string] [required]
   --networkAdminCertificateFile, -C  The certificate of the business network administrator  [string]
+  --networkAdminPrivateKeyFile, -K   The private key of the business network administrator  [string]
   --networkAdminEnrollSecret, -S     The enrollment secret for the business network administrator  [string]
   --card, -c                         The cardname to use to start the network  [string] [required]
   --file, -f                         File name of the card to be created  [string]


### PR DESCRIPTION
Resolves #4044 

Ensures that, when the network is started using network admin
certificates instead of enrollment secrets, the network admin
card(s) produced can actually be imported and used.

The `networkAdminPrivateKeyFile` option is optional, so the CLI
can still be used in an identical manner to before this change.