### PR TITLE
Add integration tests for transaction return types and commit flag

### DIFF
--- a/packages/composer-cli/test/transaction/submit.js
+++ b/packages/composer-cli/test/transaction/submit.js
@@ -14,50 +14,50 @@
 
 'use strict';
 
-const Client = require('composer-client');
-const Admin = require('composer-admin');
-const Common = require('composer-common');
-const BusinessNetworkConnection = Client.BusinessNetworkConnection;
-const BusinessNetworkDefinition = Admin.BusinessNetworkDefinition;
-const Serializer = Common.Serializer;
-const Resource = Common.Resource;
-
-const Submit = require('../../lib/cmds/transaction/submitCommand.js');
+const { BusinessNetworkConnection } = require('composer-client');
+const { BusinessNetworkDefinition } = require('composer-common');
 const CmdUtil = require('../../lib/cmds/utils/cmdutils.js');
+const Pretty = require('prettyjson');
+const Submit = require('../../lib/cmds/transaction/submitCommand.js');
 
 const chai = require('chai');
-const sinon = require('sinon');
-
 chai.should();
 chai.use(require('chai-things'));
 chai.use(require('chai-as-promised'));
+const sinon = require('sinon');
 
-const NAMESPACE = 'net.biz.TestNetwork';
 const ENROLL_SECRET = 'SuccessKidWin';
-
-
 
 describe('composer transaction submit CLI unit tests', () => {
     let sandbox;
     let mockBusinessNetworkConnection;
-    let mockBusinessNetwork;
-    let mockSerializer;
-    let mockResource;
+    let businessNetworkDefinition;
+    let modelManager;
+    let factory;
+    let spyPretty;
 
     beforeEach(() => {
         sandbox = sinon.sandbox.create();
+
+        businessNetworkDefinition = new BusinessNetworkDefinition('test-network@0.0.1');
+        modelManager = businessNetworkDefinition.getModelManager();
+        modelManager.addModelFile(`
+        namespace org.acme
+        concept MyConcept {
+            o String value
+        }
+        transaction MyTransaction {
+            o Boolean success
+        }`);
+        factory = businessNetworkDefinition.getFactory();
+
         mockBusinessNetworkConnection = sinon.createStubInstance(BusinessNetworkConnection);
-        mockBusinessNetwork = sinon.createStubInstance(BusinessNetworkDefinition);
-        mockSerializer = sinon.createStubInstance(Serializer);
-        mockResource = sinon.createStubInstance(Resource);
-        mockBusinessNetworkConnection.getBusinessNetwork.returns(mockBusinessNetwork);
+        mockBusinessNetworkConnection.getBusinessNetwork.returns(businessNetworkDefinition);
         mockBusinessNetworkConnection.connect.resolves();
-        mockBusinessNetwork.getSerializer.returns(mockSerializer);
-        mockSerializer.fromJSON.returns(mockResource);
-        mockResource.getIdentifier.returns('SuccessKid');
 
         sandbox.stub(CmdUtil, 'createBusinessNetworkConnection').returns(mockBusinessNetworkConnection);
         sandbox.stub(process, 'exit');
+        spyPretty = sandbox.spy(Pretty, 'render');
     });
 
     afterEach(() => {
@@ -66,71 +66,124 @@ describe('composer transaction submit CLI unit tests', () => {
 
     describe('#hander', () => {
 
-        it('should not error when all requred params (card based) are specified', () => {
+        it('should not error when all requred params (card based) are specified', async () => {
             sandbox.stub(CmdUtil, 'prompt').resolves(ENROLL_SECRET);
 
             let argv = {
                 card: 'cardname',
-                data: '{"$class": "'+NAMESPACE+'", "success": true}'
+                data: '{"$class": "org.acme.MyTransaction", "success": true}'
             };
 
-            return Submit.handler(argv)
-            .then((res) => {
-                sinon.assert.calledWith(mockBusinessNetworkConnection.connect,'cardname');
-
-            });
+            await Submit.handler(argv);
+            sinon.assert.calledWith(mockBusinessNetworkConnection.connect,'cardname');
         });
 
-        it('should  error when can not parse the json (card based)', () => {
-            sandbox.stub(JSON, 'parse').throws(new Error('failure'));
+        it('should not error when the transaction returns a primitive value', async () => {
+            mockBusinessNetworkConnection.submitTransaction.resolves('foobar');
+            sandbox.stub(CmdUtil, 'prompt').resolves(ENROLL_SECRET);
 
             let argv = {
                 card: 'cardname',
-                data: '{"$class": "'+NAMESPACE+'", "success": true}'
+                data: '{"$class": "org.acme.MyTransaction", "success": true}'
             };
 
-            return Submit.handler(argv).should.be.rejectedWith(/JSON error/);
+            await Submit.handler(argv);
+            sinon.assert.calledWith(mockBusinessNetworkConnection.connect,'cardname');
+            sinon.assert.calledOnce(spyPretty);
+            sinon.assert.calledWith(spyPretty, 'foobar');
         });
 
-        it('should error when the transaction fails to submit', () => {
+        it('should not error when the transaction returns an array of primitive values', async () => {
+            mockBusinessNetworkConnection.submitTransaction.resolves(['foobar', 'doge', 'cat']);
+            sandbox.stub(CmdUtil, 'prompt').resolves(ENROLL_SECRET);
+
             let argv = {
                 card: 'cardname',
-                data: '{"$class": "'+NAMESPACE+'", "success": true}'
+                data: '{"$class": "org.acme.MyTransaction", "success": true}'
+            };
+
+            await Submit.handler(argv);
+            sinon.assert.calledWith(mockBusinessNetworkConnection.connect,'cardname');
+            sinon.assert.calledOnce(spyPretty);
+            sinon.assert.calledWith(spyPretty, ['foobar', 'doge', 'cat']);
+        });
+
+        it('should not error when the transaction returns a concept value', async () => {
+            const concept = factory.newConcept('org.acme', 'MyConcept');
+            concept.value = 'foobar';
+            mockBusinessNetworkConnection.submitTransaction.resolves(concept);
+            sandbox.stub(CmdUtil, 'prompt').resolves(ENROLL_SECRET);
+
+            let argv = {
+                card: 'cardname',
+                data: '{"$class": "org.acme.MyTransaction", "success": true}'
+            };
+
+            await Submit.handler(argv);
+            sinon.assert.calledWith(mockBusinessNetworkConnection.connect,'cardname');
+            sinon.assert.calledOnce(spyPretty);
+            sinon.assert.calledWith(spyPretty, { $class: 'org.acme.MyConcept', value: 'foobar' });
+        });
+
+        it('should not error when the transaction returns an array of concept values', async () => {
+            const concept1 = factory.newConcept('org.acme', 'MyConcept');
+            concept1.value = 'foobar';
+            const concept2 = factory.newConcept('org.acme', 'MyConcept');
+            concept2.value = 'doge';
+            const concept3 = factory.newConcept('org.acme', 'MyConcept');
+            concept3.value = 'cat';
+            mockBusinessNetworkConnection.submitTransaction.resolves([concept1, concept2, concept3]);
+            sandbox.stub(CmdUtil, 'prompt').resolves(ENROLL_SECRET);
+
+            let argv = {
+                card: 'cardname',
+                data: '{"$class": "org.acme.MyTransaction", "success": true}'
+            };
+
+            await Submit.handler(argv);
+            sinon.assert.calledWith(mockBusinessNetworkConnection.connect,'cardname');
+            sinon.assert.calledOnce(spyPretty);
+            sinon.assert.calledWith(spyPretty, [{ $class: 'org.acme.MyConcept', value: 'foobar' }, { $class: 'org.acme.MyConcept', value: 'doge' }, { $class: 'org.acme.MyConcept', value: 'cat' }]);
+        });
+
+        it('should  error when can not parse the json (card based)', async () => {
+            let argv = {
+                card: 'cardname',
+                data: '{"$class": "org.acme.MyTransaction", "success": true'
+            };
+
+            await Submit.handler(argv).should.be.rejectedWith(/JSON error/);
+        });
+
+        it('should error when the transaction fails to submit', async () => {
+            let argv = {
+                card: 'cardname',
+                data: '{"$class": "org.acme.MyTransaction", "success": true}'
             };
 
             mockBusinessNetworkConnection.submitTransaction.rejects(new Error('some error'));
-            return Submit.handler(argv)
-                .then((res) => {
-                    // sinon.assert.calledWith(process.exit, 1);
-                }).catch((error) => {
-                    error.toString().should.equal('Error: some error');
-                });
+            await Submit.handler(argv)
+                .should.be.rejectedWith(/some error/);
         });
 
-        it('should error if data is not a string', () => {
+        it('should error if data is not a string', async () => {
             let argv = {
                 card: 'cardname',
                 data: {}
             };
 
-            return Submit.handler(argv)
-                .then((res) => {
-                }).catch((error) => {
-                    error.toString().should.equal('Error: Data must be a string');
-                });
+            await Submit.handler(argv)
+                .should.be.rejectedWith(/Data must be a string/);
         });
 
-        it('should error if data class is not supplied', () => {
+        it('should error if data class is not supplied', async () => {
             let argv = {
                 card: 'cardname',
                 data: '{"success": true}'
             };
 
-            return Submit.handler(argv)
-                .then((res) => {
-                }).catch((error) => {
-                    error.toString().should.equal('Error: $class attribute not supplied');
-                });
+            await Submit.handler(argv)
+                .should.be.rejectedWith(/\$class attribute not supplied/);
         });
     });
 });

--- a/packages/composer-connector-hlfv1/lib/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/lib/hlfconnection.js
@@ -900,6 +900,14 @@ class HLFConnection extends Connection {
         const method = 'invokeChainCode';
         LOG.entry(method, securityContext, functionName, args, options);
 
+        // If commit has been set to false, we do not want to order the transaction or wait for any events.
+        if (options.commit === false) {
+            LOG.debug(method, 'Commit has been set to false, deferring to queryChainCode instead');
+            const result = await this.queryChainCode(securityContext, functionName, args, options);
+            LOG.exit(method, result);
+            return result;
+        }
+
         if (!this.businessNetworkIdentifier) {
             throw new Error('No business network has been specified for this connection');
         }
@@ -959,13 +967,6 @@ class HLFConnection extends Connection {
                 LOG.debug(method, `Response includes payload data of ${firstValidResponse.response.payload.length} bytes`);
             } else {
                 LOG.debug(method, 'Response does not include payload data');
-            }
-
-            // If commit has been set to false, do not order the transaction or wait for any events.
-            if (options.commit === false) {
-                LOG.debug(method, 'Commit has been set to false, not ordering transaction or waiting for any events');
-                LOG.exit(method, result);
-                return result;
             }
 
             // Submit the endorsed transaction to the primary orderers.

--- a/packages/composer-runtime/lib/engine.transactions.js
+++ b/packages/composer-runtime/lib/engine.transactions.js
@@ -297,7 +297,7 @@ class EngineTransactions {
                 LOG.error(method, error);
                 throw error;
             }
-            return context.getSerializer().toJSON(actualReturnValue);
+            return context.getSerializer().toJSON(actualReturnValue, { convertResourcesToRelationships: true, permitResourcesForRelationships: false });
         };
 
         // Handle the non-array case - a single return value.

--- a/packages/composer-runtime/test/engine.transactions.js
+++ b/packages/composer-runtime/test/engine.transactions.js
@@ -56,8 +56,13 @@ describe('EngineTransactions', () => {
         modelManager.addDecoratorFactory(new ReturnsDecoratorFactory());
         modelManager.addModelFile(`
         namespace org.acme
+        asset MyAsset identified by assetId {
+            o String assetId
+            o String value
+        }
         concept MyConcept {
             o String value
+            --> MyAsset asset optional
         }
         participant MyParticipant identified by participantId {
             o String participantId
@@ -567,6 +572,31 @@ describe('EngineTransactions', () => {
             engine._processComplexReturnValue(mockContext, transaction, concept).should.deep.equal({
                 $class: 'org.acme.MyConcept',
                 value: 'hello world'
+            });
+        });
+
+        it('should handle a concept return value with a relationship to an asset that is a relationship', () => {
+            const transaction = factory.newTransaction('org.acme', 'MyTransactionThatReturnsConcept');
+            const concept = factory.newConcept('org.acme', 'MyConcept');
+            concept.value = 'hello world';
+            concept.asset = factory.newRelationship('org.acme', 'MyAsset', '1234');
+            engine._processComplexReturnValue(mockContext, transaction, concept).should.deep.equal({
+                $class: 'org.acme.MyConcept',
+                value: 'hello world',
+                asset: 'resource:org.acme.MyAsset#1234'
+            });
+        });
+
+        it('should handle a concept return value with a relationship to an asset that is a resource', () => {
+            const transaction = factory.newTransaction('org.acme', 'MyTransactionThatReturnsConcept');
+            const concept = factory.newConcept('org.acme', 'MyConcept');
+            concept.value = 'hello world';
+            concept.asset = factory.newResource('org.acme', 'MyAsset', '1234');
+            concept.asset.value = 'hello dogez';
+            engine._processComplexReturnValue(mockContext, transaction, concept).should.deep.equal({
+                $class: 'org.acme.MyConcept',
+                value: 'hello world',
+                asset: 'resource:org.acme.MyAsset#1234'
             });
         });
 

--- a/packages/composer-tests-integration/features/cli-network.feature
+++ b/packages/composer-tests-integration/features/cli-network.feature
@@ -118,6 +118,25 @@ Feature: Cli network steps
         Then The stdout information should include text matching /Transaction Submitted./
         And The stdout information should include text matching /Command succeeded/
 
+    Scenario: Using the CLI, I can execute a transaction that returns data from within the business network
+        When I run the following expected pass CLI command
+            """
+            composer transaction submit
+              -c admin@marbles-network
+              -d '{
+                    "$class": "org.hyperledger_composer.marbles.TradeMarbleWithReceipt",
+                    "marble": "resource:org.hyperledger_composer.marbles.Marble#101",
+                    "newOwner": "resource:org.hyperledger_composer.marbles.Player#bob"
+                }'
+            """
+        Then The stdout information should include text matching /Transaction Submitted./
+        And The stdout information should include text matching /\$class:   org.hyperledger_composer.marbles.TradeReceipt/
+        And The stdout information should include text matching /marble:/
+        And The stdout information should include text matching /owner:    resource:org.hyperledger_composer.marbles.Player#bob/
+        And The stdout information should include text matching /oldOwner:/
+        And The stdout information should include text matching /newOwner:/
+        And The stdout information should include text matching /Command succeeded/
+
     Scenario: Using the CLI, I can update the network to a newer version
         Given I have the following folders
             | ../resources/sample-networks/marbles-network-update |
@@ -253,10 +272,10 @@ Feature: Cli network steps
         And The stdout information should include text matching /marbleId: 201/
         And The stdout information should include text matching /size:     SMALL/
         And The stdout information should include text matching /color:    RED/
-        And The stdout information should include text matching /owner:    resource:org.hyperledger_composer.marbles.Player#bob/
+        And The stdout information should include text matching /owner:    resource:org.hyperledger_composer.marbles.Player#bob2/
         And The stdout information should include text matching /Command succeeded/
 
-    Scenario: Using the CLI, I can execute a newtransaction from within the new business network
+    Scenario: Using the CLI, I can execute a transaction from within the new business network
         When I run the following expected pass CLI command
             """
             composer transaction submit
@@ -270,6 +289,24 @@ Feature: Cli network steps
         Then The stdout information should include text matching /Transaction Submitted./
         And The stdout information should include text matching /Command succeeded/
 
+    Scenario: Using the CLI, I can execute a transaction that returns data from within the new business network
+        When I run the following expected pass CLI command
+            """
+            composer transaction submit
+              -c admin@marbles-network
+              -d '{
+                    "$class": "org.hyperledger_composer.marbles.TradeMarbleWithReceipt",
+                    "marble": "resource:org.hyperledger_composer.marbles.NewMarble#201",
+                    "newOwner": "resource:org.hyperledger_composer.marbles.Player#bob2"
+                }'
+            """
+        Then The stdout information should include text matching /Transaction Submitted./
+        And The stdout information should include text matching /\$class:   org.hyperledger_composer.marbles.TradeReceipt/
+        And The stdout information should include text matching /marble:/
+        And The stdout information should include text matching /owner:    resource:org.hyperledger_composer.marbles.Player#bob2/
+        And The stdout information should include text matching /oldOwner:/
+        And The stdout information should include text matching /newOwner:/
+        And The stdout information should include text matching /Command succeeded/
 
     Scenario: Using the CLI, I can reset the network to remove all assets
         When I run the following expected pass CLI command

--- a/packages/composer-tests-integration/features/cli-other-networks.feature
+++ b/packages/composer-tests-integration/features/cli-other-networks.feature
@@ -1,0 +1,343 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+@cli @cli-other-networks
+Feature: Cli-other-networks steps
+
+    Background:
+        Given I have admin business cards available
+        And I have deployed the business network marbles-network as marbles-network-1
+        And I have deployed the business network marbles-network as marbles-network-2
+        And I have deployed the business network marbles-network as marbles-network-3
+        And I have deployed the business network marbles-network as marbles-network-4
+
+    Scenario: Using the CLI, I can create a participant in network 1
+        When I run the following expected pass CLI command
+            """
+            composer transaction submit
+              --card admin@marbles-network-1
+              -d '{
+                  "$class": "org.hyperledger.composer.system.AddParticipant",
+                  "targetRegistry": "resource:org.hyperledger.composer.system.ParticipantRegistry#org.hyperledger_composer.marbles.Player",
+                  "resources": [{
+                    "$class": "org.hyperledger_composer.marbles.Player",
+                    "email": "alice@email.com",
+                    "firstName": "alice",
+                    "lastName": "a"
+                  }]
+                }'
+            """
+        Then The stdout information should include text matching /Transaction Submitted./
+        And The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can issue an identity called lostmymarbles to the participant in network 1
+        When I run the following expected pass CLI command
+            """
+            composer identity issue --card admin@marbles-network-1 -u lostmymarbles -a resource:org.hyperledger_composer.marbles.Player#alice@email.com -f ./tmp/lostmymarbles_DONOTIMPORT@marbles-network-1.card
+            """
+        Then The stdout information should include text matching /Command succeeded/
+        Then I have the following files
+            | ../tmp/lostmymarbles_DONOTIMPORT@marbles-network-1.card |
+
+    Scenario: Using the CLI, I can request certificates for the identity lostmymarbles
+        Given I have saved the secret in file to LOSTMYMARBLES_SECRET
+           """
+           ./tmp/lostmymarbles_DONOTIMPORT@marbles-network-1.card
+           """
+        When I substitue the alias LOSTMYMARBLES_SECRET and run an expected pass CLI command
+           """
+           composer identity request --card admin@marbles-network-1 -u lostmymarbles -s LOSTMYMARBLES_SECRET -d ./tmp
+           """
+        Then The stdout information should include text matching /Command succeeded/
+        Then I have the following files
+            | ../tmp/lostmymarbles-pub.pem |
+            | ../tmp/lostmymarbles-priv.pem |
+
+    Scenario: Using the CLI, I can create a card for the identity lostmymarbles for use with network 1
+        When I run the following expected pass CLI command
+            | command | composer card create |
+            | -p | ./profiles/basic-connection-org1.yaml |
+            | -u | lostmymarbles |
+            | -n | marbles-network-1 |
+            | -c | ./tmp/lostmymarbles-pub.pem |
+            | -k | ./tmp/lostmymarbles-priv.pem |
+            | -f | ./tmp/lostmymarbles@marbles-network-1.card |
+
+        Then The stdout information should include text matching /Command succeeded/
+        Then I have the following files
+            | ../tmp/lostmymarbles@marbles-network-1.card |
+
+    Scenario: Using the CLI, I can import the card that was just created
+        Given I have the following files
+            | ../tmp/lostmymarbles@marbles-network-1.card |
+        When I run the following expected pass CLI command
+            """
+            composer card import --file ./tmp/lostmymarbles@marbles-network-1.card
+            """
+        Then The stdout information should include text matching /Successfully imported business network card/
+        Then The stdout information should include text matching /Card file: ./tmp/lostmymarbles@marbles-network-1.card/
+        Then The stdout information should include text matching /Card name: lostmymarbles@marbles-network-1/
+        Then The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can create an asset in network 1
+        When I run the following expected pass CLI command
+            """
+            composer transaction submit
+              --card lostmymarbles@marbles-network-1
+              -d '{
+                  "$class": "org.hyperledger.composer.system.AddAsset",
+                  "targetRegistry": "resource:org.hyperledger.composer.system.AssetRegistry#org.hyperledger_composer.marbles.Marble",
+                  "resources": [{
+                    "$class": "org.hyperledger_composer.marbles.Marble",
+                    "marbleId": "1001",
+                    "size": "SMALL",
+                    "color": "RED",
+                    "owner": "resource:org.hyperledger_composer.marbles.Player#alice@email.com"
+                  }]
+                }'
+            """
+        Then The stdout information should include text matching /Transaction Submitted./
+        And The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can create a participant in network 2
+        When I run the following expected pass CLI command
+            """
+            composer transaction submit
+              --card admin@marbles-network-2
+              -d '{
+                  "$class": "org.hyperledger.composer.system.AddParticipant",
+                  "targetRegistry": "resource:org.hyperledger.composer.system.ParticipantRegistry#org.hyperledger_composer.marbles.Player",
+                  "resources": [{
+                    "$class": "org.hyperledger_composer.marbles.Player",
+                    "email": "bob@email.com",
+                    "firstName": "bob",
+                    "lastName": "b"
+                  }]
+                }'
+            """
+        Then The stdout information should include text matching /Transaction Submitted./
+        And The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can bind an identity called lostmymarbles to the participant in network 2
+        When I run the following expected pass CLI command
+            """
+            composer identity bind --card admin@marbles-network-2 -a resource:org.hyperledger_composer.marbles.Player#bob@email.com -e ./tmp/lostmymarbles-pub.pem
+            """
+        Then The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can create a card for the identity lostmymarbles for use with network 2
+        When I run the following expected pass CLI command
+            | command | composer card create |
+            | -p | ./profiles/basic-connection-org1.yaml |
+            | -u | lostmymarbles |
+            | -n | marbles-network-2 |
+            | -c | ./tmp/lostmymarbles-pub.pem |
+            | -k | ./tmp/lostmymarbles-priv.pem |
+            | -f | ./tmp/lostmymarbles@marbles-network-2.card |
+
+        Then The stdout information should include text matching /Command succeeded/
+        Then I have the following files
+            | ../tmp/lostmymarbles@marbles-network-2.card |
+
+    Scenario: Using the CLI, I can import the card that was just created
+        Given I have the following files
+            | ../tmp/lostmymarbles@marbles-network-2.card |
+        When I run the following expected pass CLI command
+            """
+            composer card import --file ./tmp/lostmymarbles@marbles-network-2.card
+            """
+        Then The stdout information should include text matching /Successfully imported business network card/
+        Then The stdout information should include text matching /Card file: ./tmp/lostmymarbles@marbles-network-2.card/
+        Then The stdout information should include text matching /Card name: lostmymarbles@marbles-network-2/
+        Then The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can create an asset in network 2
+        When I run the following expected pass CLI command
+            """
+            composer transaction submit
+              --card lostmymarbles@marbles-network-2
+              -d '{
+                  "$class": "org.hyperledger.composer.system.AddAsset",
+                  "targetRegistry": "resource:org.hyperledger.composer.system.AssetRegistry#org.hyperledger_composer.marbles.Marble",
+                  "resources": [{
+                    "$class": "org.hyperledger_composer.marbles.Marble",
+                    "marbleId": "1002",
+                    "size": "SMALL",
+                    "color": "YELLOW",
+                    "owner": "resource:org.hyperledger_composer.marbles.Player#bob@email.com"
+                  }]
+                }'
+            """
+        Then The stdout information should include text matching /Transaction Submitted./
+        And The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can create a participant in network 3
+        When I run the following expected pass CLI command
+            """
+            composer transaction submit
+              --card admin@marbles-network-3
+              -d '{
+                  "$class": "org.hyperledger.composer.system.AddParticipant",
+                  "targetRegistry": "resource:org.hyperledger.composer.system.ParticipantRegistry#org.hyperledger_composer.marbles.Player",
+                  "resources": [{
+                    "$class": "org.hyperledger_composer.marbles.Player",
+                    "email": "charlie@email.com",
+                    "firstName": "charlie",
+                    "lastName": "c"
+                  }]
+                }'
+            """
+        Then The stdout information should include text matching /Transaction Submitted./
+        And The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can bind an identity called lostmymarbles to the participant in network 3
+        When I run the following expected pass CLI command
+            """
+            composer identity bind --card admin@marbles-network-3 -a resource:org.hyperledger_composer.marbles.Player#charlie@email.com -e ./tmp/lostmymarbles-pub.pem
+            """
+        Then The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can create a card for the identity lostmymarbles for use with network 3
+        When I run the following expected pass CLI command
+            | command | composer card create |
+            | -p | ./profiles/basic-connection-org1.yaml |
+            | -u | lostmymarbles |
+            | -n | marbles-network-3 |
+            | -c | ./tmp/lostmymarbles-pub.pem |
+            | -k | ./tmp/lostmymarbles-priv.pem |
+            | -f | ./tmp/lostmymarbles@marbles-network-3.card |
+
+        Then The stdout information should include text matching /Command succeeded/
+        Then I have the following files
+            | ../tmp/lostmymarbles@marbles-network-3.card |
+
+    Scenario: Using the CLI, I can import the card that was just created
+        Given I have the following files
+            | ../tmp/lostmymarbles@marbles-network-3.card |
+        When I run the following expected pass CLI command
+            """
+            composer card import --file ./tmp/lostmymarbles@marbles-network-3.card
+            """
+        Then The stdout information should include text matching /Successfully imported business network card/
+        Then The stdout information should include text matching /Card file: ./tmp/lostmymarbles@marbles-network-3.card/
+        Then The stdout information should include text matching /Card name: lostmymarbles@marbles-network-3/
+        Then The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can create an asset in network 3
+        When I run the following expected pass CLI command
+            """
+            composer transaction submit
+              --card lostmymarbles@marbles-network-3
+              -d '{
+                  "$class": "org.hyperledger.composer.system.AddAsset",
+                  "targetRegistry": "resource:org.hyperledger.composer.system.AssetRegistry#org.hyperledger_composer.marbles.Marble",
+                  "resources": [{
+                    "$class": "org.hyperledger_composer.marbles.Marble",
+                    "marbleId": "1003",
+                    "size": "SMALL",
+                    "color": "GREEN",
+                    "owner": "resource:org.hyperledger_composer.marbles.Player#charlie@email.com"
+                  }]
+                }'
+            """
+        Then The stdout information should include text matching /Transaction Submitted./
+        And The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can create a participant in network 4
+        When I run the following expected pass CLI command
+            """
+            composer transaction submit
+              --card admin@marbles-network-4
+              -d '{
+                  "$class": "org.hyperledger.composer.system.AddParticipant",
+                  "targetRegistry": "resource:org.hyperledger.composer.system.ParticipantRegistry#org.hyperledger_composer.marbles.Player",
+                  "resources": [{
+                    "$class": "org.hyperledger_composer.marbles.Player",
+                    "email": "dana@email.com",
+                    "firstName": "dana",
+                    "lastName": "d"
+                  }]
+                }'
+            """
+        Then The stdout information should include text matching /Transaction Submitted./
+        And The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can bind an identity called lostmymarbles to the participant in network 4
+        When I run the following expected pass CLI command
+            """
+            composer identity bind --card admin@marbles-network-4 -a resource:org.hyperledger_composer.marbles.Player#dana@email.com -e ./tmp/lostmymarbles-pub.pem
+            """
+        Then The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can create a card for the identity lostmymarbles for use with network 4
+        When I run the following expected pass CLI command
+            | command | composer card create |
+            | -p | ./profiles/basic-connection-org1.yaml |
+            | -u | lostmymarbles |
+            | -n | marbles-network-4 |
+            | -c | ./tmp/lostmymarbles-pub.pem |
+            | -k | ./tmp/lostmymarbles-priv.pem |
+            | -f | ./tmp/lostmymarbles@marbles-network-4.card |
+
+        Then The stdout information should include text matching /Command succeeded/
+        Then I have the following files
+            | ../tmp/lostmymarbles@marbles-network-4.card |
+
+    Scenario: Using the CLI, I can import the card that was just created
+        Given I have the following files
+            | ../tmp/lostmymarbles@marbles-network-4.card |
+        When I run the following expected pass CLI command
+            """
+            composer card import --file ./tmp/lostmymarbles@marbles-network-4.card
+            """
+        Then The stdout information should include text matching /Successfully imported business network card/
+        Then The stdout information should include text matching /Card file: ./tmp/lostmymarbles@marbles-network-4.card/
+        Then The stdout information should include text matching /Card name: lostmymarbles@marbles-network-4/
+        Then The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can create an asset in network 4
+        When I run the following expected pass CLI command
+            """
+            composer transaction submit
+              --card lostmymarbles@marbles-network-4
+              -d '{
+                  "$class": "org.hyperledger.composer.system.AddAsset",
+                  "targetRegistry": "resource:org.hyperledger.composer.system.AssetRegistry#org.hyperledger_composer.marbles.Marble",
+                  "resources": [{
+                    "$class": "org.hyperledger_composer.marbles.Marble",
+                    "marbleId": "1004",
+                    "size": "SMALL",
+                    "color": "BLUE",
+                    "owner": "resource:org.hyperledger_composer.marbles.Player#dana@email.com"
+                  }]
+                }'
+            """
+        Then The stdout information should include text matching /Transaction Submitted./
+        And The stdout information should include text matching /Command succeeded/
+
+    Scenario: Using the CLI, I can execute a transaction that returns all of the assets from all of the networks via network 1
+        When I run the following expected pass CLI command
+            """
+            composer transaction submit
+              -c lostmymarbles@marbles-network-1
+              -d '{
+                    "$class": "org.hyperledger_composer.marbles.GetAllMarbles"
+                }'
+            """
+        Then The stdout information should include text matching /Transaction Submitted./
+        Then The stdout information should include text matching /marbleId: 1001/
+        Then The stdout information should include text matching /marbleId: 1002/
+        Then The stdout information should include text matching /marbleId: 1003/
+        Then The stdout information should include text matching /marbleId: 1004/
+        And The stdout information should include text matching /Command succeeded/

--- a/packages/composer-tests-integration/resources/sample-networks/marbles-network-update/lib/logic.js
+++ b/packages/composer-tests-integration/resources/sample-networks/marbles-network-update/lib/logic.js
@@ -12,16 +12,31 @@
  * limitations under the License.
  */
 
- /**
-  * Trade a marble to a new player
-  * @param  {org.hyperledger_composer.marbles.TradeMarble} tradeMarble - the trade marble transaction
-  * @returns {*} promise
-  * @transaction
-  */
- function tradeMarble(tradeMarble) {
-   tradeMarble.marble.owner = tradeMarble.newOwner;
-   return getAssetRegistry('org.hyperledger_composer.marbles.NewMarble')
-     .then(function (assetRegistry) {
-       return assetRegistry.update(tradeMarble.marble);
-     });
- }
+/**
+ * Trade a marble to a new player
+ * @param  {org.hyperledger_composer.marbles.TradeMarble} tradeMarble - the trade marble transaction
+ * @transaction
+ */
+async function tradeMarble(tradeMarble) {
+    tradeMarble.marble.owner = tradeMarble.newOwner;
+    const assetRegistry = await getAssetRegistry('org.hyperledger_composer.marbles.NewMarble');
+    await assetRegistry.update(tradeMarble.marble);
+}
+
+/**
+ * Trade a marble to a new player and produce a receipt
+ * @param  {org.hyperledger_composer.marbles.TradeMarbleWithReceipt} tradeMarble - the trade marble transaction
+ * @returns {org.hyperledger_composer.marbles.TradeReceipt} receipt
+ * @transaction
+ */
+async function tradeMarbleWithReceipt(tradeMarble) {
+    const marble = tradeMarble.marble;
+    const oldOwner = marble.owner;
+    const newOwner = tradeMarble.newOwner;
+    marble.owner = newOwner;
+    const assetRegistry = await getAssetRegistry('org.hyperledger_composer.marbles.NewMarble');
+    await assetRegistry.update(marble);
+    const receipt = getFactory().newConcept('org.hyperledger_composer.marbles', 'TradeReceipt');
+    Object.assign(receipt, { marble, oldOwner, newOwner });
+    return receipt;
+}

--- a/packages/composer-tests-integration/resources/sample-networks/marbles-network-update/models/marbles.cto
+++ b/packages/composer-tests-integration/resources/sample-networks/marbles-network-update/models/marbles.cto
@@ -48,3 +48,15 @@ transaction TradeMarble {
   --> NewMarble marble
   --> Player newOwner
 }
+
+concept TradeReceipt {
+    o NewMarble marble
+    o Player oldOwner
+    o Player newOwner
+}
+
+@returns(TradeReceipt)
+transaction TradeMarbleWithReceipt {
+  --> NewMarble marble
+  --> Player newOwner
+}

--- a/packages/composer-tests-integration/resources/sample-networks/marbles-network/lib/logic.js
+++ b/packages/composer-tests-integration/resources/sample-networks/marbles-network/lib/logic.js
@@ -12,16 +12,58 @@
  * limitations under the License.
  */
 
- /**
-  * Trade a marble to a new player
-  * @param  {org.hyperledger_composer.marbles.TradeMarble} tradeMarble - the trade marble transaction
-  * @returns {*} promise
-  * @transaction
-  */
- function tradeMarble(tradeMarble) {
-   tradeMarble.marble.owner = tradeMarble.newOwner;
-   return getAssetRegistry('org.hyperledger_composer.marbles.Marble')
-     .then(function (assetRegistry) {
-       return assetRegistry.update(tradeMarble.marble);
-     });
- }
+'use strict';
+
+/**
+ * Trade a marble to a new player
+ * @param  {org.hyperledger_composer.marbles.TradeMarble} tradeMarble - the trade marble transaction
+ * @transaction
+ */
+async function tradeMarble(tradeMarble) {
+    tradeMarble.marble.owner = tradeMarble.newOwner;
+    const assetRegistry = await getAssetRegistry('org.hyperledger_composer.marbles.Marble');
+    await assetRegistry.update(tradeMarble.marble);
+}
+
+/**
+ * Trade a marble to a new player and produce a receipt
+ * @param  {org.hyperledger_composer.marbles.TradeMarbleWithReceipt} tradeMarble - the trade marble transaction
+ * @returns {org.hyperledger_composer.marbles.TradeReceipt} receipt
+ * @transaction
+ */
+async function tradeMarbleWithReceipt(tradeMarble) {
+    const marble = tradeMarble.marble;
+    const oldOwner = marble.owner;
+    const newOwner = tradeMarble.newOwner;
+    marble.owner = newOwner;
+    const assetRegistry = await getAssetRegistry('org.hyperledger_composer.marbles.Marble');
+    await assetRegistry.update(marble);
+    const receipt = getFactory().newConcept('org.hyperledger_composer.marbles', 'TradeReceipt');
+    Object.assign(receipt, { marble, oldOwner, newOwner });
+    return receipt;
+}
+
+/**
+ * Get all marbles from all business networks
+ * @param  {org.hyperledger_composer.marbles.GetAllMarbles} transaction The transaction.
+ * @return {org.hyperledger_composer.marbles.Marble[]} All marbles.
+ * @transaction
+ */
+async function getAllMarbles(transaction) {
+    const allMarbles = [];
+    const assetRegistry = await getAssetRegistry('org.hyperledger_composer.marbles.Marble');
+    const marbles = await assetRegistry.getAll();
+    for (const marble of marbles) {
+        allMarbles.push(marble);
+    }
+    const businessNetworkNames = [/* 'marbles-network-1', */ 'marbles-network-2', 'marbles-network-3', 'marbles-network-4'];
+    for (const businessNetworkName of businessNetworkNames) {
+        const response = await getNativeAPI().invokeChaincode(businessNetworkName, ['getAllResourcesInRegistry', 'Asset', 'org.hyperledger_composer.marbles.Marble'], 'composerchannel');
+        const jsonString = response.payload.toString('utf8');
+        const json = JSON.parse(jsonString);
+        for (const item of json) {
+            allMarbles.push(getSerializer().fromJSON(item));
+        }
+    }
+    return allMarbles;
+}

--- a/packages/composer-tests-integration/resources/sample-networks/marbles-network/models/marbles.cto
+++ b/packages/composer-tests-integration/resources/sample-networks/marbles-network/models/marbles.cto
@@ -23,6 +23,7 @@ enum MarbleColor {
   o BLUE
   o PURPLE
   o ORANGE
+  o YELLOW
 }
 
 enum MarbleSize {
@@ -47,4 +48,21 @@ participant Player identified by email {
 transaction TradeMarble {
   --> Marble marble
   --> Player newOwner
+}
+
+concept TradeReceipt {
+    o Marble marble
+    o Player oldOwner
+    o Player newOwner
+}
+
+@returns(TradeReceipt)
+transaction TradeMarbleWithReceipt {
+  --> Marble marble
+  --> Player newOwner
+}
+
+@commit(false)
+@returns(Marble[])
+transaction GetAllMarbles {
 }

--- a/packages/composer-tests-integration/scripts/run-integration-tests.sh
+++ b/packages/composer-tests-integration/scripts/run-integration-tests.sh
@@ -46,6 +46,8 @@ rm -rf ${HOME}/.composer/cards/charlie*
 rm -rf ${HOME}/.composer/client-data/charlie*
 rm -rf ${HOME}/.composer/cards/yaml*
 rm -rf ${HOME}/.composer/client-data/yaml*
+rm -rf ${HOME}/.composer/cards/lostmymarbles*
+rm -rf ${HOME}/.composer/client-data/lostmymarbles*
 rm -rf ./tmp/*           # temp folder for BNA files that are generated
 rm -rf ./my-empty-bus-net      # a business network created from generator
 rm -rf ./my-bus-net      # a business network created from generator


### PR DESCRIPTION
#4165, #4224 

- Extend the CLI command `composer transaction submit` so that it prints any return values (#4165)
- HLFv1 connector should defer to `queryChainCode` when `invokeChainCode` called with commit set to false, to avoid sending endorsements to multiple peers (#4224)
- Runtime should serialize resources as relationships where appropriate, to avoid sending back invalid data (#4165)
- Add integration tests that demonstrate return values working by returning a trade receipt from a marble trade, and checking the output of the CLI command above (#4165)
- Add integration tests that demonstrate read-only transaction processor functions by calling a transaction processor function that reads marbles from multiple business networks, and returns them in a single call (#4224)