### PR TITLE
Archive validation 3910

### DIFF
--- a/packages/composer-cli/lib/cmds/archive/lib/migrationchecker.js
+++ b/packages/composer-cli/lib/cmds/archive/lib/migrationchecker.js
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const BusinessNetworkDefinition = require('composer-common').BusinessNetworkDefinition;
+const fs = require('fs');
+let DepGraph = require('dependency-graph').DepGraph;
+const _ = require('lodash');
+const cmdUtil = require('../../utils/cmdutils');
+const path = require('path');
+const EventEmitter = require('events');
+const chalk = require('chalk');
+
+/**
+ * composer archive validate command
+ * https://hyperledger.github.io/composer/latest/reference/model-compatibility
+ * @private
+ */
+class MigrationChecker extends EventEmitter {
+
+    /**
+     * @param {Object} args command line arguments
+     */
+    constructor(args) {
+        super();
+        this.facts = {
+            comingFromClassList: [],
+            goingToClassList: []
+        };
+        this.facts.graph_comingFrom = new DepGraph();
+        this.facts.graph_goingTo = new DepGraph();
+        this.events = { 'success': [], 'failure': [], 'warning': [] };
+        this.fromFileName = path.resolve(args.f);
+        this.toFileName = path.resolve(args.t);
+    }
+
+    /**
+     * Creates a DAG (directed acyclic graph) to represent declaration hierarchy of a model file
+     */
+    async loadNetworks() {
+
+        // Load business network definitions for each bna file
+        let bnd_comingFrom = await BusinessNetworkDefinition.fromArchive(fs.readFileSync(this.fromFileName));
+        let bnd_goingTo = await BusinessNetworkDefinition.fromArchive(fs.readFileSync(this.toFileName));
+
+        // Create list of namespace declarations for each bna (transactions, participants, assets, events, enums, concepts)
+        let classDeclarations_from = bnd_comingFrom.getIntrospector().getClassDeclarations().filter((e) => { return !e.isSystemType(); });
+        let classDeclarations_to = bnd_goingTo.getIntrospector().getClassDeclarations().filter((e) => { return !e.isSystemType(); });
+
+        // Create a DAG (directed acyclic graph) of declarations where namespace is the key and Type object is the value
+        for (const iterator of classDeclarations_from) {
+            this.facts.graph_comingFrom.addNode(iterator.getFullyQualifiedName(), iterator);
+
+            // Define necessary system declarations from which child declarations depend on
+            if (!this.facts.graph_comingFrom.hasNode(iterator.getSuperType())) {
+                this.facts.graph_comingFrom.addNode(iterator.getSuperType(), iterator.getSuperTypeDeclaration());
+            }
+            this.facts.graph_comingFrom.addDependency(iterator.getSuperType(), iterator.getFullyQualifiedName());
+            this.facts.comingFromClassList.push(iterator.getFullyQualifiedName());
+        }
+
+        for (const iterator of classDeclarations_to) {
+            this.facts.graph_goingTo.addNode(iterator.getFullyQualifiedName(), iterator);
+            if (!this.facts.graph_goingTo.hasNode(iterator.getSuperType())) {
+                this.facts.graph_goingTo.addNode(iterator.getSuperType(), iterator.getSuperTypeDeclaration());
+            }
+            this.facts.graph_goingTo.addDependency(iterator.getSuperType(), iterator.getFullyQualifiedName());
+            this.facts.goingToClassList.push(iterator.getFullyQualifiedName());
+        }
+    }
+
+    /**
+     * @returns {Array} of Event objects for the failures
+     */
+    getFailureEvents() {
+        return this.events.failure;
+    }
+
+    /**
+     * @returns {Array} of Event objects for the successes
+     */
+    getSuccessEvents() {
+        return this.events.success;
+    }
+
+    /**
+     * @returns {Array} of Event objects for the warnings
+     */
+    getWarningEvents() {
+        return this.events.warning;
+    }
+
+    /**
+     *
+     */
+    async runRules() {
+
+        const globalClassRules = require('./rule.js').globalClassRules;
+        const perClassRules = require('./rule.js').perClassRules;
+
+        await this.run(this.facts.comingFromClassList, this.facts.goingToClassList, globalClassRules);
+
+        // Finds all fqdn that are the same in both lists
+        let toCheck = _.intersection(this.facts.comingFromClassList, this.facts.goingToClassList);
+        for (const iterator of toCheck) {
+            await this.run(this.facts.graph_comingFrom.getNodeData(iterator), this.facts.graph_goingTo.getNodeData(iterator), perClassRules);
+        }
+    }
+
+    /** Run the rules and store the events, and emit them as well.
+     * @param {Object} from facts determining the from state
+     * @param {Object} to facts determining the from to
+     * @param {Object} rules to enforce
+    */
+    async run(from, to, rules) {
+        let keys = Object.keys(rules);
+        for (const iterator of keys) {
+            let events = await rules[iterator](from, to);
+            for (const event of events) {
+                event.type = iterator;
+                this.events[event.result].push(event);
+                this.emit(event.result, event);
+            }
+        }
+    }
+
+    /**
+      * Command process for deploy command
+      * @param {string} args argument list from composer command
+      * @return {Promise} promise when command complete
+      */
+    static handler(args) {
+
+        cmdUtil.log(chalk.blue.bold('Business Network Archive Validation\n'));
+
+        // Create MigrationChecker class instance and create events
+        let checker = new MigrationChecker(args);
+
+        checker.on('success', event => {
+            cmdUtil.log(`${chalk.green('PASS')}: ${chalk.blue(JSON.stringify(event.data))} passed the ${chalk.blue(event.type)} rule`);
+        })
+        .on('failure', event => {
+            cmdUtil.log(`${chalk.red('FAIL')}: ${chalk.blue(JSON.stringify(event.data))}  failed the ${chalk.blue(event.type)} rule`);
+        })
+        .on('warning', event => {
+            cmdUtil.log(`${chalk.yellow('WARN')}: ${chalk.blue(JSON.stringify(event.data))}  triggered the ${chalk.blue(event.type)} rule`);
+        });
+
+        cmdUtil.log(`Checking migration of model \n\tfrom ${chalk.blue.bold(checker.fromFileName)} \n\tto  ${chalk.blue.bold(checker.toFileName)}\n`);
+        return checker.loadNetworks()
+          .then(()=>{
+              return checker.runRules();
+          })
+          .then( ()=>{
+              let failEvents = checker.getFailureEvents();
+              let passEvents = checker.getSuccessEvents();
+              let warnEvents = checker.getWarningEvents();
+              cmdUtil.log(`\n\n${chalk.blue.bold('Summary:')}`);
+              cmdUtil.log(`${chalk.green(passEvents.length)} Pass${(passEvents.length === 1) ? '' : 'es' }, ${chalk.red(failEvents.length)} Failure${(failEvents.length===1)?'':'s'}, ${chalk.yellow(warnEvents.length)} Warning${(warnEvents.length===1)?'':'s'}`);
+
+              if (failEvents.length > 0) {
+                  return Promise.reject('Model will not migrate cleanly');
+              } else {
+                  return Promise.resolve('Model will migrate');
+              }
+          });
+
+    }
+}
+
+module.exports = MigrationChecker;

--- a/packages/composer-cli/lib/cmds/archive/lib/rule.js
+++ b/packages/composer-cli/lib/cmds/archive/lib/rule.js
@@ -1,0 +1,206 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const _ = require('lodash');
+
+module.exports.perClassRules = {
+
+    class_not_made_abstract : async (from, to) => {
+        // are all in from in t
+        let event = {};
+        event.result = (!from.isAbstract() && to.isAbstract()) ? 'failure':'success';
+        event.data = from.getFullyQualifiedName();
+        return [event];
+    },
+
+
+    must_not_change_cardinality_property : async (from, to) => {
+        // are all in from in t
+        let events = [];
+        let fromProps = from.getProperties();
+        let toProps = to.getProperties();
+
+        let fromPropsNames = fromProps.map((e)=>{return e.getName();});
+        let toPropsNames = toProps.map((e)=>{return e.getName();});
+        let additionalProps = _.intersection(toPropsNames,fromPropsNames);
+
+        // find difference for those properties that where added
+        for (const propName of additionalProps) {
+            // get the prop itself...
+            let toProp = to.getProperty(propName);
+            let fromProp = from.getProperty(propName);
+
+            events.push( { data: { fqn:toProp.getFullyQualifiedName() },
+                result : (toProp.isArray() !== fromProp.isArray()) ? 'failure':'success'
+            } ) ;
+
+        }
+
+        return events;
+    },
+
+    new_not_default_optional_property : async (from, to) => {
+        // are all in from in t
+        let events = [];
+        let fromProps = from.getProperties();
+        let toProps = to.getProperties();
+
+        let fromPropsNames = fromProps.map((e)=>{return e.getName();});
+        let toPropsNames = toProps.map((e)=>{return e.getName();});
+        let additionalProps = _.difference(toPropsNames,fromPropsNames);
+
+        // find difference for those propeties that where added
+        for (const propName of additionalProps) {
+            // get the prop itself...
+            let prop = to.getProperty(propName);
+            let optional = prop.isOptional();
+            let defValue = prop.getDefaultValue()===null ? false:true;
+
+            events.push( { data: { fqn:prop.getFullyQualifiedName(),optional,defValue },
+                result : (!optional && !defValue) ? 'failure':'success'
+            } ) ;
+
+        }
+
+
+        return events;
+    },
+
+    deleting_property_instability_risk : async (from, to) => {
+        // are all in from in t
+        let events = [];
+        let fromProps = from.getProperties();
+        let toProps = to.getProperties();
+
+        let fromPropsNames = fromProps.map((e)=>{return e.getName();});
+        let toPropsNames = toProps.map((e)=>{return e.getName();});
+        let additionalProps = _.difference(fromPropsNames, toPropsNames);
+
+        // find difference for those properties that where added
+        for (const propName of additionalProps) {
+            // get the prop itself...
+            let prop = from.getProperty(propName);
+            events.push( { data: { fqn:prop.getFullyQualifiedName() },
+                result : 'warning'
+            }) ;
+
+        }
+
+        return events;
+    },
+
+    change_property_type_instability_risk : async (from, to) => {
+        let events = [];
+
+        let fromProps = from.getProperties();
+        let toProps = to.getProperties();
+
+        let fromPropsNames = fromProps.map((e) => { return e.getName(); });
+        let toPropsNames = toProps.map((e) => { return e.getName(); });
+        let sameProps = _.intersection(fromPropsNames, toPropsNames);
+
+        for (const propName of sameProps) {
+            let propFrom = from.getProperty(propName);
+            let propTo = to.getProperty(propName);
+            let propFromType = propFrom.type;
+            let propToType = propTo.type;
+
+            if (_.isEqual(propFromType, propToType)) {
+                events.push({
+                    data: { fqn: propFrom.getFullyQualifiedName() },
+                    result: 'success'
+                });
+            } else {
+                events.push({
+                    data: { fqn: propFrom.getFullyQualifiedName(), changeFrom: propFromType, changeTo: propToType },
+                    result: 'warning'
+                });
+            }
+        }
+
+        return events;
+    },
+
+    change_validation_expression_instability_risk : async (from, to) => {
+        let events = [];
+
+        let fromProps = from.getProperties();
+        let toProps = to.getProperties();
+
+        let fromPropsNames = fromProps.map((e) => { return e.getName(); });
+        let toPropsNames = toProps.map((e) => { return e.getName(); });
+        let sameProps = _.intersection(fromPropsNames, toPropsNames);
+
+        for (const propName of sameProps) {
+            let propFrom = from.getProperty(propName);
+            let propTo = to.getProperty(propName);
+
+            if (propTo.validator) {
+                let fromValidator = null;
+                if (propFrom.validator){
+                    fromValidator = propFrom.validator.validator;
+                }
+                const toValidator = propTo.validator.validator;
+
+                events.push({
+                    data: { fqn: propFrom.getFullyQualifiedName(), originalValidator: fromValidator, newValidator: toValidator },
+                    result: (fromValidator === toValidator) ? 'success': 'warning'
+                });
+            }
+        }
+
+        return events;
+    },
+
+    change_superclass_hierarchy_instability_risk : async (from, to) => {
+        let event = {};
+
+        const fromSuper = from.getSuperTypeDeclaration();
+        const toSuper = to.getSuperTypeDeclaration();
+        const superTypesLength = to.getAllSuperTypeDeclarations().length;
+
+        // If class has 2 or more super types, changing its direct parent may alter relationship with grandparent
+        if (superTypesLength > 1 && fromSuper.ast.classExtension) {
+            const fromParentExtension = fromSuper.ast.classExtension.class.name;
+            const toParentExtension = toSuper.ast.classExtension.class.name;
+            event.data = { fqn: from.getFullyQualifiedName(), fromParentExtension: fromParentExtension, toParentExtension: toParentExtension };
+            event.result = (_.isEqual(fromParentExtension, toParentExtension)) ? 'success' : 'warning';
+        } else {
+            event.data = { fqn: from.getFullyQualifiedName() };
+            event.result = 'success';
+        }
+
+        return [event];
+    }
+};
+
+module.exports.globalClassRules = {
+
+    // returns result
+    fqn_in_both_lists : async (from, to) => {
+        let event = {};
+        let diff = _.difference(from,to);
+        event.result = (diff.length === 0) ? 'success' : 'failure';
+        if (event.result === 'failure') {
+            event.data = { error: _.clone(diff) };
+        } else {
+            event.data = 'All Classes';
+        }
+
+        return [event];
+    }
+
+};

--- a/packages/composer-cli/lib/cmds/archive/validateCommand.js
+++ b/packages/composer-cli/lib/cmds/archive/validateCommand.js
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const MigrationChecker = require ('./lib/migrationchecker.js');
+
+
+module.exports.command = 'validate [options]';
+module.exports.describe = 'validate a Business Network Archive for migration';
+module.exports.builder = function (yargs){
+
+    yargs.options({
+        'from': {alias: 'f', required: true, describe: 'BNA Archive filename migrating FROM', type: 'string' },
+        'to': {alias: 't', required: true, describe:'BNA Archive file migrating TO', type:'string' },
+    });
+    yargs.usage('composer archive validate --from digitalPropertyNetwork-one.bna --to digitialPropertyNetwork-two.bna');
+
+    return yargs;
+};
+
+module.exports.handler = (argv) => {
+    return argv.thePromise = MigrationChecker.handler(argv);
+};

--- a/packages/composer-cli/test/archive/validate.js
+++ b/packages/composer-cli/test/archive/validate.js
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const Validate = require('../../lib/cmds/archive/validateCommand.js');
+const MigrationChecker = require('../../lib/cmds/archive/lib/migrationchecker.js');
+//const CmdUtil = require('../../lib/cmds/utils/cmdutils.js');
+
+require('chai').should();
+
+const chai = require('chai');
+const sinon = require('sinon');
+chai.should();
+chai.use(require('chai-things'));
+chai.use(require('chai-as-promised'));
+
+describe('composer archive validate unit tests', function () {
+
+    let sandbox;
+
+    beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+        sandbox.stub(path, 'resolve');
+        sandbox.stub(fs, 'readFileSync');
+        sandbox.stub(process, 'exit');
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('List handler() method tests', function () {
+
+        it('should correctly execute when all params correctly specified.', function () {
+
+            let argv = { from: 'somearchive.zip', to: 'anotherarchive.zip' };
+
+            let loadNetworkStub = sinon.stub(MigrationChecker.prototype, 'loadNetworks').resolves();
+            let runRulesStub = sinon.stub(MigrationChecker.prototype, 'runRules').resolves();
+
+            return Validate.handler(argv)
+            .then ((result) => {
+                argv.thePromise.should.be.a('promise');
+                sinon.assert.calledOnce(loadNetworkStub);
+                sinon.assert.calledOnce(runRulesStub);
+
+                loadNetworkStub.restore();
+                runRulesStub.restore();
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
This pull request is in relation to issue #3910 as a "community contribution" requested by @mbwhite .  In accordance to [model compatibility standards](https://hyperledger.github.io/composer/latest/reference/model-compatibility), this adds `composer-cli` functionality in the form of `composer archive validate --from some-archive-from.bna --to some-archive-to.bna`.

The code is finished and all "hotspots" have been accounted for, but I was having issues writing proper unit/integration tests.  I am submitting this in hopes that a more knowledgeable tester could assist in completing the test cases for this code.