### PR TITLE
speed up `fromJSON()` serialisation process

### DIFF
--- a/packages/composer-common/lib/introspect/modelfile.js
+++ b/packages/composer-common/lib/introspect/modelfile.js
@@ -50,6 +50,7 @@ class ModelFile {
         this.modelManager = modelManager;
         this.external = false;
         this.declarations = [];
+        this.localTypes = new Map();
         this.imports = [];
         this.importShortNames = new Map();
         this.importWildcardNamespaces = [];
@@ -137,6 +138,13 @@ class ModelFile {
                     'type': thing.type,
                 }),this.modelFile);
             }
+        }
+
+        // Now build local types from Declarations
+        for(let index in this.declarations) {
+            let classDeclaration = this.declarations[index];
+            let localType = this.getNamespace() + '.' + classDeclaration.getName();
+            this.localTypes.set(localType, this.declarations[index]);
         }
     }
 
@@ -428,13 +436,11 @@ class ModelFile {
             type = this.getNamespace() + '.' + type;
         }
 
-        for(let n=0; n < this.declarations.length; n++) {
-            let classDeclaration = this.declarations[n];
-            if(type === this.getNamespace() + '.' + classDeclaration.getName() ) {
-                return classDeclaration;
-            }
+        if (this.localTypes.has(type)) {
+            return this.localTypes.get(type);
+        } else {
+            return null;
         }
-        return null;
     }
 
     /**

--- a/packages/composer-common/lib/model/resourceid.js
+++ b/packages/composer-common/lib/model/resourceid.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const URI = require('uri-js');
+const URIJS = require('urijs');
 
 const ModelUtils = require('../modelutil');
 
@@ -69,14 +69,19 @@ class ResourceId {
      * @throws {Error} - On an invalid resource URI.
      */
     static fromURI(uri, legacyNamespace, legacyType) {
-        const uriComponents = URI.parse(uri, { unicodeSupport: true });
+        let uriComponents;
+        try {
+            uriComponents = URIJS.parse(uri);
+        } catch (err){
+            throw new Error('Invalid URI: ' + uri);
+        }
 
-        const scheme = uriComponents.scheme;
+        const scheme = uriComponents.protocol;
         // Accept legacy identifiers with missing URI scheme as valid
         if (scheme && scheme !== RESOURCE_SCHEME) {
             throw new Error('Invalid URI scheme: ' + uri);
         }
-        if (uriComponents.userinfo || uriComponents.host || uriComponents.port || uriComponents.query) {
+        if (uriComponents.username || uriComponents.password || uriComponents.port || uriComponents.query) {
             throw new Error('Invalid resource URI format: ' + uri);
         }
 

--- a/packages/composer-common/package.json
+++ b/packages/composer-common/package.json
@@ -74,7 +74,7 @@
     "sprintf-js": "1.0.3",
     "thenify": "3.2.1",
     "thenify-all": "1.6.0",
-    "uri-js": "3.0.2",
+    "urijs": "1.19.1",
     "uuid": "3.0.1",
     "winston": "2.3.1"
   },

--- a/packages/composer-common/test/model/relationship.js
+++ b/packages/composer-common/test/model/relationship.js
@@ -147,8 +147,14 @@ describe('Relationship', function () {
 
         it('should error on invalid URI content', function() {
             (function () {
-                Relationship.fromURI(modelManager, 'resource://USER:PASSWORD@HOSTNAME:PORT/org.acme.l1.Person#123');
-            }).should.throw(/USER:PASSWORD@HOSTNAME:PORT/);
+                Relationship.fromURI(modelManager, 'resource://NOT-A-URI:SUCH-WRONG/org.acme.l1.Person#123');
+            }).should.throw(/Invalid URI: resource:\/\/NOT-A-URI:SUCH-WRONG/);
+        });
+
+        it('should error on URI content that Composer does not support', function() {
+            (function () {
+                Relationship.fromURI(modelManager, 'resource://USER:PASSWORD@HOSTNAME:1567/org.acme.l1.Person#123');
+            }).should.throw(/Invalid resource URI format: resource:\/\/USER:PASSWORD@HOSTNAME:1567/);
         });
 
         it('should error on missing namespace in URI', function() {


### PR DESCRIPTION
Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>

Changing to a different standard npm module (npmjs instead of npm-js) gives us a 6% throughput boost for free 👍  (Well, according to 100k hits on the `fromJSON()` method it does )

try catch required as this module likes to throw instead of 'do it's best' ... which might be why it's faster 🤷‍♂️ 

Now includes a map in the model file to hold local types, which helps yield a 13% perf boost