### PR TITLE
Add decorator factory and implementation for @returns

### DIFF
--- a/packages/composer-common/api.txt
+++ b/packages/composer-common/api.txt
@@ -251,6 +251,17 @@ class ModelManager {
    + DecoratorFactory[] getDecoratorFactories() 
    + void addDecoratorFactory(DecoratorFactory) 
 }
+class ReturnsDecorator extends Decorator {
+   + void constructor(Object) throws IllegalModelException
+   + string getType() 
+   + ClassDeclaration getResolvedType() 
+   + boolean isArray() 
+   + boolean isPrimitive() 
+   + boolean isTypeEnum() 
+}
+class ReturnsDecoratorFactory extends DecoratorFactory {
+   + Decorator newDecorator(Object) 
+}
 class Serializer {
    + void constructor(Factory,ModelManager) 
    + void setDefaultOptions(Object) 

--- a/packages/composer-common/changelog.txt
+++ b/packages/composer-common/changelog.txt
@@ -24,8 +24,9 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 0.19.10 {363781808e51ce0ec2b216c65f8fe3fa} 2018-06-29
+Version 0.19.11 {38988b983f6b23ad7e6e7b28bc33961d} 2018-06-29
 - Add decorator factories
+- Add returns decorator factory
 
 Version 0.19.1 {f6814276d318be3b4ed0f6212bc77c6f} 2018-04-06
 - Enable simple JSON.stringify serialization of resources

--- a/packages/composer-common/lib/businessnetworkdefinition.js
+++ b/packages/composer-common/lib/businessnetworkdefinition.js
@@ -26,6 +26,7 @@ const minimatch = require('minimatch');
 const ModelManager = require('./modelmanager');
 const QueryFile = require('./query/queryfile');
 const QueryManager = require('./querymanager');
+const ReturnsDecoratorFactory = require('./returnsdecoratorfactory');
 const ScriptManager = require('./scriptmanager');
 const semver = require('semver');
 const thenify = require('thenify');
@@ -114,6 +115,7 @@ class BusinessNetworkDefinition {
         }
 
         this.modelManager = new ModelManager();
+        this.modelManager.addDecoratorFactory(new ReturnsDecoratorFactory());
         this.factory = this.modelManager.getFactory();
         this.serializer = this.modelManager.getSerializer();
         this.aclManager = new AclManager(this.modelManager);

--- a/packages/composer-common/lib/introspect/modelfile.js
+++ b/packages/composer-common/lib/introspect/modelfile.js
@@ -248,10 +248,15 @@ class ModelFile {
      * Check that the type is valid.
      * @param {string} context - error reporting context
      * @param {string} type - a short type name
+     * @param {Object} [fileLocation] - location details of the error within the model file.
+     * @param {String} fileLocation.start.line - start line of the error location.
+     * @param {String} fileLocation.start.column - start column of the error location.
+     * @param {String} fileLocation.end.line - end line of the error location.
+     * @param {String} fileLocation.end.column - end column of the error location.
      * @throws {IllegalModelException} - if the type is not defined
      * @private
      */
-    resolveType(context,type) {
+    resolveType(context,type,fileLocation) {
         // is the type a primitive?
         if(!ModelUtil.isPrimitiveType(type)) {
             // is it an imported type?
@@ -261,8 +266,8 @@ class ModelFile {
                     let formatter = Globalize('en').messageFormatter('modelfile-resolvetype-undecltype');
                     throw new IllegalModelException(formatter({
                         'type': type,
-                        'context': context
-                    }),this.modelFile);
+                        'context': context,
+                    }),this.modelFile,fileLocation);
                 }
             }
             else {

--- a/packages/composer-common/lib/returnsdecorator.js
+++ b/packages/composer-common/lib/returnsdecorator.js
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Decorator = require('./introspect/decorator');
+const IllegalModelException = require('./introspect/illegalmodelexception');
+const ModelUtil = require('./modelutil');
+
+/**
+ * Specialised decorator implementation for the @returns decorator.
+ */
+class ReturnsDecorator extends Decorator {
+
+    /**
+     * Create a Decorator.
+     * @param {ClassDeclaration | Property} parent - the owner of this property
+     * @param {Object} ast - The AST created by the parser
+     * @throws {IllegalModelException}
+     */
+    constructor(parent, ast) {
+        super(parent, ast);
+    }
+
+    /**
+     * Process the AST and build the model
+     * @throws {IllegalModelException}
+     * @private
+     */
+    process() {
+        super.process();
+        const args = this.getArguments();
+        if (args.length !== 1) {
+            throw new IllegalModelException(`@returns decorator expects 1 argument, but ${args.length} arguments were specified.`, this.parent.getModelFile(), this.ast.location);
+        }
+        const arg = args[0];
+        if (typeof arg !== 'object' || arg.type !== 'Identifier') {
+            throw new IllegalModelException(`@returns decorator expects an identifier argument, but an argument of type ${typeof arg} was specified.`, this.parent.getModelFile(), this.ast.location);
+        }
+        this.type = arg.name;
+        this.array = arg.array;
+    }
+
+    /**
+     * Validate the property
+     * @throws {IllegalModelException}
+     * @private
+     */
+    validate() {
+        super.validate();
+        this.parent.getModelFile().resolveType('@returns decorator.', this.type, this.ast.location);
+        this.resolvedType = this.parent.getModelFile().getType(this.type);
+    }
+
+    /**
+     * Get the type specified in this returns declaration.
+     * @returns {string} The type specified in this returns declaration.
+     */
+    getType() {
+        return this.type;
+    }
+
+    /**
+     * Get the resolved type specified in this returns declaration.
+     * @returns {ClassDeclaration} The resolved type specified in this returns declaration.
+     */
+    getResolvedType() {
+        return this.resolvedType;
+    }
+
+    /**
+     * Returns true if this returns declaration specifies an array type.
+     * @returns {boolean} True if this returns declaration specifies an array type.
+     */
+    isArray() {
+        return this.array;
+    }
+
+    /**
+     * Returns true if this returns declaration specifies a primitive type.
+     * @returns {boolean} True if this returns declaration specifies a primitive type.
+     */
+    isPrimitive() {
+        return ModelUtil.isPrimitiveType(this.getType());
+    }
+
+    /**
+     * Returns true if this returns declaration specifies an enumeration type.
+     * @return {boolean} True if this returns declaration specifies an enumeration type.
+     */
+    isTypeEnum() {
+        if(this.isPrimitive()) {
+            return false;
+        }
+        const type = this.getParent().getModelFile().getType(this.getType());
+        return type.isEnum();
+    }
+
+}
+
+module.exports = ReturnsDecorator;

--- a/packages/composer-common/lib/returnsdecoratorfactory.js
+++ b/packages/composer-common/lib/returnsdecoratorfactory.js
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const DecoratorFactory = require('./introspect/decoratorfactory');
+const ReturnsDecorator = require('./returnsdecorator');
+
+/**
+ * A decorator factory for the @returns decorator.
+ */
+class ReturnsDecoratorFactory extends DecoratorFactory {
+
+    /**
+     * Process the decorator, and return a specific implementation class for that
+     * decorator, or return null if this decorator is not handled by this processor.
+     * @abstract
+     * @param {ClassDeclaration | Property} parent - the owner of this property
+     * @param {Object} ast - The AST created by the parser
+     * @return {Decorator} The decorator.
+     */
+    newDecorator(parent, ast) {
+        if (ast.name !== 'returns') {
+            return null;
+        }
+        return new ReturnsDecorator(parent, ast);
+    }
+
+}
+
+module.exports = ReturnsDecoratorFactory;

--- a/packages/composer-common/test/businessnetworkdefinition.js
+++ b/packages/composer-common/test/businessnetworkdefinition.js
@@ -15,14 +15,14 @@
 'use strict';
 
 const BusinessNetworkDefinition = require('../lib/businessnetworkdefinition');
-const ModelFile = require('../lib/introspect/modelfile');
 const fs = require('fs');
-const path = require('path');
-const os = require('os');
 const JSZip = require('jszip');
+const ModelFile = require('../lib/introspect/modelfile');
 const moxios = require('moxios');
 const nodeUtil = require('util');
-
+const os = require('os');
+const path = require('path');
+const ReturnsDecorator = require('../lib/returnsdecorator');
 const rimraf = nodeUtil.promisify(require('rimraf'));
 
 const chai = require('chai');
@@ -488,4 +488,21 @@ describe('BusinessNetworkDefinition', () => {
 
 
     });
+
+    describe('#decorator processors', () => {
+
+        it('should install the decorator processor for @returns', () => {
+            const bnd = new BusinessNetworkDefinition('id@1.0.0', 'description', null, 'readme');
+            const modelManager = bnd.getModelManager();
+            modelManager.addModelFile(`
+            namespace org.acme
+            @returns(String)
+            concept C { }`);
+            const conceptDeclaration = modelManager.getType('org.acme.C');
+            const decorator = conceptDeclaration.getDecorator('returns');
+            decorator.should.be.an.instanceOf(ReturnsDecorator);
+        });
+
+    });
+
 });

--- a/packages/composer-common/test/returnsdecorator.js
+++ b/packages/composer-common/test/returnsdecorator.js
@@ -1,0 +1,236 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const ConceptDeclaration = require('../lib/introspect/conceptdeclaration');
+const ModelFile = require('../lib/introspect/modelfile');
+const ModelManager = require('../lib/modelmanager');
+const ReturnsDecorator = require('../lib/returnsdecorator');
+const ReturnsDecoratorFactory = require('../lib/returnsdecoratorfactory');
+
+require('chai').should();
+
+describe('ReturnsDecorator', () => {
+
+    let modelManager;
+    let conceptDeclaration;
+
+    beforeEach(() => {
+        modelManager = new ModelManager();
+        modelManager.addDecoratorFactory(new ReturnsDecoratorFactory());
+        modelManager.addModelFile(`
+        namespace org.acme
+        concept C { }
+        `);
+        conceptDeclaration = modelManager.getType('org.acme.C');
+    });
+
+    describe('#process', () => {
+
+        it('should throw if no arguments are specified', () => {
+            (() => {
+                new ReturnsDecorator(conceptDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'returns', arguments: { list: [] } });
+            }).should.throw(/@returns decorator expects 1 argument, but 0 arguments were specified. Line 1 column 1, to line 1 column 23./);
+        });
+
+        it('should throw if two arguments are specified', () => {
+            (() => {
+                new ReturnsDecorator(conceptDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'returns', arguments: { list: [ { value: true }, { value: false } ] } });
+            }).should.throw(/@returns decorator expects 1 argument, but 2 arguments were specified. Line 1 column 1, to line 1 column 23./);
+        });
+
+        it('should throw if a an incorrectly typed argument is specified', () => {
+            (() => {
+                new ReturnsDecorator(conceptDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'returns', arguments: { list: [ { value: true } ] } });
+            }).should.throw(/@returns decorator expects an identifier argument, but an argument of type boolean was specified. Line 1 column 1, to line 1 column 23./);
+        });
+
+    });
+
+    describe('#validate', () => {
+
+        it('should throw if a reference to a missing type is specified', () => {
+            (() => {
+                const decorator = new ReturnsDecorator(conceptDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'returns', arguments: { list: [ { value: { type: 'Identifier', name: 'foo' } } ] } });
+                decorator.validate();
+            }).should.throw(/Undeclared type foo in @returns decorator. Line 1 column 1, to line 1 column 23./);
+        });
+
+        it('should work if a reference to a concept type is specified', () => {
+            const decorator = new ReturnsDecorator(conceptDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'returns', arguments: { list: [ { value: { type: 'Identifier', name: 'C' } } ] } });
+            decorator.validate();
+        });
+
+        it('should work if a reference to a fully qualified concept type is specified', () => {
+            const decorator = new ReturnsDecorator(conceptDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'returns', arguments: { list: [ { value: { type: 'Identifier', name: 'org.acme.C' } } ] } });
+            decorator.validate();
+        });
+
+        it('should work if a reference to a concept array type is specified', () => {
+            const decorator = new ReturnsDecorator(conceptDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'returns', arguments: { list: [ { value: { type: 'Identifier', name: 'C', array: true } } ] } });
+            decorator.validate();
+        });
+
+        it('should work if a reference to a primitive type is specified', () => {
+            const decorator = new ReturnsDecorator(conceptDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'returns', arguments: { list: [ { value: { type: 'Identifier', name: 'String' } } ] } });
+            decorator.validate();
+        });
+
+        it('should work if a reference to a primitive array type is specified', () => {
+            const decorator = new ReturnsDecorator(conceptDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'returns', arguments: { list: [ { value: { type: 'Identifier', name: 'String', array: true } } ] } });
+            decorator.validate();
+        });
+
+    });
+
+    /**
+     * Get the returns decorator for the transaction T in the specified model.
+     * @param {string} model The specified model.
+     * @returns {returnsDecorator} The returns declaration for the transaction T.
+     */
+    function getReturnsDecorator(model) {
+        const modelFile = new ModelFile(modelManager, model);
+        const transactionDeclaration = modelFile.getTransactionDeclaration('T');
+        return transactionDeclaration.getDecorator('returns');
+    }
+
+    describe('#getType', () => {
+
+        it('should return the type', () => {
+            const model = `
+            namespace org.acme
+            @returns(C)
+            transaction T {
+                o String foo
+            }`;
+            const returnsDecorator = getReturnsDecorator(model);
+            returnsDecorator.getType().should.equal('C');
+        });
+
+    });
+
+    describe('#getResolvedType', () => {
+
+        it('should return null for a primitive type', () => {
+            const model = `
+            namespace org.acme
+            @returns(String)
+            transaction T {
+                o String foo
+            } `;
+            const returnsDecorator = getReturnsDecorator(model);
+            returnsDecorator.validate();
+            returnsDecorator.getResolvedType().should.equal('String');
+        });
+
+        it('should return the class declaration for a complex type', () => {
+            const model = `
+            namespace org.acme
+            concept C {
+                o String bar
+            }
+            @returns(C)
+            transaction T {
+                o String foo
+            }`;
+            const returnsDecorator = getReturnsDecorator(model);
+            returnsDecorator.validate();
+            returnsDecorator.getResolvedType().should.be.an.instanceOf(ConceptDeclaration);
+        });
+
+    });
+
+    describe('#isArray', () => {
+
+        it('should return false for a non-array type', () => {
+            const model = `
+            namespace org.acme
+            @returns(String)
+            transaction T {
+                o String foo
+            }`;
+            const returnsDecorator = getReturnsDecorator(model);
+            returnsDecorator.isArray().should.be.false;
+        });
+
+        it('should return true for an array type', () => {
+            const model = `
+            namespace org.acme
+            @returns(String[])
+            transaction T {
+                o String foo
+            }`;
+            const returnsDecorator = getReturnsDecorator(model);
+            returnsDecorator.isArray().should.be.true;
+        });
+
+    });
+
+    describe('#isPrimitive', () => {
+
+        it('should return true for a primitive type', () => {
+            const model = `
+            namespace org.acme
+            @returns(String)
+            transaction T {
+                o String foo
+            }`;
+            const returnsDecorator = getReturnsDecorator(model);
+            returnsDecorator.isPrimitive().should.be.true;
+        });
+
+        it('should return true for a complex type', () => {
+            const model = `
+            namespace org.acme
+            @returns(C)
+            transaction T {
+                o String foo
+            }`;
+            const returnsDecorator = getReturnsDecorator(model);
+            returnsDecorator.isPrimitive().should.be.false;
+        });
+
+    });
+
+    describe('#isTypeEnum', () => {
+
+        it('should return true for an enum type', () => {
+            const model = `
+            namespace org.acme
+            enum E {
+                o VALUE_1
+            }
+            @returns(E)
+            transaction T {
+                o String foo
+            }`;
+            const returnsDecorator = getReturnsDecorator(model);
+            returnsDecorator.isTypeEnum().should.be.true;
+        });
+
+        it('should return false for a non-enum type', () => {
+            const model = `
+            namespace org.acme
+            @returns(String)
+            transaction T {
+                o String foo
+            }`;
+            const returnsDecorator = getReturnsDecorator(model);
+            returnsDecorator.isTypeEnum().should.be.false;
+        });
+
+    });
+
+});

--- a/packages/composer-common/test/returnsdecoratorfactory.js
+++ b/packages/composer-common/test/returnsdecoratorfactory.js
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const ModelManager = require('../lib/modelmanager');
+const ReturnsDecorator = require('../lib/returnsdecorator');
+const ReturnsDecoratorFactory = require('../lib/returnsdecoratorfactory');
+
+const should = require('chai').should();
+
+describe('ReturnsDecoratorFactory', () => {
+
+    let modelManager;
+    let conceptDeclaration;
+    let factory;
+
+    beforeEach(() => {
+        modelManager = new ModelManager();
+        modelManager.addModelFile(`
+        namespace org.acme
+        concept C { }
+        `);
+        conceptDeclaration = modelManager.getType('org.acme.C');
+        factory = new ReturnsDecoratorFactory();
+    });
+
+    describe('#process', () => {
+
+        it('should return null for a @foobar decorator', () => {
+            should.equal(factory.newDecorator(conceptDeclaration, { name: 'foobar' }), null);
+        });
+
+        it('should return a returns decorator instance for a @returns decorator', () => {
+            const decorator = factory.newDecorator(conceptDeclaration, { name: 'returns', arguments: { list: [ { value: { type: 'Identifier', name: 'C' } } ] } });
+            decorator.should.be.an.instanceOf(ReturnsDecorator);
+        });
+
+    });
+
+});


### PR DESCRIPTION
#4165 

Add a decorator implementation and decorator factory for handling `@returns` decorators.
Allows the following decorators to be validated by Composer:

```
concept MyConcept { }

@returns(MyConcept)
transaction MyTransaction { }
```

```
enum MyEnum {
    o VALUE_1
    o VALUE_2
    o VALUE_3
    o VALUE_4
}

@returns(MyEnum)
transaction MyTransaction { }
```

```
@returns(String)
transaction MyTransaction { }
```