### PR TITLE
Allow decorators to accept types, add decorator factory

### DIFF
--- a/packages/composer-common/api.txt
+++ b/packages/composer-common/api.txt
@@ -71,7 +71,6 @@ class AssetDeclaration extends ClassDeclaration {
 }
 class ClassDeclaration extends Decorated {
    + void constructor(ModelFile,string) throws IllegalModelException
-   + ModelFile getModelFile() 
    + ClassDeclaration _resolveSuperType() 
    + string getSystemType() 
    + boolean isAbstract() 
@@ -100,6 +99,15 @@ class ClassDeclaration extends Decorated {
 class ConceptDeclaration extends ClassDeclaration {
    + void constructor(ModelFile,Object) throws IllegalModelException
    + boolean isConcept() 
+}
+class Decorator {
+   + void constructor(Object) throws IllegalModelException
+   + void getParent() 
+   + string getName() 
+   + object[] getArguments() 
+}
+class DecoratorFactory {
+   + Decorator newDecorator(Object) 
 }
 class EnumDeclaration extends ClassDeclaration {
    + void constructor(ModelFile,Object) throws IllegalModelException
@@ -240,6 +248,8 @@ class ModelManager {
    + ConceptDeclaration[] getConceptDeclarations(Boolean) 
    + Factory getFactory() 
    + Serializer getSerializer() 
+   + DecoratorFactory[] getDecoratorFactories() 
+   + void addDecoratorFactory(DecoratorFactory) 
 }
 class Serializer {
    + void constructor(Factory,ModelManager) 

--- a/packages/composer-common/changelog.txt
+++ b/packages/composer-common/changelog.txt
@@ -24,6 +24,9 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
+Version 0.19.10 {363781808e51ce0ec2b216c65f8fe3fa} 2018-06-29
+- Add decorator factories
+
 Version 0.19.1 {f6814276d318be3b4ed0f6212bc77c6f} 2018-04-06
 - Enable simple JSON.stringify serialization of resources
 

--- a/packages/composer-common/lib/introspect/classdeclaration.js
+++ b/packages/composer-common/lib/introspect/classdeclaration.js
@@ -46,23 +46,9 @@ class ClassDeclaration extends Decorated {
      * @throws {IllegalModelException}
      */
     constructor(modelFile, ast) {
-        super(ast);
-
-        if(!modelFile) {
-            throw new IllegalModelException(Globalize.formatMessage('classdeclaration-constructor-modelastreq'));
-        }
-        this.modelFile = modelFile;
+        super(modelFile, ast);
         this.process();
-        this.fqn = ModelUtil.getFullyQualifiedName(modelFile.getNamespace(), this.name);
-    }
-
-    /**
-     * Returns the ModelFile that defines this class.
-     *
-     * @return {ModelFile} the owning ModelFile
-     */
-    getModelFile() {
-        return this.modelFile;
+        this.fqn = ModelUtil.getFullyQualifiedName(this.modelFile.getNamespace(), this.name);
     }
 
     /**

--- a/packages/composer-common/lib/introspect/decorator.js
+++ b/packages/composer-common/lib/introspect/decorator.js
@@ -16,7 +16,6 @@
 
 /**
  * Decorator encapsulates a decorator (annotation) on a class or property.
- * @private
  * @class
  * @memberof module:composer-common
  */

--- a/packages/composer-common/lib/introspect/decoratorfactory.js
+++ b/packages/composer-common/lib/introspect/decoratorfactory.js
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * An interface for a class that processes a decorator and returns a specific
+ * implementation class for that decorator.
+ * @class
+ * @memberof module:composer-common
+ */
+class DecoratorFactory {
+
+    /**
+     * Process the decorator, and return a specific implementation class for that
+     * decorator, or return null if this decorator is not handled by this processor.
+     * @abstract
+     * @param {ClassDeclaration | Property} parent - the owner of this property
+     * @param {Object} ast - The AST created by the parser
+     * @return {Decorator} The decorator.
+     */
+    newDecorator(parent, ast) {
+        throw new Error('abstract function called');
+    }
+
+}
+
+module.exports = DecoratorFactory;

--- a/packages/composer-common/lib/introspect/parser.pegjs
+++ b/packages/composer-common/lib/introspect/parser.pegjs
@@ -1334,7 +1334,7 @@ VCHAR
 WSP
   = SP
   / HTAB
-  
+
 /* http://tools.ietf.org/html/rfc3986#section-2.1 Percent-Encoding */
 pct_encoded
   = $("%" HEXDIG HEXDIG)
@@ -1645,10 +1645,20 @@ DecoratorBoolean =
       }
   }
 
+DecoratorIdentifier =
+  value:Identifier __ array:"[]"? {
+      return {
+          type: "Identifier",
+          value: Object.assign({ array: !!array }, value),
+          location: location()
+      }
+  }
+
 DecoratorLiteral =
   DecoratorString
   / DecoratorBoolean
   / DecoratorNumber
+  / DecoratorIdentifier
 
 DecoratorArguments
   = "(" __ first:(d:DecoratorLiteral __ "," __ {return d;})* last:DecoratorLiteral? __ ")" {
@@ -1968,14 +1978,14 @@ Namespace
   = NamespaceToken __ namespace: QualifiedName __ {
   	return namespace;
   }
-  
+
 ImportInternal
     = ImportToken __ ns:$(QualifiedName '.*'?) __ {
     	return {
         	namespace: ns
         }
   }
-  
+
  ImportFrom
     = ImportToken __ ns:$(QualifiedName '.*'?) __ FromToken __ u:$URI __ {
     	return {

--- a/packages/composer-common/lib/introspect/property.js
+++ b/packages/composer-common/lib/introspect/property.js
@@ -33,7 +33,7 @@ class Property extends Decorated {
      * @throws {IllegalModelException}
      */
     constructor(parent, ast) {
-        super(ast);
+        super(parent.getModelFile(), ast);
         this.parent = parent;
         this.process();
     }

--- a/packages/composer-common/lib/modelmanager.js
+++ b/packages/composer-common/lib/modelmanager.js
@@ -61,9 +61,10 @@ class ModelManager {
     constructor() {
         LOG.entry('constructor');
         this.modelFiles = {};
-        this.addSystemModels();
         this.factory = new Factory(this);
         this.serializer = new Serializer(this.factory, this);
+        this.decoratorFactories = [];
+        this.addSystemModels();
         LOG.exit('constructor');
     }
 
@@ -556,6 +557,22 @@ class ModelManager {
      */
     getSerializer() {
         return this.serializer;
+    }
+
+    /**
+     * Get the decorator factories for this model manager.
+     * @return {DecoratorFactory[]} The decorator factories for this model manager.
+     */
+    getDecoratorFactories() {
+        return this.decoratorFactories;
+    }
+
+    /**
+     * Add a decorator factory to this model manager.
+     * @param {DecoratorFactory} factory The decorator factory to add to this model manager.
+     */
+    addDecoratorFactory(factory) {
+        this.decoratorFactories.push(factory);
     }
 
 }

--- a/packages/composer-common/test/composer/i18n.js
+++ b/packages/composer-common/test/composer/i18n.js
@@ -18,7 +18,6 @@ require('chai').should();
 const expect = require('chai').expect;
 const Globalize = require('./../../lib/globalize');
 const fs = require('fs');
-const ClassDeclaration = require('./../../lib/introspect/classdeclaration');
 const IllegalModelException = require('./../../lib/introspect/illegalmodelexception');
 const Factory = require('./../../lib/factory');
 const Serializer = require('./../../lib/serializer');
@@ -85,38 +84,6 @@ describe('Globalization', function() {
     });
 
     describe('#check ClassDeclaration messages are correct', function() {
-        it('check message in constructor()', function() {
-            let modelFileReq = Globalize.messageFormatter('classdeclaration-constructor-modelastreq');
-            modelFileReq(0).should.equal('ModelFile and AST are required to create a ClassDecl.');
-
-             // create and populate the ModelManager with a model file
-            const modelManager = new ModelManager();
-            let fileName = './test/data/model/composer.cto';
-            let file = fs.readFileSync(fileName, 'utf8');
-            file.should.not.be.null;
-            modelManager.addModelFile(file,fileName);
-
-            let modelFile = modelManager.getModelFile('composer');
-            modelFile.getNamespace().should.equal('composer');
-            let classDeclaration = modelFile.getType('composer.MyParticipant');
-            classDeclaration.should.not.be.undefined;
-
-            expect(function(){
-                new ClassDeclaration(true, classDeclaration.ast);
-            }).to.not.throw(IllegalModelException, 'ModelFile and AST are required to create a ClassDecl.');
-
-            expect(function(){
-                new ClassDeclaration(false, true);
-            }).to.throw(IllegalModelException, 'ModelFile and AST are required to create a ClassDecl.');
-
-            expect(function(){
-                new ClassDeclaration(true, false);
-            }).to.throw(IllegalModelException, 'ModelFile and AST are required to create a ClassDecl.');
-
-            expect(function(){
-                new ClassDeclaration(false, false);
-            }).to.throw(IllegalModelException, 'ModelFile and AST are required to create a ClassDecl.');
-        });
 
         it('check message in process()', function() {
             let formatter = Globalize('en').messageFormatter('classdeclaration-process-unrecmodelelem');

--- a/packages/composer-common/test/data/decorators/model.cto
+++ b/packages/composer-common/test/data/decorators/model.cto
@@ -91,3 +91,29 @@ enum MyEnum {
   @bar("enumValue")
   o VALUE
 }
+
+@returns(MyConcept)
+transaction MyTransactionIdentifier1 {
+
+}
+
+@returns(MyConcept[])
+transaction MyTransactionIdentifier2 {
+
+}
+
+@returns(String)
+transaction MyTransactionIdentifier3 {
+
+}
+
+@returns(String[])
+transaction MyTransactionIdentifier4 {
+
+}
+
+// should be boolean, not an identifier
+@returns(true)
+transaction MyTransactionIdentifier5 {
+
+}

--- a/packages/composer-common/test/introspect/assetdeclaration.js
+++ b/packages/composer-common/test/introspect/assetdeclaration.js
@@ -61,23 +61,6 @@ describe('AssetDeclaration', () => {
         return assets[assets.length - 1];
     };
 
-    describe('#constructor', () => {
-
-        it('should throw if modelFile not specified', () => {
-            (() => {
-                new AssetDeclaration(null, {});
-            }).should.throw(/required/);
-        });
-
-        it('should throw if ast not specified', () => {
-            let mockModelFile = sinon.createStubInstance(ModelFile);
-            (() => {
-                new AssetDeclaration(mockModelFile, null);
-            }).should.throw(/required/);
-        });
-
-    });
-
     describe('#validate', () => {
 
         // skip('should resolve an imported base asset', () => {

--- a/packages/composer-common/test/introspect/classdeclaration.js
+++ b/packages/composer-common/test/introspect/classdeclaration.js
@@ -43,18 +43,6 @@ describe('ClassDeclaration', () => {
 
     describe('#constructor', () => {
 
-        it('should throw if modelFile not specified', () => {
-            (() => {
-                new ClassDeclaration(null, {});
-            }).should.throw(/required/);
-        });
-
-        it('should throw if ast not specified', () => {
-            (() => {
-                new ClassDeclaration(modelFile, null);
-            }).should.throw(/required/);
-        });
-
         it('should throw if ast contains invalid type', () => {
             (() => {
                 new ClassDeclaration(modelFile, {
@@ -158,23 +146,6 @@ describe('ClassDeclaration', () => {
             clz.accept(visitor, ['some', 'args']);
             sinon.assert.calledOnce(visitor.visit);
             sinon.assert.calledWith(visitor.visit, clz, ['some', 'args']);
-        });
-
-    });
-
-    describe('#getModelFile', () => {
-
-        it('should return the model file', () => {
-            let clz = new ClassDeclaration(modelFile, {
-                id: {
-                    name: 'suchName'
-                },
-                body: {
-                    declarations: [
-                    ]
-                }
-            });
-            clz.getModelFile().should.equal(modelFile);
         });
 
     });

--- a/packages/composer-common/test/introspect/decorated.js
+++ b/packages/composer-common/test/introspect/decorated.js
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Decorated = require('../../lib/introspect/decorated');
+const ModelFile = require('../../lib/introspect/modelfile');
+
+require('chai').should();
+const sinon = require('sinon');
+
+describe('Decorated', () => {
+
+    let modelFile;
+    let decorated;
+
+    beforeEach(() => {
+        modelFile = sinon.createStubInstance(ModelFile);
+        decorated = new Decorated(modelFile, { ast: true });
+    });
+
+    describe('#constructor', () => {
+
+        it('should throw if modelFile not specified', () => {
+            (() => {
+                new Decorated(null, { ast: true });
+            }).should.throw(/modelFile not specified/);
+        });
+
+        it('should throw if ast not specified', () => {
+            (() => {
+                new Decorated(modelFile, null);
+            }).should.throw(/ast not specified/);
+        });
+
+    });
+
+    describe('#getModelFile', () => {
+
+        it('should return the model file', () => {
+            decorated.getModelFile().should.equal(modelFile);
+        });
+
+    });
+
+});

--- a/packages/composer-common/test/introspect/decoratorfactory.js
+++ b/packages/composer-common/test/introspect/decoratorfactory.js
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const DecoratorFactory = require('../../lib/introspect/decoratorfactory');
+
+require('chai').should();
+
+describe('DecoratorFactory', () => {
+
+    let decoratorFactory;
+
+    beforeEach(() => {
+        decoratorFactory = new DecoratorFactory();
+    });
+
+    describe('#newDecorator', () => {
+
+        it('should throw as abstract', () => {
+            (() => {
+                decoratorFactory.newDecorator();
+            }).should.throw(/abstract function called/);
+        });
+
+    });
+
+});

--- a/packages/composer-common/test/introspect/eventdeclaration.js
+++ b/packages/composer-common/test/introspect/eventdeclaration.js
@@ -68,22 +68,6 @@ describe('EventDeclaration', () => {
         sandbox.restore();
     });
 
-    describe('#constructor', () => {
-
-        it('should throw if modelFile not specified', () => {
-            (() => {
-                new EventDeclaration(null, {});
-            }).should.throw(/required/);
-        });
-
-        it('should throw if ast not specified', () => {
-            let mockModelFile = sinon.createStubInstance(ModelFile);
-            (() => {
-                new EventDeclaration(mockModelFile, null);
-            }).should.throw(/required/);
-        });
-    });
-
     describe('#validate', () => {
         it('should throw if event is not a system type but named event', () => {
             let event = loadLastDeclaration('test/data/parser/eventdeclaration.systypename.cto', EventDeclaration);

--- a/packages/composer-common/test/introspect/field.js
+++ b/packages/composer-common/test/introspect/field.js
@@ -16,6 +16,7 @@
 
 const ClassDeclaration = require('../../lib/introspect/classdeclaration');
 const Field = require('../../lib/introspect/field');
+const ModelFile = require('../../lib/introspect/modelfile');
 
 const should = require('chai').should();
 const sinon = require('sinon');
@@ -23,9 +24,12 @@ const sinon = require('sinon');
 describe('Field', () => {
 
     let mockClassDeclaration;
+    let mockModelFile;
 
     beforeEach(() => {
         mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+        mockModelFile = sinon.createStubInstance(ModelFile);
+        mockClassDeclaration.getModelFile.returns(mockModelFile);
     });
 
     describe('#constructor', () => {

--- a/packages/composer-common/test/introspect/participantdeclaration.js
+++ b/packages/composer-common/test/introspect/participantdeclaration.js
@@ -14,13 +14,11 @@
 
 'use strict';
 
-const ParticipantDeclaration = require('../../lib/introspect/participantdeclaration');
 const ModelFile = require('../../lib/introspect/modelfile');
 const ModelManager = require('../../lib/modelmanager');
 const fs = require('fs');
 
 require('chai').should();
-const sinon = require('sinon');
 
 describe('ParticipantDeclaration', () => {
 
@@ -38,23 +36,6 @@ describe('ParticipantDeclaration', () => {
 
         return assets[0];
     };
-
-    describe('#constructor', () => {
-
-        it('should throw if modelFile not specified', () => {
-            (() => {
-                new ParticipantDeclaration(null, {});
-            }).should.throw(/required/);
-        });
-
-        it('should throw if ast not specified', () => {
-            let mockModelFile = sinon.createStubInstance(ModelFile);
-            (() => {
-                new ParticipantDeclaration(mockModelFile, null);
-            }).should.throw(/required/);
-        });
-
-    });
 
     describe('#isRelationshipTarget', () => {
         it('should return true', () => {

--- a/packages/composer-common/test/introspect/property.js
+++ b/packages/composer-common/test/introspect/property.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const ClassDeclaration = require('../../lib/introspect/classdeclaration');
+const ModelFile = require('../../lib/introspect/modelfile');
 const Property = require('../../lib/introspect/property');
 
 const should = require('chai').should();
@@ -23,9 +24,12 @@ const sinon = require('sinon');
 describe('Property', () => {
 
     let mockClassDeclaration;
+    let mockModelFile;
 
     beforeEach(() => {
         mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+        mockModelFile = sinon.createStubInstance(ModelFile);
+        mockClassDeclaration.getModelFile.returns(mockModelFile);
     });
 
     describe('#constructor', () => {

--- a/packages/composer-common/test/modelmanager.js
+++ b/packages/composer-common/test/modelmanager.js
@@ -16,6 +16,7 @@
 
 const AssetDeclaration = require('../lib/introspect/assetdeclaration');
 const ConceptDeclaration = require('../lib/introspect/conceptdeclaration');
+const DecoratorFactory = require('../lib/introspect/decoratorfactory');
 const EnumDeclaration = require('../lib/introspect/enumdeclaration');
 const EventDeclaration = require('../lib/introspect/eventdeclaration');
 const Factory = require('../lib/factory');
@@ -958,6 +959,32 @@ concept Bar {
 
         it('should return a serializer', () => {
             modelManager.getSerializer().should.be.an.instanceOf(Serializer);
+        });
+
+    });
+
+    describe('#getDecoratorFactories', () => {
+
+        it('should return an empty array by default', () => {
+            modelManager.getDecoratorFactories().should.deep.equal([]);
+        });
+
+        it('should return an array of processors', () => {
+            const factory1 = sinon.createStubInstance(DecoratorFactory);
+            const factory2 = sinon.createStubInstance(DecoratorFactory);
+            modelManager.decoratorFactories = [factory1, factory2];
+            modelManager.getDecoratorFactories().should.deep.equal([factory1, factory2]);
+        });
+
+    });
+
+    describe('#addDecoratorFactory', () => {
+
+        it('should add a factory to the array', () => {
+            modelManager.decoratorFactories.should.deep.equal([]);
+            const factory1 = sinon.createStubInstance(DecoratorFactory);
+            modelManager.addDecoratorFactory(factory1);
+            modelManager.decoratorFactories.should.deep.equal([factory1]);
         });
 
     });

--- a/packages/composer-playground/src/app/test/resource/resource.component.ts
+++ b/packages/composer-playground/src/app/test/resource/resource.component.ts
@@ -146,7 +146,7 @@ export class ResourceComponent implements OnInit {
                 allowEmptyId: true
             };
             let resource = factory.newResource(
-                this.resourceDeclaration.getModelFile().getNamespace(),
+                this.resourceDeclaration.getNamespace(),
                 this.resourceDeclaration.getName(),
                 id,
                 generateParameters);


### PR DESCRIPTION
https://github.com/hyperledger/composer/issues/4165

Allow a decorator to accept a type (identifier), so that you can do nice things like:

```
@returns(org.acme.Foo[])
transaction MyTransaction { }
```

Allow a model manager to be given a set of decorator factories, which can be optionally added to create a specialised decorator (a subclass of Decorator) to add additional functionality or validation.

For example, we can add a decorator processor for `@returns` to the Composer runtime, that ensures only one argument is passed and that one argument is a reference to a valid type - without adding that constraint for all users of the Composer modelling language.