### PR TITLE
Add decorator factory and implementation for @commit

### DIFF
--- a/packages/composer-common/api.txt
+++ b/packages/composer-common/api.txt
@@ -39,6 +39,13 @@ class Certificate {
 class CertificateUtil {
    + void generate(Object,string,string,string,string) 
 }
+class CommitDecorator extends Decorator {
+   + void constructor(Object) throws IllegalModelException
+   + boolean getValue() 
+}
+class CommitDecoratorFactory extends DecoratorFactory {
+   + Decorator newDecorator(Object) 
+}
 class Factory {
    + Resource newResource(String,String,String,Object,boolean,String,boolean,boolean) throws TypeNotFoundException
    + Resource newConcept(String,String,Object,boolean,String,boolean) throws TypeNotFoundException

--- a/packages/composer-common/changelog.txt
+++ b/packages/composer-common/changelog.txt
@@ -24,9 +24,10 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 0.19.11 {38988b983f6b23ad7e6e7b28bc33961d} 2018-06-29
+Version 0.19.11 {765772c9b73656c289a15398bccc76fd} 2018-06-29
 - Add decorator factories
 - Add returns decorator factory
+- Add commit decorator factory
 
 Version 0.19.1 {f6814276d318be3b4ed0f6212bc77c6f} 2018-04-06
 - Enable simple JSON.stringify serialization of resources

--- a/packages/composer-common/index.js
+++ b/packages/composer-common/index.js
@@ -60,6 +60,7 @@ module.exports.Certificate = require('./lib/certificate');
 module.exports.CertificateUtil = require('./lib/certificateutil');
 module.exports.ClassDeclaration = require('./lib/introspect/classdeclaration');
 module.exports.CodeGen = require('./lib/codegen/codegen.js');
+module.exports.CommitDecoratorFactory = require('./lib/commitdecoratorfactory');
 module.exports.Concept = require('./lib/model/concept');
 module.exports.ConceptDeclaration = require('./lib/introspect/conceptdeclaration');
 module.exports.Connection = require('./lib/connection');

--- a/packages/composer-common/lib/businessnetworkdefinition.js
+++ b/packages/composer-common/lib/businessnetworkdefinition.js
@@ -17,6 +17,7 @@
 const AclFile = require('./acl/aclfile');
 const AclManager = require('./aclmanager');
 const BusinessNetworkMetadata = require('./businessnetworkmetadata');
+const CommitDecoratorFactory = require('./commitdecoratorfactory');
 const fs = require('fs');
 const fsPath = require('path');
 const Introspector = require('./introspect/introspector');
@@ -115,6 +116,7 @@ class BusinessNetworkDefinition {
         }
 
         this.modelManager = new ModelManager();
+        this.modelManager.addDecoratorFactory(new CommitDecoratorFactory());
         this.modelManager.addDecoratorFactory(new ReturnsDecoratorFactory());
         this.factory = this.modelManager.getFactory();
         this.serializer = this.modelManager.getSerializer();

--- a/packages/composer-common/lib/commitdecorator.js
+++ b/packages/composer-common/lib/commitdecorator.js
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Decorator = require('./introspect/decorator');
+const IllegalModelException = require('./introspect/illegalmodelexception');
+
+/**
+ * Specialised decorator implementation for the @commit decorator.
+ */
+class CommitDecorator extends Decorator {
+
+    /**
+     * Create a Decorator.
+     * @param {ClassDeclaration | Property} parent - the owner of this property
+     * @param {Object} ast - The AST created by the parser
+     * @throws {IllegalModelException}
+     */
+    constructor(parent, ast) {
+        super(parent, ast);
+    }
+
+    /**
+     * Process the AST and build the model
+     * @throws {IllegalModelException}
+     * @private
+     */
+    process() {
+        super.process();
+        const args = this.getArguments();
+        if (args.length !== 1) {
+            throw new IllegalModelException(`@commit decorator expects 1 argument, but ${args.length} arguments were specified.`, this.parent.getModelFile(), this.ast.location);
+        }
+        const arg = args[0];
+        if (typeof arg !== 'boolean') {
+            throw new IllegalModelException(`@commit decorator expects a boolean argument, but an argument of type ${typeof arg} was specified.`, this.parent.getModelFile(), this.ast.location);
+        }
+        this.value = arg;
+    }
+
+    /**
+     * Get the value of this commit decorator.
+     * @return {boolean} The value of this commit decorator.
+     */
+    getValue() {
+        return this.value;
+    }
+
+}
+
+module.exports = CommitDecorator;

--- a/packages/composer-common/lib/commitdecoratorfactory.js
+++ b/packages/composer-common/lib/commitdecoratorfactory.js
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const DecoratorFactory = require('./introspect/decoratorfactory');
+const CommitDecorator = require('./commitdecorator');
+
+/**
+ * A decorator factory for the @commit decorator.
+ */
+class CommitDecoratorFactory extends DecoratorFactory {
+
+    /**
+     * Process the decorator, and return a specific implementation class for that
+     * decorator, or return null if this decorator is not handled by this processor.
+     * @abstract
+     * @param {ClassDeclaration | Property} parent - the owner of this property
+     * @param {Object} ast - The AST created by the parser
+     * @return {Decorator} The decorator.
+     */
+    newDecorator(parent, ast) {
+        if (ast.name !== 'commit') {
+            return null;
+        }
+        return new CommitDecorator(parent, ast);
+    }
+
+}
+
+module.exports = CommitDecoratorFactory;

--- a/packages/composer-common/test/businessnetworkdefinition.js
+++ b/packages/composer-common/test/businessnetworkdefinition.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const BusinessNetworkDefinition = require('../lib/businessnetworkdefinition');
+const CommitDecorator = require('../lib/commitdecorator');
 const fs = require('fs');
 const JSZip = require('jszip');
 const ModelFile = require('../lib/introspect/modelfile');
@@ -490,6 +491,18 @@ describe('BusinessNetworkDefinition', () => {
     });
 
     describe('#decorator processors', () => {
+
+        it('should install the decorator processor for @commit', () => {
+            const bnd = new BusinessNetworkDefinition('id@1.0.0', 'description', null, 'readme');
+            const modelManager = bnd.getModelManager();
+            modelManager.addModelFile(`
+            namespace org.acme
+            @commit(false)
+            transaction T { }`);
+            const transactionDeclaration = modelManager.getType('org.acme.T');
+            const decorator = transactionDeclaration.getDecorator('commit');
+            decorator.should.be.an.instanceOf(CommitDecorator);
+        });
 
         it('should install the decorator processor for @returns', () => {
             const bnd = new BusinessNetworkDefinition('id@1.0.0', 'description', null, 'readme');

--- a/packages/composer-common/test/commitdecorator.js
+++ b/packages/composer-common/test/commitdecorator.js
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const CommitDecorator = require('../lib/commitdecorator');
+const CommitDecoratorFactory = require('../lib/commitdecoratorfactory');
+const ModelManager = require('../lib/modelmanager');
+
+require('chai').should();
+
+describe('CommitDecorator', () => {
+
+    let modelManager;
+    let transactionDeclaration;
+
+    beforeEach(() => {
+        modelManager = new ModelManager();
+        modelManager.addDecoratorFactory(new CommitDecoratorFactory());
+        modelManager.addModelFile(`
+        namespace org.acme
+        transaction T { }
+        `);
+        transactionDeclaration = modelManager.getType('org.acme.T');
+    });
+
+    describe('#process', () => {
+
+        it('should throw if no arguments are specified', () => {
+            (() => {
+                new CommitDecorator(transactionDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'commit', arguments: { list: [] } });
+            }).should.throw(/@commit decorator expects 1 argument, but 0 arguments were specified. Line 1 column 1, to line 1 column 23./);
+        });
+
+        it('should throw if two arguments are specified', () => {
+            (() => {
+                new CommitDecorator(transactionDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'commit', arguments: { list: [ { value: true }, { value: false } ] } });
+            }).should.throw(/@commit decorator expects 1 argument, but 2 arguments were specified. Line 1 column 1, to line 1 column 23./);
+        });
+
+        it('should throw if a an incorrectly typed argument is specified', () => {
+            (() => {
+                new CommitDecorator(transactionDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'commit', arguments: { list: [ { value: 'hello world' } ] } });
+            }).should.throw(/@commit decorator expects a boolean argument, but an argument of type string was specified. Line 1 column 1, to line 1 column 23./);
+        });
+
+    });
+
+    describe('#getValue', () => {
+
+        it('should return true if the argument is true', () => {
+            const decorator = new CommitDecorator(transactionDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'commit', arguments: { list: [ { value: true } ] } });
+            decorator.getValue().should.be.true;
+        });
+
+        it('should return false if the argument is false', () => {
+            const decorator = new CommitDecorator(transactionDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'commit', arguments: { list: [ { value: false } ] } });
+            decorator.getValue().should.be.false;
+        });
+
+    });
+
+});

--- a/packages/composer-common/test/commitdecoratorfactory.js
+++ b/packages/composer-common/test/commitdecoratorfactory.js
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const CommitDecorator = require('../lib/commitdecorator');
+const CommitDecoratorFactory = require('../lib/commitdecoratorfactory');
+const ModelManager = require('../lib/modelmanager');
+
+const should = require('chai').should();
+
+describe('CommitDecoratorFactory', () => {
+
+    let modelManager;
+    let transactionDeclaration;
+    let factory;
+
+    beforeEach(() => {
+        modelManager = new ModelManager();
+        modelManager.addModelFile(`
+        namespace org.acme
+        transaction T { }
+        `);
+        transactionDeclaration = modelManager.getType('org.acme.T');
+        factory = new CommitDecoratorFactory();
+    });
+
+    describe('#process', () => {
+
+        it('should return null for a @foobar decorator', () => {
+            should.equal(factory.newDecorator(transactionDeclaration, { name: 'foobar' }), null);
+        });
+
+        it('should return a commit decorator instance for a @commit decorator', () => {
+            const decorator = factory.newDecorator(transactionDeclaration, { name: 'commit', arguments: { list: [ { value: false } ] } });
+            decorator.should.be.an.instanceOf(CommitDecorator);
+        });
+
+    });
+
+});


### PR DESCRIPTION
#4224

Add a decorator implementation and decorator factory for handling @commit decorators.
Allows the following decorators to be validated by Composer:

```
@commit(true)
transaction TransactionWithCommitTrue {
    o String stringValue
}

@commit(false)
transaction TransactionWithCommitFalse {
    o String stringValue
}
```