### PR TITLE
Extend connectors and embedded/web runtime to support commit flag

### DIFF
--- a/packages/composer-connector-embedded/lib/embeddedconnection.js
+++ b/packages/composer-connector-embedded/lib/embeddedconnection.js
@@ -286,17 +286,18 @@ class EmbeddedConnection extends Connection {
      * @param {SecurityContext} securityContext The participant's security context.
      * @param {string} functionName The name of the chaincode function to invoke.
      * @param {string[]} args The arguments to pass to the chaincode function.
+     * @param {Object} [additionalConnectorOptions] Additional connector specific options for this transaction.
      * @return {Buffer} A buffer containing the data returned by the chaincode function,
      * or null if no data was returned.
      */
-    async invokeChainCode(securityContext, functionName, args) {
+    async invokeChainCode(securityContext, functionName, args, additionalConnectorOptions = {}) {
         if (!this.businessNetworkIdentifier) {
             throw new Error('No business network has been specified for this connection');
         }
         let identity = securityContext.getIdentity();
         let chaincodeUUID = securityContext.getChaincodeID();
         let chaincode = EmbeddedConnection.getChaincode(chaincodeUUID);
-        let context = new EmbeddedContext(chaincode.engine, identity, this, chaincode.installedBusinessNetwork);
+        let context = new EmbeddedContext(chaincode.engine, identity, this, chaincode.installedBusinessNetwork, additionalConnectorOptions);
         const data = await chaincode.engine.invoke(context, functionName, args);
         return !Util.isNull(data) ? Buffer.from(JSON.stringify(data)) : null;
     }

--- a/packages/composer-connector-embedded/test/embeddedconnection.js
+++ b/packages/composer-connector-embedded/test/embeddedconnection.js
@@ -466,6 +466,83 @@ describe('EmbeddedConnection', () => {
             }), 'testFunction', ['arg1', 'arg2']);
             JSON.parse(result.toString()).should.deep.equal({ test: 'data from engine' });
         });
+
+        it('should call the engine invoke method with commit set to true', async () => {
+
+            // Mock a container
+            let mockContainer = sinon.createStubInstance(EmbeddedContainer);
+            mockContainer.getUUID.returns('6eeb8858-eced-4a32-b1cd-2491f1e3718f');
+            sandbox.stub(EmbeddedConnection, 'createContainer').returns(mockContainer);
+
+            // Mock an engine
+            let mockEngine = sinon.createStubInstance(Engine);
+            mockEngine.getContainer.returns(mockContainer);
+            mockEngine.init.resolves();
+            mockEngine.invoke.resolves();
+            sandbox.stub(EmbeddedConnection, 'createEngine').returns(mockEngine);
+
+            // Mock a security context
+            mockSecurityContext.getIdentity.returns(identity);
+            mockSecurityContext.getChaincodeID.returns('6eeb8858-eced-4a32-b1cd-2491f1e3718f');
+
+            // do required install/start
+            await connection.install(mockSecurityContext, businessNetworkDefinition);
+            await connection.start(mockSecurityContext,
+                businessNetworkDefinition.getName(),
+                businessNetworkDefinition.getVersion(),
+                '{"start":"json"}',
+                { start: 'options' });
+
+            // test the function
+            await connection.invokeChainCode(mockSecurityContext, 'testFunction', ['arg1', 'arg2'], { commit: true });
+
+            // validate the behaviour
+            sinon.assert.calledOnce(mockEngine.invoke);
+            sinon.assert.calledWith(mockEngine.invoke, sinon.match((context) => {
+                context.should.be.an.instanceOf(Context);
+                context.additionalConnectorOptions.commit.should.be.true;
+                return true;
+            }), 'testFunction', ['arg1', 'arg2']);
+        });
+
+        it('should call the engine invoke method with commit set to false', async () => {
+
+            // Mock a container
+            let mockContainer = sinon.createStubInstance(EmbeddedContainer);
+            mockContainer.getUUID.returns('6eeb8858-eced-4a32-b1cd-2491f1e3718f');
+            sandbox.stub(EmbeddedConnection, 'createContainer').returns(mockContainer);
+
+            // Mock an engine
+            let mockEngine = sinon.createStubInstance(Engine);
+            mockEngine.getContainer.returns(mockContainer);
+            mockEngine.init.resolves();
+            mockEngine.invoke.resolves();
+            sandbox.stub(EmbeddedConnection, 'createEngine').returns(mockEngine);
+
+            // Mock a security context
+            mockSecurityContext.getIdentity.returns(identity);
+            mockSecurityContext.getChaincodeID.returns('6eeb8858-eced-4a32-b1cd-2491f1e3718f');
+
+            // do required install/start
+            await connection.install(mockSecurityContext, businessNetworkDefinition);
+            await connection.start(mockSecurityContext,
+                businessNetworkDefinition.getName(),
+                businessNetworkDefinition.getVersion(),
+                '{"start":"json"}',
+                { start: 'options' });
+
+            // test the function
+            await connection.invokeChainCode(mockSecurityContext, 'testFunction', ['arg1', 'arg2'], { commit: false });
+
+            // validate the behaviour
+            sinon.assert.calledOnce(mockEngine.invoke);
+            sinon.assert.calledWith(mockEngine.invoke, sinon.match((context) => {
+                context.should.be.an.instanceOf(Context);
+                context.additionalConnectorOptions.commit.should.be.false;
+                return true;
+            }), 'testFunction', ['arg1', 'arg2']);
+        });
+
     });
 
     describe('#getIdentities', () => {

--- a/packages/composer-connector-hlfv1/lib/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/lib/hlfconnection.js
@@ -896,7 +896,7 @@ class HLFConnection extends Connection {
      * @return {Promise} A promise that is resolved once the chaincode function
      * has been invoked, or rejected with an error.
      */
-    async invokeChainCode(securityContext, functionName, args, options) {
+    async invokeChainCode(securityContext, functionName, args, options = {}) {
         const method = 'invokeChainCode';
         LOG.entry(method, securityContext, functionName, args, options);
 
@@ -959,6 +959,13 @@ class HLFConnection extends Connection {
                 LOG.debug(method, `Response includes payload data of ${firstValidResponse.response.payload.length} bytes`);
             } else {
                 LOG.debug(method, 'Response does not include payload data');
+            }
+
+            // If commit has been set to false, do not order the transaction or wait for any events.
+            if (options.commit === false) {
+                LOG.debug(method, 'Commit has been set to false, not ordering transaction or waiting for any events');
+                LOG.exit(method, result);
+                return result;
             }
 
             // Submit the endorsed transaction to the primary orderers.

--- a/packages/composer-connector-hlfv1/test/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/test/hlfconnection.js
@@ -1231,8 +1231,8 @@ describe('HLFConnection', () => {
                 mockChannel.verifyProposalResponse.returns(true);
                 mockChannel.compareProposalResponseResults.returns(false);
                 mockEventHub1.registerTxEvent.yields(mockTransactionID.getTransactionID().toString(), 'INVALID');
-                connection.start(mockSecurityContext, mockBusinessNetwork.getName(), mockBusinessNetwork.getVersion(), '{"start":"json"}')
-                .should.be.rejectedWith(/such error'/);
+                return connection.start(mockSecurityContext, mockBusinessNetwork.getName(), mockBusinessNetwork.getVersion(), '{"start":"json"}')
+                    .should.be.rejectedWith(/such error/);
             });
         });
 
@@ -2015,6 +2015,74 @@ describe('HLFConnection', () => {
             mockEventHub1.registerTxEvent.yields('00000000-0000-0000-0000-000000000000', 'VALID');
             return connection.invokeChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2'])
                 .should.be.rejectedWith(/Failed to send/);
+        });
+
+        it('should submit an invoke request to the chaincode and order it if commit specified as true', () => {
+            const proposalResponses = [{
+                response: {
+                    status: 200,
+                    payload: 'hello world'
+                }
+            }];
+            const proposal = { proposal: 'i do' };
+            const header = { header: 'gooooal' };
+            mockChannel.sendTransactionProposal.resolves([ proposalResponses, proposal, header ]);
+            connection._validatePeerResponses.returns({ignoredErrors: 0, validResponses: proposalResponses});
+            // This is the commit proposal and response (from the orderer).
+            const response = {
+                status: 'SUCCESS'
+            };
+            mockChannel.sendTransaction.withArgs({ proposalResponses: proposalResponses, proposal: proposal, header: header }).resolves(response);
+            // This is the event hub response.
+            mockEventHub1.registerTxEvent.yields('00000000-0000-0000-0000-000000000000', 'VALID');
+            return connection.invokeChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2'], { commit: true })
+                .then((result) => {
+                    result.should.equal('hello world');
+                    sinon.assert.calledOnce(mockChannel.sendTransactionProposal);
+                    sinon.assert.calledWith(mockChannel.sendTransactionProposal, {
+                        chaincodeId: mockBusinessNetwork.getName(),
+                        txId: mockTransactionID,
+                        fcn: 'myfunc',
+                        args: ['arg1', 'arg2']
+                    });
+                    sinon.assert.calledOnce(mockChannel.sendTransaction);
+                    sinon.assert.calledOnce(connection._checkCCListener);
+                    sinon.assert.calledOnce(connection._checkEventhubs);
+                });
+        });
+
+        it('should submit an invoke request to the chaincode and not order it if commit specified as false', () => {
+            const proposalResponses = [{
+                response: {
+                    status: 200,
+                    payload: 'hello world'
+                }
+            }];
+            const proposal = { proposal: 'i do' };
+            const header = { header: 'gooooal' };
+            mockChannel.sendTransactionProposal.resolves([ proposalResponses, proposal, header ]);
+            connection._validatePeerResponses.returns({ignoredErrors: 0, validResponses: proposalResponses});
+            // This is the commit proposal and response (from the orderer).
+            const response = {
+                status: 'SUCCESS'
+            };
+            mockChannel.sendTransaction.withArgs({ proposalResponses: proposalResponses, proposal: proposal, header: header }).resolves(response);
+            // This is the event hub response.
+            mockEventHub1.registerTxEvent.yields('00000000-0000-0000-0000-000000000000', 'VALID');
+            return connection.invokeChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2'], { commit: false })
+                .then((result) => {
+                    result.should.equal('hello world');
+                    sinon.assert.calledOnce(mockChannel.sendTransactionProposal);
+                    sinon.assert.calledWith(mockChannel.sendTransactionProposal, {
+                        chaincodeId: mockBusinessNetwork.getName(),
+                        txId: mockTransactionID,
+                        fcn: 'myfunc',
+                        args: ['arg1', 'arg2']
+                    });
+                    sinon.assert.notCalled(mockChannel.sendTransaction);
+                    sinon.assert.notCalled(connection._checkCCListener);
+                    sinon.assert.calledOnce(connection._checkEventhubs);
+                });
         });
 
     });

--- a/packages/composer-connector-web/lib/webconnection.js
+++ b/packages/composer-connector-web/lib/webconnection.js
@@ -218,13 +218,14 @@ class WebConnection extends Connection {
      * @param {SecurityContext} securityContext The participant's security context.
      * @param {string} functionName The name of the chaincode function to invoke.
      * @param {string[]} args The arguments to pass to the chaincode function.
+     * @param {Object} [additionalConnectorOptions] Additional connector specific options for this transaction.
      * @return {Buffer} A buffer containing the data returned by the chaincode function,
      * or null if no data was returned.
      */
-    async invokeChainCode(securityContext, functionName, args) {
+    async invokeChainCode(securityContext, functionName, args, additionalConnectorOptions = {}) {
         const identity = securityContext.getIdentity();
         const networkInfo = await this._getNetworkInfo(securityContext.getNetworkName());
-        const context = new WebContext(networkInfo.engine, networkInfo.installedNetwork, identity, this);
+        const context = new WebContext(networkInfo.engine, networkInfo.installedNetwork, identity, this, additionalConnectorOptions);
         const data = await networkInfo.engine.invoke(context, functionName, args);
         return !Util.isNull(data) ? Buffer.from(JSON.stringify(data)) : null;
     }

--- a/packages/composer-connector-web/test/webconnection.js
+++ b/packages/composer-connector-web/test/webconnection.js
@@ -322,6 +322,56 @@ describe('WebConnection', () => {
             JSON.parse(actual.toString()).should.deep.equal(expected);
         });
 
+        it('should call the engine invoke method with commit set to true', async () => {
+            const networkDefinition = new BusinessNetworkDefinition('test-network@1.0.0');
+            const functionName = 'testFunction';
+            const functionArgs = ['a', 'b', 'c'];
+
+            const mockContainer = sinon.createStubInstance(WebContainer);
+            sandbox.stub(WebConnection, 'createContainer').returns(mockContainer);
+            const mockEngine = sinon.createStubInstance(Engine);
+            mockEngine.getContainer.returns(mockContainer);
+            sandbox.stub(WebConnection, 'createEngine').returns(mockEngine);
+            mockEngine.init.resolves();
+            mockEngine.invoke.resolves();
+            mockSecurityContext.getNetworkName.returns(networkDefinition.getName());
+
+            await connection.install(mockSecurityContext, networkDefinition);
+            await connection.start(mockSecurityContext, networkDefinition.getName(), networkDefinition.getVersion());
+            await connection.invokeChainCode(mockSecurityContext, functionName, functionArgs, { commit: true });
+
+            sinon.assert.calledWith(mockEngine.invoke, sinon.match((context) => {
+                context.should.be.an.instanceOf(Context);
+                context.additionalConnectorOptions.commit.should.be.true;
+                return true;
+            }), functionName, functionArgs);
+        });
+
+        it('should call the engine invoke method with commit set to false', async () => {
+            const networkDefinition = new BusinessNetworkDefinition('test-network@1.0.0');
+            const functionName = 'testFunction';
+            const functionArgs = ['a', 'b', 'c'];
+
+            const mockContainer = sinon.createStubInstance(WebContainer);
+            sandbox.stub(WebConnection, 'createContainer').returns(mockContainer);
+            const mockEngine = sinon.createStubInstance(Engine);
+            mockEngine.getContainer.returns(mockContainer);
+            sandbox.stub(WebConnection, 'createEngine').returns(mockEngine);
+            mockEngine.init.resolves();
+            mockEngine.invoke.resolves();
+            mockSecurityContext.getNetworkName.returns(networkDefinition.getName());
+
+            await connection.install(mockSecurityContext, networkDefinition);
+            await connection.start(mockSecurityContext, networkDefinition.getName(), networkDefinition.getVersion());
+            await connection.invokeChainCode(mockSecurityContext, functionName, functionArgs, { commit: false });
+
+            sinon.assert.calledWith(mockEngine.invoke, sinon.match((context) => {
+                context.should.be.an.instanceOf(Context);
+                context.additionalConnectorOptions.commit.should.be.false;
+                return true;
+            }), functionName, functionArgs);
+        });
+
     });
 
     describe('#getIdentities', () => {

--- a/packages/composer-runtime-embedded/lib/embeddedcontext.js
+++ b/packages/composer-runtime-embedded/lib/embeddedcontext.js
@@ -33,12 +33,14 @@ class EmbeddedContext extends Context {
      * @param {Object} identity The current identity.
      * @param {EventEmitter} eventSink The event emitter
      * @param {InstalledBusinessNetwork} installedBusinessNetwork The installed business network
+     * @param {Object} [additionalConnectorOptions] Additional connector specific options for this transaction.
      */
-    constructor(engine, identity, eventSink, installedBusinessNetwork) {
+    constructor(engine, identity, eventSink, installedBusinessNetwork, additionalConnectorOptions = {}) {
         super(engine, installedBusinessNetwork);
-        this.dataService = new EmbeddedDataService(engine.getContainer().getUUID());
+        this.dataService = new EmbeddedDataService(engine.getContainer().getUUID(), false, additionalConnectorOptions);
         this.identityService = new EmbeddedIdentityService(identity);
         this.eventSink = eventSink;
+        this.additionalConnectorOptions = additionalConnectorOptions;
     }
 
     /**
@@ -97,6 +99,7 @@ class EmbeddedContext extends Context {
     getNativeAPI() {
         throw new Error('Native API not available in embedded runtime');
     }
+
 }
 
 module.exports = EmbeddedContext;

--- a/packages/composer-runtime-embedded/lib/embeddeddataservice.js
+++ b/packages/composer-runtime-embedded/lib/embeddeddataservice.js
@@ -32,9 +32,10 @@ class EmbeddedDataService extends PouchDBDataService {
      * Constructor.
      * @param {string} [uuid] The UUID of the container.
      * @param {boolean} [autocommit] Should this data service auto commit?
+     * @param {Object} [additionalConnectorOptions] Additional connector specific options for this transaction.
      */
-    constructor(uuid, autocommit) {
-        super(uuid, autocommit, { adapter: 'memory' });
+    constructor(uuid, autocommit, additionalConnectorOptions = {}) {
+        super(uuid, autocommit, { adapter: 'memory' }, additionalConnectorOptions);
         const method = 'constructor';
         LOG.entry(method, uuid, autocommit);
         LOG.exit(method);

--- a/packages/composer-runtime-embedded/test/embeddeddataservice.js
+++ b/packages/composer-runtime-embedded/test/embeddeddataservice.js
@@ -43,6 +43,11 @@ describe('EmbeddedDataService', () => {
             dataService.should.be.an.instanceOf(DataService);
         });
 
+        it('should pass additional connector options', () => {
+            dataService = new EmbeddedDataService(null, null, { commit: false });
+            dataService.additionalConnectorOptions.commit.should.be.false;
+        });
+
     });
 
 });

--- a/packages/composer-runtime-web/lib/webcontext.js
+++ b/packages/composer-runtime-web/lib/webcontext.js
@@ -32,12 +32,14 @@ class WebContext extends Context {
      * @param {InstalledBusinessNetwork} installedBusinessNetwork Information on the installed business network.
      * @param {Object} identity The current identity.
      * @param {EventEmitter} eventSink The event emitter
+     * @param {Object} [additionalConnectorOptions] Additional connector specific options for this transaction.
      */
-    constructor(engine, installedBusinessNetwork, identity, eventSink) {
+    constructor(engine, installedBusinessNetwork, identity, eventSink, additionalConnectorOptions = {}) {
         super(engine, installedBusinessNetwork);
-        this.dataService = WebDataService.newNetworkDataService(engine.getContainer().getName());
+        this.dataService = WebDataService.newNetworkDataService(engine.getContainer().getName(), false, additionalConnectorOptions);
         this.identityService = new WebIdentityService(identity);
         this.eventSink = eventSink;
+        this.additionalConnectorOptions = additionalConnectorOptions;
     }
 
     /**

--- a/packages/composer-runtime-web/lib/webdataservice.js
+++ b/packages/composer-runtime-web/lib/webdataservice.js
@@ -32,27 +32,30 @@ class WebDataService extends PouchDBDataService {
      * Get a new data service for storing network (blockchain) data.
      * @param {String} containerName Name of the runtime container.
      * @param {boolean} [autocommit] true if the data service should be auto-commit; otherwise false.
+     * @param {Object} [additionalConnectorOptions] Additional connector specific options for this transaction.
      * @return {DataService} the data service.
      */
-    static newNetworkDataService(containerName, autocommit = false) {
-        return new WebDataService(containerName, autocommit);
+    static newNetworkDataService(containerName, autocommit = false, additionalConnectorOptions = {}) {
+        return new WebDataService(containerName, autocommit, additionalConnectorOptions);
     }
 
     /**
      * Get the top-level Composer data service.
+     * @param {Object} [additionalConnectorOptions] Additional connector specific options for this transaction.
      * @return {DataService} the data service.
      */
-    static newComposerDataService() {
-        return new WebDataService(null, true);
+    static newComposerDataService(additionalConnectorOptions = {}) {
+        return new WebDataService(null, true, additionalConnectorOptions);
     }
 
     /**
      * Constructor.
      * @param {string} [uuid] The UUID of the container.
      * @param {boolean} [autocommit] Should this data service auto commit?
+     * @param {Object} [additionalConnectorOptions] Additional connector specific options for this transaction.
      */
-    constructor(uuid, autocommit) {
-        super(uuid, autocommit);
+    constructor(uuid, autocommit, additionalConnectorOptions = {}) {
+        super(uuid, autocommit, null, additionalConnectorOptions);
         const method = 'constructor';
         LOG.entry(method, uuid, autocommit);
         LOG.exit(method);

--- a/packages/composer-runtime-web/test/webdataservice.js
+++ b/packages/composer-runtime-web/test/webdataservice.js
@@ -42,6 +42,11 @@ describe('WebDataService', () => {
             dataService.should.be.an.instanceOf(DataService);
         });
 
+        it('should pass additional connector options', () => {
+            dataService = new WebDataService(null, null, { commit: false });
+            dataService.additionalConnectorOptions.commit.should.be.false;
+        });
+
     });
 
 });


### PR DESCRIPTION
#4224 

All connectors (embedded, web, hlfv1) need to be extended not to commit when the commit option is specified and the value is false. In addition to this, the PouchDB runtime (used by the embedded and web runtimes) needs to be updated to handle this, because commit is done there rather than on the client side as it is with hlfv1.