### PR TITLE
Fix for manual refresh when assets/participants are edited

### DIFF
--- a/packages/composer-tests-integration/features/generator-angular.feature
+++ b/packages/composer-tests-integration/features/generator-angular.feature
@@ -44,7 +44,7 @@ Feature: Angular Application Generator
             """
             npm test --prefix ./my-angular-app
             """
-        Then The stdout information should include text matching /Executed 5 of 5 SUCCESS/
+        Then The stdout information should include text matching /Executed 11 of 11 SUCCESS/
 
     Scenario: I can start the generated application and test it with generated integration tests
         When I spawn the following background task GENERATED_APP, and wait for /webpack: Compiled successfully./

--- a/packages/generator-hyperledger-composer/generators/angular/index.js
+++ b/packages/generator-hyperledger-composer/generators/angular/index.js
@@ -745,7 +745,7 @@ module.exports = yeoman.Base.extend({
                 this.fs.copyTpl(
                     this.templatePath('src/app/asset/asset.component.spec.ts'),
                     this.destinationPath('src/app/' + assetList[x].name + '/' + assetList[x].name + '.component.spec.ts'), {
-                        assetName: assetList[x].name
+                        currentAsset: assetList[x]
                     }
                 );
                 this.fs.copyTpl(
@@ -782,7 +782,7 @@ module.exports = yeoman.Base.extend({
                 this.fs.copyTpl(
                     this.templatePath('src/app/participant/participant.component.spec.ts'),
                     this.destinationPath('src/app/' + participantList[x].name + '/' + participantList[x].name + '.component.spec.ts'), {
-                        participantName: participantList[x].name
+                        currentParticipant: participantList[x]
                     }
                 );
                 this.fs.copyTpl(

--- a/packages/generator-hyperledger-composer/generators/angular/templates/src/app/asset/asset.component.html
+++ b/packages/generator-hyperledger-composer/generators/angular/templates/src/app/asset/asset.component.html
@@ -66,7 +66,7 @@
         </div>
         <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-          <button (click)="addAsset(myForm);" type="submit" class="btn btn-success" value="Refresh Page" onClick="setTimeout(window.location.reload.bind(window.location), 2000);" data-dismiss="modal">Confirm</button>
+          <button (click)="addAsset(myForm);" type="submit" class="btn btn-success" data-dismiss="modal">Confirm</button>
 
         </div>
       </form>
@@ -138,7 +138,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-          <button (click)="updateAsset(myForm)" type="submit" class="btn btn-success" value="Refresh Page" onClick="setTimeout(window.location.reload.bind(window.location), 2000);" data-dismiss="modal">Submit</button>
+          <button (click)="updateAsset(myForm)" type="submit" class="btn btn-success" data-dismiss="modal">Submit</button>
         </div>
       </form>
     </div>
@@ -154,13 +154,13 @@
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <h4 class="modal-title" id="deleteAssetModalLabel">Delete Asset</h4>
       </div>
-      <form [formGroup]="myForm" (ngSubmit)="deleteAsset()">
+      <form [formGroup]="myForm">
         <div class="modal-body">
           Are you sure you want to delete this asset?
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">No</button>
-          <button (click)="deleteAsset()" type="submit" class="btn btn-danger" value="Refresh Page" onClick="setTimeout(window.location.reload.bind(window.location), 2000);" data-dismiss="modal">Yes</button>
+          <button (click)="deleteAsset()" type="submit" class="btn btn-danger" data-dismiss="modal">Yes</button>
         </div>
       </form>
     </div>

--- a/packages/generator-hyperledger-composer/generators/angular/templates/src/app/asset/asset.component.spec.ts
+++ b/packages/generator-hyperledger-composer/generators/angular/templates/src/app/asset/asset.component.spec.ts
@@ -12,33 +12,34 @@
  * limitations under the License.
  */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { HttpModule } from '@angular/http';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, FormGroup, FormControl } from '@angular/forms';
 import * as sinon from 'sinon';
 import { DataService } from '../data.service';
-import { <%= assetName %>Component } from './<%= assetName %>.component';
-import { <%= assetName %>Service } from './<%= assetName %>.service';
+import { <%= currentAsset.name %>Component } from './<%= currentAsset.name %>.component';
+import { <%= currentAsset.name %>Service } from './<%= currentAsset.name %>.service';
+import { Observable } from 'rxjs'
 
-describe('<%= assetName %>Component', () => {
-  let component: <%= assetName %>Component;
-  let fixture: ComponentFixture<<%= assetName %>Component>;
+describe('<%= currentAsset.name %>Component', () => {
+  let component: <%= currentAsset.name %>Component;
+  let fixture: ComponentFixture<<%= currentAsset.name %>Component>;
 
-  let mock<%= assetName %>Service;
+  let mock<%= currentAsset.name %>Service;
   let mockDataService
 
   beforeEach(async(() => {
 
-    mock<%= assetName %>Service = sinon.createStubInstance(<%= assetName %>Service);
-    mock<%= assetName %>Service.getAll.returns([]);
+    mock<%= currentAsset.name %>Service = sinon.createStubInstance(<%= currentAsset.name %>Service);
+    mock<%= currentAsset.name %>Service.getAll.returns([]);
     mockDataService = sinon.createStubInstance(DataService);
 
     TestBed.configureTestingModule({
-      declarations: [ <%= assetName %>Component ],
+      declarations: [ <%= currentAsset.name %>Component ],
       imports: [
         BrowserModule,
         FormsModule,
@@ -46,12 +47,12 @@ describe('<%= assetName %>Component', () => {
         HttpModule
       ],
       providers: [
-        {provide: <%= assetName %>Service, useValue: mock<%= assetName %>Service },
+        {provide: <%= currentAsset.name %>Service, useValue: mock<%= currentAsset.name %>Service },
         {provide: DataService, useValue: mockDataService },
       ]
     });
 
-    fixture = TestBed.createComponent(<%= assetName %>Component);
+    fixture = TestBed.createComponent(<%= currentAsset.name %>Component);
     component = fixture.componentInstance;
 
   }));
@@ -59,5 +60,60 @@ describe('<%= assetName %>Component', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should update the table when a <%= currentAsset.name %> is added', fakeAsync(() => {
+    let loadAllSpy = sinon.stub(component, 'loadAll');
+    sinon.stub(component.service<%= currentAsset.name %>, 'addAsset').returns(new Observable<any>(observer => {
+      observer.next('');
+      observer.complete();
+    }));
+
+    component.addAsset({});
+
+    tick();
+    
+    expect(loadAllSpy.callCount).toBe(1);
+
+    loadAllSpy.restore();
+  }));
+
+  it('should update the table when a <%= currentAsset.name %> is updated', fakeAsync(() => {
+    let loadAllSpy = sinon.stub(component, 'loadAll');
+    sinon.stub(component.service<%= currentAsset.name %>, 'updateAsset').returns(new Observable<any>(observer => {
+      observer.next('');
+      observer.complete();
+    }));
+
+    // mock form to be passed to the update function
+    let mockForm = new FormGroup({
+      <%= currentAsset.identifier %>: new FormControl('id')
+    });
+
+    component.updateAsset(mockForm);
+
+    tick();
+
+    expect(loadAllSpy.callCount).toBe(1);
+
+    loadAllSpy.restore();
+  }));
+
+  it('should update the table when a <%= currentAsset.name %> is deleted', fakeAsync(() => {
+    let loadAllSpy = sinon.stub(component, 'loadAll');
+    sinon.stub(component.service<%= currentAsset.name %>, 'deleteAsset').returns(new Observable<any>(observer => {
+      observer.next('');
+      observer.complete();
+    }));
+
+    component.setId('id');
+    
+    component.deleteAsset();
+
+    tick();
+
+    expect(loadAllSpy.callCount).toBe(1);
+
+    loadAllSpy.restore();
+  }));  
 
 });

--- a/packages/generator-hyperledger-composer/generators/angular/templates/src/app/asset/asset.component.ts
+++ b/packages/generator-hyperledger-composer/generators/angular/templates/src/app/asset/asset.component.ts
@@ -40,7 +40,7 @@ export class <%= currentAsset.name %>Component implements OnInit {
             <%_ } _%>
       <%_ } _%>
 
-  constructor(private service<%= currentAsset.name %>: <%= currentAsset.name %>Service, fb: FormBuilder) {
+  constructor(public service<%= currentAsset.name %>: <%= currentAsset.name %>Service, fb: FormBuilder) {
     this.myForm = fb.group({
           <%_ for(var x=0;x<currentAsset.properties.length;x++){ _%>
               <%_ if (x == currentAsset.properties.length-1) { _%>
@@ -138,6 +138,7 @@ export class <%= currentAsset.name %>Component implements OnInit {
               <%_ } _%>
             <%_ } _%>
       });
+      this.loadAll();
     })
     .catch((error) => {
       if (error === 'Server error') {
@@ -169,6 +170,7 @@ export class <%= currentAsset.name %>Component implements OnInit {
     .toPromise()
     .then(() => {
       this.errorMessage = null;
+      this.loadAll();
     })
     .catch((error) => {
       if (error === 'Server error') {
@@ -188,6 +190,7 @@ export class <%= currentAsset.name %>Component implements OnInit {
     .toPromise()
     .then(() => {
       this.errorMessage = null;
+      this.loadAll();
     })
     .catch((error) => {
       if (error === 'Server error') {

--- a/packages/generator-hyperledger-composer/generators/angular/templates/src/app/participant/participant.component.html
+++ b/packages/generator-hyperledger-composer/generators/angular/templates/src/app/participant/participant.component.html
@@ -66,7 +66,7 @@
           </div>
           <div class="modal-footer">
               <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-            <button (click)="addParticipant(myForm);" type="submit" class="btn btn-success" value="Refresh Page" onClick="setTimeout(window.location.reload.bind(window.location), 2000);" data-dismiss="modal">Confirm</button>
+            <button (click)="addParticipant(myForm);" type="submit" class="btn btn-success" data-dismiss="modal">Confirm</button>
   
           </div>
         </form>
@@ -138,7 +138,7 @@
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-            <button (click)="updateParticipant(myForm)" type="submit" class="btn btn-success" value="Refresh Page" onClick="setTimeout(window.location.reload.bind(window.location), 2000);" data-dismiss="modal">Submit</button>
+            <button (click)="updateParticipant(myForm)" type="submit" class="btn btn-success" data-dismiss="modal">Submit</button>
           </div>
         </form>
       </div>
@@ -154,13 +154,13 @@
           <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
           <h4 class="modal-title" id="deleteParticipantModalLabel">Delete Participant</h4>
         </div>
-        <form [formGroup]="myForm" (ngSubmit)="deleteParticipant()">
+        <form [formGroup]="myForm">
           <div class="modal-body">
             Are you sure you want to delete this participant?
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">No</button>
-            <button (click)="deleteParticipant()" type="submit" class="btn btn-danger" value="Refresh Page" onClick="setTimeout(window.location.reload.bind(window.location), 2000);" data-dismiss="modal">Yes</button>
+            <button (click)="deleteParticipant()" type="submit" class="btn btn-danger" data-dismiss="modal">Yes</button>
           </div>
         </form>
       </div>

--- a/packages/generator-hyperledger-composer/generators/angular/templates/src/app/participant/participant.component.spec.ts
+++ b/packages/generator-hyperledger-composer/generators/angular/templates/src/app/participant/participant.component.spec.ts
@@ -12,33 +12,34 @@
  * limitations under the License.
  */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { HttpModule } from '@angular/http';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, FormGroup, FormControl } from '@angular/forms';
 import * as sinon from 'sinon';
 import { DataService } from '../data.service';
-import { <%= participantName %>Component } from './<%= participantName %>.component';
-import {<%= participantName %>Service} from './<%= participantName %>.service';
+import { <%= currentParticipant.name %>Component } from './<%= currentParticipant.name %>.component';
+import { <%= currentParticipant.name %>Service } from './<%= currentParticipant.name %>.service';
+import { Observable } from 'rxjs';
 
-describe('<%= participantName %>Component', () => {
-  let component: <%= participantName %>Component;
-  let fixture: ComponentFixture<<%= participantName %>Component>;
+describe('<%= currentParticipant.name %>Component', () => {
+  let component: <%= currentParticipant.name %>Component;
+  let fixture: ComponentFixture<<%= currentParticipant.name %>Component>;
 
-  let mock<%= participantName %>Service;
+  let mock<%= currentParticipant.name %>Service;
   let mockDataService
 
   beforeEach(async(() => {
 
-    mock<%= participantName %>Service = sinon.createStubInstance(<%= participantName %>Service);
-    mock<%= participantName %>Service.getAll.returns([]);
+    mock<%= currentParticipant.name %>Service = sinon.createStubInstance(<%= currentParticipant.name %>Service);
+    mock<%= currentParticipant.name %>Service.getAll.returns([]);
     mockDataService = sinon.createStubInstance(DataService);
 
     TestBed.configureTestingModule({
-      declarations: [ <%= participantName %>Component ],
+      declarations: [ <%= currentParticipant.name %>Component ],
       imports: [
         BrowserModule,
         FormsModule,
@@ -46,12 +47,12 @@ describe('<%= participantName %>Component', () => {
         HttpModule
       ],
       providers: [
-        {provide: <%= participantName %>Service, useValue: mock<%= participantName %>Service },
+        {provide: <%= currentParticipant.name %>Service, useValue: mock<%= currentParticipant.name %>Service },
         {provide: DataService, useValue: mockDataService },
       ]
     });
 
-    fixture = TestBed.createComponent(<%= participantName %>Component);
+    fixture = TestBed.createComponent(<%= currentParticipant.name %>Component);
     component = fixture.componentInstance;
 
   }));
@@ -59,5 +60,58 @@ describe('<%= participantName %>Component', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should update the table when a <%= currentParticipant.name %> is added', fakeAsync(() => {
+    let loadAllSpy = sinon.stub(component, 'loadAll');
+    sinon.stub(component.service<%= currentParticipant.name %>, 'addParticipant').returns(new Observable(observer => {
+      observer.next('');
+      observer.complete();
+    }));
+
+    component.addParticipant({});
+
+    tick();
+
+    expect(loadAllSpy.callCount).toBe(1);
+
+    loadAllSpy.restore();
+  }));
+
+  it('should update the table when a <%= currentParticipant.name %> is updated', fakeAsync(() => {
+    let loadAllSpy = sinon.stub(component, 'loadAll');
+    sinon.stub(component.service<%= currentParticipant.name %>, 'updateParticipant').returns(new Observable(observer => {
+      observer.next('');
+      observer.complete();
+    }));
+
+    // mock form to be passed to the update function
+    let mockForm = new FormGroup({
+      <%= currentParticipant.identifier %>: new FormControl('id')
+    });
+    
+    component.updateParticipant(mockForm);
+
+    tick();
+
+    expect(loadAllSpy.callCount).toBe(1);
+
+    loadAllSpy.restore();
+  }));
+  
+  it('should update the table when a <%= currentParticipant.name %> is deleted', fakeAsync(() => {
+    let loadAllSpy = sinon.stub(component, 'loadAll');
+    sinon.stub(component.service<%= currentParticipant.name %>, 'deleteParticipant').returns(new Observable(observer => {
+      observer.next('');
+      observer.complete();
+    }));
+
+    component.deleteParticipant();
+
+    tick();
+
+    expect(loadAllSpy.callCount).toBe(1);
+
+    loadAllSpy.restore();
+  }));
 
 });

--- a/packages/generator-hyperledger-composer/generators/angular/templates/src/app/participant/participant.component.ts
+++ b/packages/generator-hyperledger-composer/generators/angular/templates/src/app/participant/participant.component.ts
@@ -41,7 +41,7 @@ export class <%= currentParticipant.name %>Component implements OnInit {
         <%_}_%>
 
 
-  constructor(private service<%= currentParticipant.name %>: <%= currentParticipant.name %>Service, fb: FormBuilder) {
+  constructor(public service<%= currentParticipant.name %>: <%= currentParticipant.name %>Service, fb: FormBuilder) {
     this.myForm = fb.group({
           <%_ for(var x=0;x<currentParticipant.properties.length;x++){ _%>
               <%_ if(x == currentParticipant.properties.length-1){ _%>
@@ -138,6 +138,7 @@ export class <%= currentParticipant.name %>Component implements OnInit {
               <%_ } _%>
             <%_ }_%>
       });
+      this.loadAll(); 
     })
     .catch((error) => {
       if (error === 'Server error') {
@@ -169,6 +170,7 @@ export class <%= currentParticipant.name %>Component implements OnInit {
     .toPromise()
     .then(() => {
       this.errorMessage = null;
+      this.loadAll();
     })
     .catch((error) => {
       if (error === 'Server error') {
@@ -188,6 +190,7 @@ export class <%= currentParticipant.name %>Component implements OnInit {
     .toPromise()
     .then(() => {
       this.errorMessage = null;
+      this.loadAll();
     })
     .catch((error) => {
       if (error === 'Server error') {


### PR DESCRIPTION
Signed-off-by: Erin Hughes <Erin.Hughes@ibm.com>

Removed the manual refresh and added a call for the list of assets/participants whenever something is updated, so that the table refreshes automatically.
Also added tests to cover this change.
