### PR TITLE
Fix query examples in documentation

### DIFF
--- a/packages/composer-runtime/lib/api.js
+++ b/packages/composer-runtime/lib/api.js
@@ -290,9 +290,9 @@ class Api {
          * configured with the CouchDB database for the world state.
          * @example
          * // Build a query.
-         * var query = buildQuery('SELECT org.example.sample.SampleAsset WHERE (value == _$inputValue)');
+         * var q = buildQuery('SELECT org.example.sample.SampleAsset WHERE (value == _$inputValue)');
          * // Execute the query.
-         * return query(query, { inputValue: 'blue' })
+         * return query(q, { inputValue: 'blue' })
          *   .then(function (assets) {
          *     assets.forEach(function (asset) {
          *       // Process each asset.


### PR DESCRIPTION
Due to the variable naming in the first example, the code could not actually be executed (an error saying that `query is not a function` would occur).

The second example could also be clarified by including an actual query that takes a variable to make the rest of the code in the example make more sense.

Thank you!