### PR TITLE
Extend connectors to return values from chaincode invoke

### DIFF
--- a/packages/composer-connector-embedded/lib/embeddedconnection.js
+++ b/packages/composer-connector-embedded/lib/embeddedconnection.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const { Certificate, CertificateUtil, Connection } = require('composer-common');
+const { Certificate, CertificateUtil, Connection, Util } = require('composer-common');
 const { EmbeddedContainer, EmbeddedContext, EmbeddedDataService } = require('composer-runtime-embedded');
 const EmbeddedSecurityContext = require('./embeddedsecuritycontext');
 const { Engine, InstalledBusinessNetwork } = require('composer-runtime');
@@ -266,8 +266,8 @@ class EmbeddedConnection extends Connection {
      * @param {SecurityContext} securityContext The participant's security context.
      * @param {string} functionName The name of the chaincode function to invoke.
      * @param {string[]} args The arguments to pass to the chaincode function.
-     * @return {Promise} A promise that is resolved with the data returned by the
-     * chaincode function once it has been invoked, or rejected with an error.
+     * @return {Buffer} A buffer containing the data returned by the chaincode function,
+     * or null if no data was returned.
      */
     async queryChainCode(securityContext, functionName, args) {
         if (!this.businessNetworkIdentifier) {
@@ -278,7 +278,7 @@ class EmbeddedConnection extends Connection {
         let chaincode = EmbeddedConnection.getChaincode(chaincodeUUID);
         let context = new EmbeddedContext(chaincode.engine, identity, this, chaincode.installedBusinessNetwork);
         const data = await chaincode.engine.query(context, functionName, args);
-        return Buffer.from(JSON.stringify(data));
+        return !Util.isNull(data) ? Buffer.from(JSON.stringify(data)) : null;
     }
 
     /**
@@ -286,17 +286,19 @@ class EmbeddedConnection extends Connection {
      * @param {SecurityContext} securityContext The participant's security context.
      * @param {string} functionName The name of the chaincode function to invoke.
      * @param {string[]} args The arguments to pass to the chaincode function.
+     * @return {Buffer} A buffer containing the data returned by the chaincode function,
+     * or null if no data was returned.
      */
     async invokeChainCode(securityContext, functionName, args) {
         if (!this.businessNetworkIdentifier) {
             throw new Error('No business network has been specified for this connection');
         }
-
         let identity = securityContext.getIdentity();
         let chaincodeUUID = securityContext.getChaincodeID();
         let chaincode = EmbeddedConnection.getChaincode(chaincodeUUID);
         let context = new EmbeddedContext(chaincode.engine, identity, this, chaincode.installedBusinessNetwork);
-        await chaincode.engine.invoke(context, functionName, args);
+        const data = await chaincode.engine.invoke(context, functionName, args);
+        return !Util.isNull(data) ? Buffer.from(JSON.stringify(data)) : null;
     }
 
     /**

--- a/packages/composer-connector-hlfv1/lib/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/lib/hlfconnection.js
@@ -858,7 +858,7 @@ class HLFConnection extends Connection {
         LOG.entry(method, securityContext, functionName, args);
 
         if (!this.businessNetworkIdentifier) {
-            return Promise.reject(new Error('No business network has been specified for this connection'));
+            throw new Error('No business network has been specified for this connection');
         }
 
         // Check that a valid security context has been specified.
@@ -866,9 +866,9 @@ class HLFConnection extends Connection {
 
         // Validate all the arguments.
         if (!functionName) {
-            return Promise.reject(new Error('functionName not specified'));
+            throw new Error('functionName not specified');
         } else if (!Array.isArray(args)) {
-            return Promise.reject(new Error('args not specified'));
+            throw new Error('args not specified');
         }
         try {
             args.forEach((arg) => {
@@ -877,11 +877,13 @@ class HLFConnection extends Connection {
                 }
             });
         } catch(error) {
-            return Promise.reject(error);
+            throw error;
         }
 
         let txId = this.client.newTransactionID();
-        return this.queryHandler.queryChaincode(txId, functionName, args);
+        let result = await this.queryHandler.queryChaincode(txId, functionName, args);
+        LOG.exit(method, result ? result : null);
+        return result ? result : null;
     }
 
     /**
@@ -894,12 +896,12 @@ class HLFConnection extends Connection {
      * @return {Promise} A promise that is resolved once the chaincode function
      * has been invoked, or rejected with an error.
      */
-    invokeChainCode(securityContext, functionName, args, options) {
+    async invokeChainCode(securityContext, functionName, args, options) {
         const method = 'invokeChainCode';
         LOG.entry(method, securityContext, functionName, args, options);
 
         if (!this.businessNetworkIdentifier) {
-            return Promise.reject(new Error('No business network has been specified for this connection'));
+            throw new Error('No business network has been specified for this connection');
         }
 
         // Check that a valid security context has been specified.
@@ -907,9 +909,9 @@ class HLFConnection extends Connection {
 
         // Validate all the arguments.
         if (!functionName) {
-            return Promise.reject(new Error('functionName not specified'));
+            throw new Error('functionName not specified');
         } else if (!Array.isArray(args)) {
-            return Promise.reject(new Error('args not specified'));
+            throw new Error('args not specified');
         }
 
         try {
@@ -919,68 +921,77 @@ class HLFConnection extends Connection {
                 }
             });
         } catch(error) {
-            return Promise.reject(error);
+            throw error;
         }
 
         let txId = this._validateTxId(options);
 
         let eventHandler;
 
-        // initialize the channel if it hasn't been initialized already otherwise verification will fail.
-        LOG.debug(method, 'loading channel configuration');
-        return this._initializeChannel()
-            .then(() => {
+        try {
 
-                // check the event hubs and reconnect if possible. Do it here as the connection attempts are asynchronous
-                this._checkEventhubs();
+            // initialize the channel if it hasn't been initialized already otherwise verification will fail.
+            LOG.debug(method, 'loading channel configuration');
+            await this._initializeChannel();
 
-                // Submit the transaction to the endorsers.
-                const request = {
-                    chaincodeId: this.businessNetworkIdentifier,
-                    txId: txId,
-                    fcn: functionName,
-                    args: args
-                };
-                return this.channel.sendTransactionProposal(request); // node sdk will target all peers on the channel that are endorsingPeer
-            })
-            .then((results) => {
-                // Validate the endorsement results.
-                LOG.debug(method, `Received ${results.length} result(s) from invoking the composer runtime chaincode`, results);
-                const proposalResponses = results[0];
-                let {validResponses} = this._validatePeerResponses(proposalResponses, true);
+            // check the event hubs and reconnect if possible. Do it here as the connection attempts are asynchronous
+            this._checkEventhubs();
 
-                // Submit the endorsed transaction to the primary orderers.
-                const proposal = results[1];
-                const header = results[2];
+            // Submit the transaction to the endorsers.
+            const request = {
+                chaincodeId: this.businessNetworkIdentifier,
+                txId: txId,
+                fcn: functionName,
+                args: args
+            };
+            const results = await this.channel.sendTransactionProposal(request); // node sdk will target all peers on the channel that are endorsingPeer
 
-                // check that we have a Chaincode listener setup and ready.
-                this._checkCCListener();
-                eventHandler = HLFConnection.createTxEventHandler(this.eventHubs, txId.getTransactionID(), this.commitTimeout);
-                eventHandler.startListening();
-                return this.channel.sendTransaction({
-                    proposalResponses: validResponses,
-                    proposal: proposal,
-                    header: header
-                });
-            })
-            .then((response) => {
-                // If the transaction was successful, wait for it to be committed.
-                LOG.debug(method, 'Received response from orderer', response);
+            // Validate the endorsement results.
+            LOG.debug(method, `Received ${results.length} result(s) from invoking the composer runtime chaincode`, results);
+            const proposalResponses = results[0];
+            let {validResponses} = this._validatePeerResponses(proposalResponses, true);
 
-                if (response.status !== 'SUCCESS') {
-                    eventHandler.cancelListening();
-                    throw new Error(`Failed to send peer responses for transaction '${txId.getTransactionID()}' to orderer. Response status '${response.status}'`);
-                }
-                return eventHandler.waitForEvents();
-            })
-            .then(() => {
-                LOG.exit(method);
-            })
-            .catch((error) => {
-                const newError = new Error('Error trying invoke business network. ' + error);
-                LOG.error(method, newError);
-                throw newError;
+            // Extract the response data, if any.
+            const firstValidResponse = validResponses[0];
+            let result = null;
+            if (firstValidResponse.response.payload && firstValidResponse.response.payload.length > 0) {
+                result = firstValidResponse.response.payload;
+                LOG.debug(method, `Response includes payload data of ${firstValidResponse.response.payload.length} bytes`);
+            } else {
+                LOG.debug(method, 'Response does not include payload data');
+            }
+
+            // Submit the endorsed transaction to the primary orderers.
+            const proposal = results[1];
+            const header = results[2];
+
+            // check that we have a Chaincode listener setup and ready.
+            this._checkCCListener();
+            eventHandler = HLFConnection.createTxEventHandler(this.eventHubs, txId.getTransactionID(), this.commitTimeout);
+            eventHandler.startListening();
+            const response = await this.channel.sendTransaction({
+                proposalResponses: validResponses,
+                proposal: proposal,
+                header: header
             });
+
+            // If the transaction was successful, wait for it to be committed.
+            LOG.debug(method, 'Received response from orderer', response);
+
+            if (response.status !== 'SUCCESS') {
+                eventHandler.cancelListening();
+                throw new Error(`Failed to send peer responses for transaction '${txId.getTransactionID()}' to orderer. Response status '${response.status}'`);
+            }
+            await eventHandler.waitForEvents();
+
+            LOG.exit(method, result);
+            return result;
+
+        } catch (error) {
+            const newError = new Error('Error trying invoke business network. ' + error);
+            LOG.error(method, newError);
+            throw newError;
+        }
     }
 
     /**

--- a/packages/composer-connector-hlfv1/test/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/test/hlfconnection.js
@@ -1721,7 +1721,15 @@ describe('HLFConnection', () => {
                 .should.be.rejectedWith(/invalid arg specified: 3.142/);
         });
 
-        it('should query chaincode and handle a good response', async () => {
+        it('should query chaincode and handle a good response without return data', async () => {
+            mockQueryHandler.queryChaincode.withArgs(mockTransactionID, 'myfunc', ['arg1', 'arg2']).resolves();
+
+            let result = await connection.queryChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2']);
+            sinon.assert.calledOnce(mockQueryHandler.queryChaincode);
+            should.equal(result, null);
+        });
+
+        it('should query chaincode and handle a good response with return data', async () => {
             const response = Buffer.from('hello world');
             mockQueryHandler.queryChaincode.withArgs(mockTransactionID, 'myfunc', ['arg1', 'arg2']).resolves(response);
 
@@ -1783,7 +1791,7 @@ describe('HLFConnection', () => {
                 .should.be.rejectedWith(/invalid arg specified: 3.142/);
         });
 
-        it('should submit an invoke request to the chaincode', () => {
+        it('should submit an invoke request to the chaincode which does not return data', () => {
             const proposalResponses = [{
                 response: {
                     status: 200
@@ -1801,7 +1809,41 @@ describe('HLFConnection', () => {
             mockEventHub1.registerTxEvent.yields('00000000-0000-0000-0000-000000000000', 'VALID');
             return connection.invokeChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2'])
                 .then((result) => {
-                    should.equal(result, undefined);
+                    should.equal(result, null);
+                    sinon.assert.calledOnce(mockChannel.sendTransactionProposal);
+                    sinon.assert.calledWith(mockChannel.sendTransactionProposal, {
+                        chaincodeId: mockBusinessNetwork.getName(),
+                        txId: mockTransactionID,
+                        fcn: 'myfunc',
+                        args: ['arg1', 'arg2']
+                    });
+                    sinon.assert.calledOnce(mockChannel.sendTransaction);
+                    sinon.assert.calledOnce(connection._checkCCListener);
+                    sinon.assert.calledOnce(connection._checkEventhubs);
+                });
+        });
+
+        it('should submit an invoke request to the chaincode which does return data', () => {
+            const proposalResponses = [{
+                response: {
+                    status: 200,
+                    payload: 'hello world'
+                }
+            }];
+            const proposal = { proposal: 'i do' };
+            const header = { header: 'gooooal' };
+            mockChannel.sendTransactionProposal.resolves([ proposalResponses, proposal, header ]);
+            connection._validatePeerResponses.returns({ignoredErrors: 0, validResponses: proposalResponses});
+            // This is the commit proposal and response (from the orderer).
+            const response = {
+                status: 'SUCCESS'
+            };
+            mockChannel.sendTransaction.withArgs({ proposalResponses: proposalResponses, proposal: proposal, header: header }).resolves(response);
+            // This is the event hub response.
+            mockEventHub1.registerTxEvent.yields('00000000-0000-0000-0000-000000000000', 'VALID');
+            return connection.invokeChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2'])
+                .then((result) => {
+                    result.should.equal('hello world');
                     sinon.assert.calledOnce(mockChannel.sendTransactionProposal);
                     sinon.assert.calledWith(mockChannel.sendTransactionProposal, {
                         chaincodeId: mockBusinessNetwork.getName(),
@@ -1834,7 +1876,7 @@ describe('HLFConnection', () => {
             mockEventHub1.registerTxEvent.yields('00000000-0000-0000-0000-000000000000', 'VALID');
             return connection.invokeChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2'],options)
                 .then((result) => {
-                    should.equal(result, undefined);
+                    should.equal(result, null);
                     sinon.assert.notCalled(mockClient.newTransactionID);
                     sinon.assert.calledOnce(mockChannel.sendTransactionProposal);
                     sinon.assert.calledWith(mockChannel.sendTransactionProposal, {
@@ -1868,7 +1910,7 @@ describe('HLFConnection', () => {
             mockEventHub1.registerTxEvent.yields('5678', 'VALID');
             return connection.invokeChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2'],options)
                 .then((result) => {
-                    should.equal(result, undefined);
+                    should.equal(result, null);
                     mockTransactionID.should.deep.equal({_nonce: '1234', _transaction_id: '5678'});
                     sinon.assert.calledOnce(mockClient.newTransactionID);
                     sinon.assert.calledOnce(mockChannel.sendTransactionProposal);

--- a/packages/composer-connector-proxy/lib/proxyconnection.js
+++ b/packages/composer-connector-proxy/lib/proxyconnection.js
@@ -169,8 +169,11 @@ class ProxyConnection extends Connection {
             this.socket.emit('/api/connectionQueryChainCode', this.connectionID, securityContext.securityContextID, functionName, args, (error, result) => {
                 if (error) {
                     return reject(ProxyUtil.inflaterr(error));
+                } else if (result) {
+                    resolve(Buffer.from(result));
+                } else {
+                    resolve(null);
                 }
-                resolve(Buffer.from(result));
             });
         });
     }
@@ -182,16 +185,19 @@ class ProxyConnection extends Connection {
      * @param {string[]} args The arguments to pass to the chaincode function.
      * @param {Object} options options to pass to invoking chaincode
      * @param {Object} options.transactionId Transaction Id to use.
-     * @return {Promise} A promise that is resolved once the chaincode function
-     * has been invoked, or rejected with an error.
+     * @return {Promise} A promise that is resolved with the data returned by the
+     * chaincode function once it has been invoked, or rejected with an error.
      */
     invokeChainCode(securityContext, functionName, args, options) {
         return new Promise((resolve, reject) => {
-            this.socket.emit('/api/connectionInvokeChainCode', this.connectionID, securityContext.securityContextID, functionName, args, options, (error) => {
+            this.socket.emit('/api/connectionInvokeChainCode', this.connectionID, securityContext.securityContextID, functionName, args, options, (error, result) => {
                 if (error) {
                     return reject(ProxyUtil.inflaterr(error));
+                } else if (result) {
+                    resolve(Buffer.from(result));
+                } else {
+                    resolve(null);
                 }
-                resolve();
             });
         });
     }

--- a/packages/composer-connector-server/lib/connectorserver.js
+++ b/packages/composer-connector-server/lib/connectorserver.js
@@ -586,8 +586,8 @@ class ConnectorServer {
         }
         return connection.queryChainCode(securityContext, functionName, args)
             .then((result) => {
-                callback(null, result.toString());
-                LOG.exit(method, result.toString());
+                callback(null, result ? result.toString() : null);
+                LOG.exit(method, result ? result.toString() : null);
             })
             .catch((error) => {
                 LOG.error(method, error);
@@ -627,14 +627,14 @@ class ConnectorServer {
             return Promise.resolve();
         }
         return connection.invokeChainCode(securityContext, functionName, args, options)
-            .then(() => {
-                callback(null);
-                LOG.exit(method);
+            .then((result) => {
+                callback(null, result ? result.toString() : null);
+                LOG.exit(method, result ? result.toString() : null);
             })
             .catch((error) => {
                 LOG.error(method, error);
                 callback(ConnectorServer.serializerr(error));
-                LOG.exit(method);
+                LOG.exit(method, null);
             });
     }
 

--- a/packages/composer-connector-server/test/connectorserver.js
+++ b/packages/composer-connector-server/test/connectorserver.js
@@ -903,7 +903,19 @@ describe('ConnectorServer', () => {
             connectorServer.securityContexts[securityContextID] = mockSecurityContext;
         });
 
-        it('should query chain code', () => {
+        it('should query chain code that does not return data', () => {
+            mockConnection.queryChainCode.withArgs(mockSecurityContext, functionName, args).resolves();
+            const cb = sinon.stub();
+            return connectorServer.connectionQueryChainCode(connectionID, securityContextID, functionName, args, cb)
+                .then(() => {
+                    sinon.assert.calledOnce(mockConnection.queryChainCode);
+                    sinon.assert.calledWith(mockConnection.queryChainCode, mockSecurityContext, functionName, args);
+                    sinon.assert.calledOnce(cb);
+                    sinon.assert.calledWith(cb, null, null);
+                });
+        });
+
+        it('should query chain code that does return data', () => {
             mockConnection.queryChainCode.withArgs(mockSecurityContext, functionName, args).resolves(Buffer.from('hello world'));
             const cb = sinon.stub();
             return connectorServer.connectionQueryChainCode(connectionID, securityContextID, functionName, args, cb)
@@ -964,7 +976,7 @@ describe('ConnectorServer', () => {
             connectorServer.securityContexts[securityContextID] = mockSecurityContext;
         });
 
-        it('should invoke chain code with no options', () => {
+        it('should invoke chain code with no options that does not return data', () => {
             mockConnection.invokeChainCode.withArgs(mockSecurityContext, functionName, args, sinon.match.any).resolves();
             const cb = sinon.stub();
             return connectorServer.connectionInvokeChainCode(connectionID, securityContextID, functionName, args, null, cb)
@@ -973,6 +985,18 @@ describe('ConnectorServer', () => {
                     sinon.assert.calledWith(mockConnection.invokeChainCode, mockSecurityContext, functionName, args);
                     sinon.assert.calledOnce(cb);
                     sinon.assert.calledWith(cb, null);
+                });
+        });
+
+        it('should invoke chain code with no options that does return data', () => {
+            mockConnection.invokeChainCode.withArgs(mockSecurityContext, functionName, args, sinon.match.any).resolves(Buffer.from('hello world'));
+            const cb = sinon.stub();
+            return connectorServer.connectionInvokeChainCode(connectionID, securityContextID, functionName, args, null, cb)
+                .then(() => {
+                    sinon.assert.calledOnce(mockConnection.invokeChainCode);
+                    sinon.assert.calledWith(mockConnection.invokeChainCode, mockSecurityContext, functionName, args);
+                    sinon.assert.calledOnce(cb);
+                    sinon.assert.calledWith(cb, null, 'hello world');
                 });
         });
 

--- a/packages/composer-connector-web/lib/webconnection.js
+++ b/packages/composer-connector-web/lib/webconnection.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const { Certificate, CertificateUtil, Connection } = require('composer-common');
+const { Certificate, CertificateUtil, Connection, Util } = require('composer-common');
 const { Engine, InstalledBusinessNetwork } = require('composer-runtime');
 const uuid = require('uuid');
 const { WebContainer, WebContext, WebDataService } = require('composer-runtime-web');
@@ -179,16 +179,15 @@ class WebConnection extends Connection {
      * @param {SecurityContext} securityContext The participant's security context.
      * @param {string} functionName The name of the chaincode function to invoke.
      * @param {string[]} args The arguments to pass to the chaincode function.
-     * @return {Promise} A promise that is resolved with the data returned by the
-     * chaincode function once it has been invoked, or rejected with an error.
-     * @async
+     * @return {Buffer} A buffer containing the data returned by the chaincode function,
+     * or null if no data was returned.
      */
     async queryChainCode(securityContext, functionName, args) {
         const identity = securityContext.getIdentity();
         const networkInfo = await this._getNetworkInfo(securityContext.getNetworkName());
         const context = new WebContext(networkInfo.engine, networkInfo.installedNetwork, identity, this);
         const data = await networkInfo.engine.query(context, functionName, args);
-        return Buffer.from(JSON.stringify(data));
+        return !Util.isNull(data) ? Buffer.from(JSON.stringify(data)) : null;
     }
 
     /**
@@ -219,13 +218,15 @@ class WebConnection extends Connection {
      * @param {SecurityContext} securityContext The participant's security context.
      * @param {string} functionName The name of the chaincode function to invoke.
      * @param {string[]} args The arguments to pass to the chaincode function.
-     * @async
+     * @return {Buffer} A buffer containing the data returned by the chaincode function,
+     * or null if no data was returned.
      */
     async invokeChainCode(securityContext, functionName, args) {
         const identity = securityContext.getIdentity();
         const networkInfo = await this._getNetworkInfo(securityContext.getNetworkName());
         const context = new WebContext(networkInfo.engine, networkInfo.installedNetwork, identity, this);
-        await networkInfo.engine.invoke(context, functionName, args);
+        const data = await networkInfo.engine.invoke(context, functionName, args);
+        return !Util.isNull(data) ? Buffer.from(JSON.stringify(data)) : null;
     }
 
     /**

--- a/packages/composer-connector-web/test/webconnection.js
+++ b/packages/composer-connector-web/test/webconnection.js
@@ -228,7 +228,29 @@ describe('WebConnection', () => {
 
     describe('#queryChainCode', () => {
 
-        it('should call the engine query method', async () => {
+        it('should call the engine query method that does not return data', async () => {
+            const networkDefinition = new BusinessNetworkDefinition('test-network@1.0.0');
+            const functionName = 'testFunction';
+            const functionArgs = ['a', 'b', 'c'];
+
+            const mockContainer = sinon.createStubInstance(WebContainer);
+            sandbox.stub(WebConnection, 'createContainer').returns(mockContainer);
+            const mockEngine = sinon.createStubInstance(Engine);
+            mockEngine.getContainer.returns(mockContainer);
+            sandbox.stub(WebConnection, 'createEngine').returns(mockEngine);
+            mockEngine.init.resolves();
+            mockEngine.query.withArgs(sinon.match.instanceOf(Context), functionName, functionArgs).resolves();
+            mockSecurityContext.getNetworkName.returns(networkDefinition.getName());
+
+            await connection.install(mockSecurityContext, networkDefinition);
+            await connection.start(mockSecurityContext, networkDefinition.getName(), networkDefinition.getVersion());
+            const actual = await connection.queryChainCode(mockSecurityContext, functionName, functionArgs);
+
+            sinon.assert.calledWith(mockEngine.query, sinon.match.instanceOf(Context), functionName, functionArgs);
+            should.equal(actual, null);
+        });
+
+        it('should call the engine query method that does returns data', async () => {
             const networkDefinition = new BusinessNetworkDefinition('test-network@1.0.0');
             const functionName = 'testFunction';
             const functionArgs = ['a', 'b', 'c'];
@@ -247,6 +269,7 @@ describe('WebConnection', () => {
             await connection.start(mockSecurityContext, networkDefinition.getName(), networkDefinition.getVersion());
             const actual = await connection.queryChainCode(mockSecurityContext, functionName, functionArgs);
 
+            sinon.assert.calledWith(mockEngine.query, sinon.match.instanceOf(Context), functionName, functionArgs);
             JSON.parse(actual.toString()).should.deep.equal(expected);
         });
 
@@ -254,7 +277,29 @@ describe('WebConnection', () => {
 
     describe('#invokeChainCode', () => {
 
-        it('should call the engine invoke method', async () => {
+        it('should call the engine invoke method that does not return data', async () => {
+            const networkDefinition = new BusinessNetworkDefinition('test-network@1.0.0');
+            const functionName = 'testFunction';
+            const functionArgs = ['a', 'b', 'c'];
+
+            const mockContainer = sinon.createStubInstance(WebContainer);
+            sandbox.stub(WebConnection, 'createContainer').returns(mockContainer);
+            const mockEngine = sinon.createStubInstance(Engine);
+            mockEngine.getContainer.returns(mockContainer);
+            sandbox.stub(WebConnection, 'createEngine').returns(mockEngine);
+            mockEngine.init.resolves();
+            mockEngine.invoke.resolves();
+            mockSecurityContext.getNetworkName.returns(networkDefinition.getName());
+
+            await connection.install(mockSecurityContext, networkDefinition);
+            await connection.start(mockSecurityContext, networkDefinition.getName(), networkDefinition.getVersion());
+            const actual = await connection.invokeChainCode(mockSecurityContext, functionName, functionArgs);
+
+            sinon.assert.calledWith(mockEngine.invoke, sinon.match.instanceOf(Context), functionName, functionArgs);
+            should.equal(actual, null);
+        });
+
+        it('should call the engine invoke method that does return data', async () => {
             const networkDefinition = new BusinessNetworkDefinition('test-network@1.0.0');
             const functionName = 'testFunction';
             const functionArgs = ['a', 'b', 'c'];
@@ -271,9 +316,10 @@ describe('WebConnection', () => {
 
             await connection.install(mockSecurityContext, networkDefinition);
             await connection.start(mockSecurityContext, networkDefinition.getName(), networkDefinition.getVersion());
-            await connection.invokeChainCode(mockSecurityContext, functionName, functionArgs);
+            const actual = await connection.invokeChainCode(mockSecurityContext, functionName, functionArgs);
 
             sinon.assert.calledWith(mockEngine.invoke, sinon.match.instanceOf(Context), functionName, functionArgs);
+            JSON.parse(actual.toString()).should.deep.equal(expected);
         });
 
     });


### PR DESCRIPTION
#4165 

All connectors (embedded, web, proxy, hlfv1) and the connector server need to be extended to support returning data from a chaincode invoke as well as a chaincode query.