### PR TITLE
Document bypass of #3923 issue for query tests

### DIFF
--- a/packages/composer-website/jekylldocs/reference/query-language.md
+++ b/packages/composer-website/jekylldocs/reference/query-language.md
@@ -78,6 +78,18 @@ query Q18 {
 }
 ```
 
+#### Testing queries
+
+If you intend to run unit test on your Queries, currently, PouchDB does not allow using testing queries that use `ORDER BY` clauses, due to issue [#3923](https://github.com/hyperledger/composer/issues/3923).
+
+You can bypass this problem by implementing the `npm test` command in `package.json` along these lines:
+
+```
+"test": "sed -i '' -e 's,  ORDER BY,// ORDER BY,g' ./queries.qry && mocha -t 0 --recursive && sed -i '' -e 's,// ORDER BY,  ORDER BY,g' ./queries.qry"
+```
+
+This comments out all the `ORDER BY` parts before testing, and uncomments them after testing. Naturally, this will not permit testing that ordering works, but can help test the expected content of queries.
+
 ## What next?
 
 - [Applying queries to a business network.](../business-network/query.html)


### PR DESCRIPTION
Added documentation on how to bypass issue affecting PouchDB that stopped tests for Queries working when an `ORDER BY` clause existed.

## Checklist
 - [x]  A link to the issue/user story that the pull request relates to
 - [x]  How to recreate the problem without the fix
 - [x]  Design of the fix
 - [x]  How to prove that the fix works
 - [x]  Automated tests that prove the fix keeps on working
 - [x]  Documentation - any JSDoc, website, or Stackoverflow answers?

## Issue/User story
#3923

## Steps to Reproduce
To recreate the problem, attempt to test a query with an `ORDER BY` clause.

## Existing issues
- [x] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [x] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [x] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

https://stackoverflow.com/questions/47968772/using-queries-with-order-by-when-testing-with-the-embedded-runtime

## Design of the fix

Added documentation to bypass the issue, since:
1) the PouchDB issue is well known and not straightforward to fix.
2) enabling tests of Queries in the short term is important enough for general code quality to warrant a temporary fix until PouchDB issue is resolved.

## Validation of the fix

N/A

## Automated Tests

N/A

## What documentation has been provided for this pull request

Fix is itself a documentation update.