### PR TITLE
Client implementation for commit flag, add functional tests

### DIFF
--- a/packages/composer-client/api.txt
+++ b/packages/composer-client/api.txt
@@ -24,7 +24,7 @@ class BusinessNetworkConnection extends EventEmitter {
    + Promise connect(String,Object) 
    + Promise getRegistry(String) 
    + Promise disconnect() 
-   + Promise submitTransaction(Resource) 
+   + Promise submitTransaction(Resource,Object) 
    + Query buildQuery(string) 
    + Promise query(Object) 
    + Promise ping() 

--- a/packages/composer-client/changelog.txt
+++ b/packages/composer-client/changelog.txt
@@ -23,6 +23,10 @@
 #
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
+
+Version 0.19.11 {ce05ff1f0ed05a74d0c98020e7a07568} 2018-07-03
+- Add additional connector specific options to submitTransaction
+
 Version 0.19.2 {ef6884530844c8fad762ea4d97f07a03} 2018-04-13
 - Added getNativeAPI() function to client APIs
 

--- a/packages/composer-client/test/businessnetworkconnection.js
+++ b/packages/composer-client/test/businessnetworkconnection.js
@@ -136,6 +136,14 @@ describe('BusinessNetworkConnection', () => {
         transaction MyTransactionThatReturnsEnumArray {
 
         }
+        @commit(true)
+        transaction MyTransactionCommitTrue {
+
+        }
+        @commit(false)
+        transaction MyTransactionCommitFalse {
+
+        }
         `);
         factory = modelManager.getFactory();
         serializer = modelManager.getSerializer();
@@ -841,7 +849,7 @@ describe('BusinessNetworkConnection', () => {
 
                     // Check that the query was made successfully.
                     sinon.assert.calledOnce(Util.invokeChainCode);
-                    sinon.assert.calledWith(Util.invokeChainCode, mockSecurityContext, 'submitTransaction', [json]);
+                    sinon.assert.calledWith(Util.invokeChainCode, mockSecurityContext, 'submitTransaction', [json], { commit: true, transactionId: 'c89291eb-969f-4b04-b653-82deb5ee0ba1' });
 
                 });
 
@@ -877,7 +885,7 @@ describe('BusinessNetworkConnection', () => {
 
                     // Check that the query was made successfully.
                     sinon.assert.calledOnce(Util.invokeChainCode);
-                    sinon.assert.calledWith(Util.invokeChainCode, mockSecurityContext, 'submitTransaction', [json]);
+                    sinon.assert.calledWith(Util.invokeChainCode, mockSecurityContext, 'submitTransaction', [json], { commit: true, transactionId: 'c89291eb-969f-4b04-b653-82deb5ee0ba1' });
 
                 });
 
@@ -910,7 +918,7 @@ describe('BusinessNetworkConnection', () => {
 
                     // Check that the query was made successfully.
                     sinon.assert.calledOnce(Util.invokeChainCode);
-                    sinon.assert.calledWith(Util.invokeChainCode, mockSecurityContext, 'submitTransaction', [json]);
+                    sinon.assert.calledWith(Util.invokeChainCode, mockSecurityContext, 'submitTransaction', [json], { commit: true, transactionId: 'c89291eb-969f-4b04-b653-82deb5ee0ba1' });
 
                 });
 
@@ -950,7 +958,7 @@ describe('BusinessNetworkConnection', () => {
 
                     // Check that the query was made successfully.
                     sinon.assert.calledOnce(Util.invokeChainCode);
-                    sinon.assert.calledWith(Util.invokeChainCode, mockSecurityContext, 'submitTransaction', [json]);
+                    sinon.assert.calledWith(Util.invokeChainCode, mockSecurityContext, 'submitTransaction', [json], { commit: true, transactionId: 'c89291eb-969f-4b04-b653-82deb5ee0ba1' });
 
                 });
 
@@ -980,6 +988,141 @@ describe('BusinessNetworkConnection', () => {
             return businessNetworkConnection
                 .submitTransaction(tx)
                 .should.be.rejectedWith(/such error/);
+
+        });
+
+        it('should invoke the chain-code for a transaction with additional options', () => {
+
+            // Fake the transaction registry.
+            const txRegistry = sinon.createStubInstance(TransactionRegistry);
+            txRegistry.id = 'd2d210a3-5f11-433b-aa48-f74d25bb0f0d';
+            sandbox.stub(businessNetworkConnection, 'getTransactionRegistry').resolves(txRegistry);
+
+            // Create the transaction.
+            const tx = factory.newResource('org.acme', 'MyTransactionThatReturnsString', 'c89291eb-969f-4b04-b653-82deb5ee0ba1');
+
+            // Set up the responses from the chain-code.
+            sandbox.stub(Util, 'invokeChainCode').resolves(Buffer.from('"hello world"'));
+            sandbox.stub(Util, 'createTransactionId').resolves({
+                id : 'c89291eb-969f-4b04-b653-82deb5ee0ba1',
+                idStr : 'c89291eb-969f-4b04-b653-82deb5ee0ba1'
+            });
+
+            // Invoke the submitTransaction function.
+            return businessNetworkConnection
+                .submitTransaction(tx, { option1: true, option2: true })
+                .then((result) => {
+
+                    // Check the result.
+                    result.should.equal('hello world');
+
+                    // Force the transaction to be serialized as some fake JSON.
+                    const json = JSON.stringify(serializer.toJSON(tx));
+
+                    // Check that the query was made successfully.
+                    sinon.assert.calledOnce(Util.invokeChainCode);
+                    sinon.assert.calledWith(Util.invokeChainCode, mockSecurityContext, 'submitTransaction', [json], { commit: true, option1: true, option2: true, transactionId: 'c89291eb-969f-4b04-b653-82deb5ee0ba1' });
+
+                });
+
+        });
+
+        it('should invoke the chain-code for a transaction with @commit(true)', () => {
+
+            // Fake the transaction registry.
+            const txRegistry = sinon.createStubInstance(TransactionRegistry);
+            txRegistry.id = 'd2d210a3-5f11-433b-aa48-f74d25bb0f0d';
+            sandbox.stub(businessNetworkConnection, 'getTransactionRegistry').resolves(txRegistry);
+
+            // Create the transaction.
+            const tx = factory.newResource('org.acme', 'MyTransactionCommitTrue', 'c89291eb-969f-4b04-b653-82deb5ee0ba1');
+
+            // Set up the responses from the chain-code.
+            sandbox.stub(Util, 'invokeChainCode').resolves();
+            sandbox.stub(Util, 'createTransactionId').resolves({
+                id : 'c89291eb-969f-4b04-b653-82deb5ee0ba1',
+                idStr : 'c89291eb-969f-4b04-b653-82deb5ee0ba1'
+            });
+
+            // Invoke the submitTransaction function.
+            return businessNetworkConnection
+                .submitTransaction(tx)
+                .then(() => {
+
+                    // Force the transaction to be serialized as some fake JSON.
+                    const json = JSON.stringify(serializer.toJSON(tx));
+
+                    // Check that the query was made successfully.
+                    sinon.assert.calledOnce(Util.invokeChainCode);
+                    sinon.assert.calledWith(Util.invokeChainCode, mockSecurityContext, 'submitTransaction', [json], { commit: true, transactionId: 'c89291eb-969f-4b04-b653-82deb5ee0ba1' });
+
+                });
+
+        });
+
+        it('should invoke the chain-code for a transaction with @commit(false)', () => {
+
+            // Fake the transaction registry.
+            const txRegistry = sinon.createStubInstance(TransactionRegistry);
+            txRegistry.id = 'd2d210a3-5f11-433b-aa48-f74d25bb0f0d';
+            sandbox.stub(businessNetworkConnection, 'getTransactionRegistry').resolves(txRegistry);
+
+            // Create the transaction.
+            const tx = factory.newResource('org.acme', 'MyTransactionCommitFalse', 'c89291eb-969f-4b04-b653-82deb5ee0ba1');
+
+            // Set up the responses from the chain-code.
+            sandbox.stub(Util, 'invokeChainCode').resolves();
+            sandbox.stub(Util, 'createTransactionId').resolves({
+                id : 'c89291eb-969f-4b04-b653-82deb5ee0ba1',
+                idStr : 'c89291eb-969f-4b04-b653-82deb5ee0ba1'
+            });
+
+            // Invoke the submitTransaction function.
+            return businessNetworkConnection
+                .submitTransaction(tx)
+                .then(() => {
+
+                    // Force the transaction to be serialized as some fake JSON.
+                    const json = JSON.stringify(serializer.toJSON(tx));
+
+                    // Check that the query was made successfully.
+                    sinon.assert.calledOnce(Util.invokeChainCode);
+                    sinon.assert.calledWith(Util.invokeChainCode, mockSecurityContext, 'submitTransaction', [json], { commit: false, transactionId: 'c89291eb-969f-4b04-b653-82deb5ee0ba1' });
+
+                });
+
+        });
+
+        it('should invoke the chain-code for a transaction with @commit(true) but commit option of false', () => {
+
+            // Fake the transaction registry.
+            const txRegistry = sinon.createStubInstance(TransactionRegistry);
+            txRegistry.id = 'd2d210a3-5f11-433b-aa48-f74d25bb0f0d';
+            sandbox.stub(businessNetworkConnection, 'getTransactionRegistry').resolves(txRegistry);
+
+            // Create the transaction.
+            const tx = factory.newResource('org.acme', 'MyTransactionCommitTrue', 'c89291eb-969f-4b04-b653-82deb5ee0ba1');
+
+            // Set up the responses from the chain-code.
+            sandbox.stub(Util, 'invokeChainCode').resolves();
+            sandbox.stub(Util, 'createTransactionId').resolves({
+                id : 'c89291eb-969f-4b04-b653-82deb5ee0ba1',
+                idStr : 'c89291eb-969f-4b04-b653-82deb5ee0ba1'
+            });
+
+            // Invoke the submitTransaction function.
+            return businessNetworkConnection
+                .submitTransaction(tx, { commit: false })
+                .then(() => {
+
+                    // Force the transaction to be serialized as some fake JSON.
+                    const json = JSON.stringify(serializer.toJSON(tx));
+
+                    // Check that the query was made successfully.
+                    sinon.assert.calledOnce(Util.invokeChainCode);
+                    sinon.assert.calledWith(Util.invokeChainCode, mockSecurityContext, 'submitTransaction', [json], { commit: false, transactionId: 'c89291eb-969f-4b04-b653-82deb5ee0ba1' });
+
+                });
 
         });
 

--- a/packages/composer-common/lib/util.js
+++ b/packages/composer-common/lib/util.js
@@ -101,13 +101,13 @@ class Util {
      * Passes it on to the invokeChainCode fn
      *
      * @param {SecurityContext} securityContext - The user's security context
-     * @param {resource|object} transaction - the transaction
-     * @param {Serializer} [serializer]  needed ONLY if the transaction passed is not a resource but pure json
-     * @param {string} [functionName]  The name of the function to call default is submitTransaction.
+     * @param {Resource|object} transaction - the transaction
+     * @param {Serializer} [serializer]  needed ONLY if the transaction passed is a resource
+     * @param {Object} [additionalConnectorOptions] Additional connector specific options for this transaction.
      * @return {Promise} - A promise that will be resolved with the value returned
      * by the chain-code function.
      */
-    static async submitTransaction(securityContext,  transaction, serializer,functionName = 'submitTransaction'){
+    static async submitTransaction(securityContext, transaction, serializer, additionalConnectorOptions = {}) {
         Util.securityCheck(securityContext);
 
         let txId = await Util.createTransactionId(securityContext);
@@ -122,7 +122,9 @@ class Util {
             json=transaction;
         }
 
-        return Util.invokeChainCode(securityContext, functionName, [JSON.stringify(json)], { transactionId: txId.id });
+        Object.assign(additionalConnectorOptions, { transactionId: txId.id });
+
+        return Util.invokeChainCode(securityContext, 'submitTransaction', [JSON.stringify(json)], additionalConnectorOptions);
     }
 
     /**

--- a/packages/composer-tests-functional/systest/data/transactions.cto
+++ b/packages/composer-tests-functional/systest/data/transactions.cto
@@ -228,3 +228,13 @@ transaction TransactionThatReturnsEnum {
 transaction TransactionThatReturnsEnumArray {
     o String value
 }
+
+@commit(true)
+transaction TransactionWithCommitTrue {
+    o String stringValue
+}
+
+@commit(false)
+transaction TransactionWithCommitFalse {
+    o String stringValue
+}

--- a/packages/composer-tests-functional/systest/data/transactions.js
+++ b/packages/composer-tests-functional/systest/data/transactions.js
@@ -512,3 +512,25 @@ async function transactionThatReturnsEnum(transaction) {
 async function transactionThatReturnsEnumArray(transaction) {
     return ['SUCH', 'MANY'];
 }
+
+/**
+ * Handle a transaction with @commit(true).
+ * @param {systest.transactions.TransactionWithCommitTrue} transaction The transaction
+ * @transaction
+ */
+async function transactionWithCommitTrue(transaction) {
+    const assetRegistry = await getAssetRegistry('systest.transactions.SimpleStringAsset');
+    const factory = getFactory();
+    const asset  = factory.newResource('systest.transactions', 'SimpleStringAsset', 'stringAsset1');
+    asset.stringValue = transaction.stringValue;
+    await assetRegistry.add(asset);
+}
+
+/**
+ * Handle a transaction with @commit(false).
+ * @param {systest.transactions.TransactionWithCommitFalse} transaction The transaction
+ * @transaction
+ */
+async function transactionWithCommitFalse(transaction) {
+    await transactionWithCommitTrue(transaction);
+}

--- a/packages/composer-tests-functional/systest/transactions.js
+++ b/packages/composer-tests-functional/systest/transactions.js
@@ -270,4 +270,34 @@ describe('Transaction system tests', function() {
         ['SUCH', 'MANY'].should.deep.equal(outputValue);
     });
 
+    it('should submit and execute a transaction processor function annotated with @commit(true)', async () => {
+        let factory = client.getBusinessNetwork().getFactory();
+        let transaction = factory.newTransaction('systest.transactions', 'TransactionWithCommitTrue');
+        transaction.stringValue = 'hello from single annotated transaction';
+        await client.submitTransaction(transaction);
+        const assetRegistry = await client.getAssetRegistry('systest.transactions.SimpleStringAsset');
+        const exists = await assetRegistry.exists('stringAsset1');
+        exists.should.be.true;
+    });
+
+    it('should submit and execute a transaction processor function annotated with @commit(false)', async () => {
+        let factory = client.getBusinessNetwork().getFactory();
+        let transaction = factory.newTransaction('systest.transactions', 'TransactionWithCommitFalse');
+        transaction.stringValue = 'hello from single annotated transaction';
+        await client.submitTransaction(transaction);
+        const assetRegistry = await client.getAssetRegistry('systest.transactions.SimpleStringAsset');
+        const exists = await assetRegistry.exists('stringAsset1');
+        exists.should.be.false;
+    });
+
+    it('should submit and execute a transaction processor function with the commit option set to false', async () => {
+        let factory = client.getBusinessNetwork().getFactory();
+        let transaction = factory.newTransaction('systest.transactions', 'TransactionWithCommitTrue');
+        transaction.stringValue = 'hello from single annotated transaction';
+        await client.submitTransaction(transaction, { commit: false });
+        const assetRegistry = await client.getAssetRegistry('systest.transactions.SimpleStringAsset');
+        const exists = await assetRegistry.exists('stringAsset1');
+        exists.should.be.false;
+    });
+
 });


### PR DESCRIPTION
#4224 

Provide client implementation for commit flag - either picking up on the `@commit` decorator for a transaction, or via extended API for `submitTransaction`, and add functional tests to ensure that it works as designed.