### PR TITLE
remove eventUrl from connection profile

### DIFF
--- a/packages/composer-cli/lib/cmds/card/lib/schema/ccpschema.json
+++ b/packages/composer-cli/lib/cmds/card/lib/schema/ccpschema.json
@@ -174,7 +174,7 @@
                 "grpcOptions" : { "$ref": "#/definitions/grpcOptions" },
                 "tlsCACerts" : { "$ref": "#/definitions/tlsCACerts" }
             },
-            "required": [ "url", "eventUrl"]
+            "required": [ "url"]
         }
     },
     "type" : "object",

--- a/packages/composer-playground/e2e/fabric/hlfv1/profiles/basic-connection-org1.json
+++ b/packages/composer-playground/e2e/fabric/hlfv1/profiles/basic-connection-org1.json
@@ -54,12 +54,10 @@
     },
     "peers": {
         "peer0.org1.example.com": {
-            "url": "grpc://localhost:7051",
-            "eventUrl": "grpc://localhost:7053"
+            "url": "grpc://localhost:7051"
         },
         "peer0.org2.example.com": {
-            "url": "grpc://localhost:8051",
-            "eventUrl": "grpc://localhost:8053"
+            "url": "grpc://localhost:8051"
         }
     },
     "certificateAuthorities": {

--- a/packages/composer-tests-functional/systest/testutil.js
+++ b/packages/composer-tests-functional/systest/testutil.js
@@ -316,7 +316,6 @@ class TestUtil {
                             'peers': {
                                 'peer0.org1.example.com': {
                                     'url': 'grpcs://localhost:7051',
-                                    'eventUrl': 'grpcs://localhost:7053',
                                     'grpcOptions': {
                                         'ssl-target-name-override': 'peer0.org1.example.com',
                                     },
@@ -326,7 +325,6 @@ class TestUtil {
                                 },
                                 'peer0.org2.example.com': {
                                     'url': 'grpcs://localhost:8051',
-                                    'eventUrl': 'grpcs://localhost:8053',
                                     'grpcOptions': {
                                         'ssl-target-name-override': 'peer0.org2.example.com',
                                     },
@@ -415,7 +413,6 @@ class TestUtil {
                             'peers': {
                                 'peer0.org1.example.com': {
                                     'url': 'grpcs://localhost:7051',
-                                    'eventUrl': 'grpcs://localhost:7053',
                                     'grpcOptions': {
                                         'ssl-target-name-override': 'peer0.org1.example.com',
                                     },
@@ -425,7 +422,6 @@ class TestUtil {
                                 },
                                 'peer0.org2.example.com': {
                                     'url': 'grpcs://localhost:8051',
-                                    'eventUrl': 'grpcs://localhost:8053',
                                     'grpcOptions': {
                                         'ssl-target-name-override': 'peer0.org2.example.com',
                                     },
@@ -545,11 +541,9 @@ class TestUtil {
                             'peers': {
                                 'peer0.org1.example.com': {
                                     'url': 'grpc://localhost:7051',
-                                    'eventUrl': 'grpc://localhost:7053'
                                 },
                                 'peer0.org2.example.com': {
                                     'url': 'grpc://localhost:8051',
-                                    'eventUrl': 'grpc://localhost:8053'
                                 }
                             },
                             'certificateAuthorities': {
@@ -620,11 +614,9 @@ class TestUtil {
                             'peers': {
                                 'peer0.org1.example.com': {
                                     'url': 'grpc://localhost:7051',
-                                    'eventUrl': 'grpc://localhost:7053'
                                 },
                                 'peer0.org2.example.com': {
                                     'url': 'grpc://localhost:8051',
-                                    'eventUrl': 'grpc://localhost:8053'
                                 }
                             },
                             'certificateAuthorities': {

--- a/packages/composer-tests-integration/profiles/basic-connection-org1-hsm.json
+++ b/packages/composer-tests-integration/profiles/basic-connection-org1-hsm.json
@@ -59,12 +59,10 @@
     },
     "peers": {
         "peer0.org1.example.com": {
-            "url": "grpc://localhost:7051",
-            "eventUrl": "grpc://localhost:7053"
+            "url": "grpc://localhost:7051"
         },
         "peer0.org2.example.com": {
-            "url": "grpc://localhost:8051",
-            "eventUrl": "grpc://localhost:8053"
+            "url": "grpc://localhost:8051"
         }
     },
     "certificateAuthorities": {

--- a/packages/composer-tests-integration/profiles/basic-connection-org1.json
+++ b/packages/composer-tests-integration/profiles/basic-connection-org1.json
@@ -54,12 +54,10 @@
     },
     "peers": {
         "peer0.org1.example.com": {
-            "url": "grpc://localhost:7051",
-            "eventUrl": "grpc://localhost:7053"
+            "url": "grpc://localhost:7051"
         },
         "peer0.org2.example.com": {
-            "url": "grpc://localhost:8051",
-            "eventUrl": "grpc://localhost:8053"
+            "url": "grpc://localhost:8051"
         }
     },
     "certificateAuthorities": {

--- a/packages/composer-tests-integration/profiles/basic-connection-org1.yaml
+++ b/packages/composer-tests-integration/profiles/basic-connection-org1.yaml
@@ -46,10 +46,8 @@ orderers:
 peers:
   peer0.org1.example.com:
     url: grpc://localhost:7051
-    eventUrl: grpc://localhost:7053
   peer0.org2.example.com:
     url: grpc://localhost:8051
-    eventUrl: grpc://localhost:8053
 certificateAuthorities:
   ca.org1.example.com:
     url: http://localhost:7054

--- a/packages/composer-tests-integration/profiles/basic-connection-org2.json
+++ b/packages/composer-tests-integration/profiles/basic-connection-org2.json
@@ -54,12 +54,10 @@
     },
     "peers": {
         "peer0.org1.example.com": {
-            "url": "grpc://localhost:7051",
-            "eventUrl": "grpc://localhost:7053"
+            "url": "grpc://localhost:7051"
         },
         "peer0.org2.example.com": {
-            "url": "grpc://localhost:8051",
-            "eventUrl": "grpc://localhost:8053"
+            "url": "grpc://localhost:8051"
         }
     },
     "certificateAuthorities": {

--- a/packages/composer-tests-integration/profiles/tls-connection-org1.json
+++ b/packages/composer-tests-integration/profiles/tls-connection-org1.json
@@ -61,7 +61,6 @@
     "peers": {
         "peer0.org1.example.com": {
             "url": "grpcs://localhost:7051",
-            "eventUrl": "grpcs://localhost:7053",
             "grpcOptions": {
                 "ssl-target-name-override": "peer0.org1.example.com"
             },
@@ -71,7 +70,6 @@
         },
         "peer0.org2.example.com": {
             "url": "grpcs://localhost:8051",
-            "eventUrl": "grpcs://localhost:8053",
             "grpcOptions": {
                 "ssl-target-name-override": "peer0.org2.example.com"
             },

--- a/packages/composer-tests-integration/profiles/tls-connection-org2.json
+++ b/packages/composer-tests-integration/profiles/tls-connection-org2.json
@@ -61,7 +61,6 @@
     "peers": {
         "peer0.org1.example.com": {
             "url": "grpcs://localhost:7051",
-            "eventUrl": "grpcs://localhost:7053",
             "grpcOptions": {
                 "ssl-target-name-override": "peer0.org1.example.com"
             },
@@ -71,7 +70,6 @@
         },
         "peer0.org2.example.com": {
             "url": "grpcs://localhost:8051",
-            "eventUrl": "grpcs://localhost:8053",
             "grpcOptions": {
                 "ssl-target-name-override": "peer0.org2.example.com"
             },

--- a/packages/composer-website/jekylldocs/reference/connectionprofile.md
+++ b/packages/composer-website/jekylldocs/reference/connectionprofile.md
@@ -69,8 +69,7 @@ A Connection Profile is used by {{site.data.conrefs.composer_full}} to connect t
     },
     "peers": {
         "peer0.org1.example.com": {
-            "url": "grpc://peer0.org1.example.com:7051",
-            "eventUrl": "grpc://peer0.org1.example.com:7053"
+            "url": "grpc://peer0.org1.example.com:7051"
         }
     },
     "certificateAuthorities": {
@@ -153,19 +152,17 @@ Here we define all the peers in all organizations in the network. Each has a uni
 ```
 "peers": {
     "peer0.org1.example.com": {
-        "url": "grpc://peer0.org1.example.com:7051",
-        "eventUrl": "grpc://peer0.org1.example.com:7053"
+        "url": "grpc://peer0.org1.example.com:7051"
     }
 },
 ```
 
-Peer definitions are similar to orderer definitions in structure, but you should define both the `url` and `eventUrl` of a peer. Older connection profile formats required that you only define the eventUrl for peers in your organization. Defining TLS for a peer is similar to orderers
+Peer definitions are similar to orderer definitions in structure.
 
 ```
 "peers": {
     "peer0.org1.example.com": {
-        "url": "grpc://peer0.org1.example.com:7051",
-        "eventUrl": "grpc://peer0.org1.example.com:7053"
+        "url": "grpc://peer0.org1.example.com:7051"
         "grpcOptions": {
             "ssl-target-name-override": "peer.org1.example.com"
         },
@@ -181,16 +178,13 @@ To define multiple peers, use the following format:
 ```
 "peers": {
     "peer0.org1.example.com": {
-        "url": "grpc://peer0.org1.example.com:7051",
-        "eventUrl": "grpc://peer0.org1.example.com:7053"
+        "url": "grpc://peer0.org1.example.com:7051"
     },
     "peer1.org1.example.com": {
-        "url": "grpc://peer1.org1.example.com:7051",
-        "eventUrl": "grpc://peer1.org1.example.com:7053"
+        "url": "grpc://peer1.org1.example.com:7051"
     },
     "peer0.org2.example.com": {
-        "url": "grpc://peer0.org2.example.com:7051",
-        "eventUrl": "grpc://peer0.org2.example.com:7053"
+        "url": "grpc://peer0.org2.example.com:7051"
     },
 },
 ```
@@ -293,8 +287,7 @@ For example a peer definition might look like:
 
 ```
 "peer0.org1.example.com": {
-    "url": "grpcs://peer0.org1.example.com:7051",
-    "eventUrl": "grpcs://peer0.org1.example.com:7053"
+    "url": "grpcs://peer0.org1.example.com:7051"
     "grpcOptions": {
         "ssl-target-name-override": "peer.org1.example.com",
         "grpc.keepalive_time_ms": 600000,

--- a/packages/composer-website/jekylldocs/reference/connectionprofile.md
+++ b/packages/composer-website/jekylldocs/reference/connectionprofile.md
@@ -162,7 +162,7 @@ Peer definitions are similar to orderer definitions in structure.
 ```
 "peers": {
     "peer0.org1.example.com": {
-        "url": "grpc://peer0.org1.example.com:7051"
+        "url": "grpc://peer0.org1.example.com:7051",
         "grpcOptions": {
             "ssl-target-name-override": "peer.org1.example.com"
         },
@@ -287,7 +287,7 @@ For example a peer definition might look like:
 
 ```
 "peer0.org1.example.com": {
-    "url": "grpcs://peer0.org1.example.com:7051"
+    "url": "grpcs://peer0.org1.example.com:7051",
     "grpcOptions": {
         "ssl-target-name-override": "peer.org1.example.com",
         "grpc.keepalive_time_ms": 600000,

--- a/packages/composer-website/jekylldocs/tutorials/deploy-to-fabric-multi-org.md
+++ b/packages/composer-website/jekylldocs/tutorials/deploy-to-fabric-multi-org.md
@@ -253,7 +253,7 @@ We need a base connection profile that describes this fabric network which can t
         },
         "peers": {
             "peer0.org1.example.com": {
-                "url": "grpcs://localhost:7051"
+                "url": "grpcs://localhost:7051",
                 "grpcOptions": {
                     "ssl-target-name-override": "peer0.org1.example.com"
                 },

--- a/packages/composer-website/jekylldocs/tutorials/deploy-to-fabric-multi-org.md
+++ b/packages/composer-website/jekylldocs/tutorials/deploy-to-fabric-multi-org.md
@@ -253,8 +253,7 @@ We need a base connection profile that describes this fabric network which can t
         },
         "peers": {
             "peer0.org1.example.com": {
-                "url": "grpcs://localhost:7051",
-                "eventUrl": "grpcs://localhost:7053",
+                "url": "grpcs://localhost:7051"
                 "grpcOptions": {
                     "ssl-target-name-override": "peer0.org1.example.com"
                 },
@@ -264,7 +263,6 @@ We need a base connection profile that describes this fabric network which can t
             },
             "peer1.org1.example.com": {
                 "url": "grpcs://localhost:8051",
-                "eventUrl": "grpcs://localhost:8053",
                 "grpcOptions": {
                     "ssl-target-name-override": "peer1.org1.example.com"
                 },
@@ -274,7 +272,6 @@ We need a base connection profile that describes this fabric network which can t
             },
             "peer0.org2.example.com": {
                 "url": "grpcs://localhost:9051",
-                "eventUrl": "grpcs://localhost:9053",
                 "grpcOptions": {
                     "ssl-target-name-override": "peer0.org2.example.com"
                 },
@@ -284,7 +281,6 @@ We need a base connection profile that describes this fabric network which can t
             },
             "peer1.org2.example.com": {
                 "url": "grpcs://localhost:10051",
-                "eventUrl": "grpcs://localhost:10053",
                 "grpcOptions": {
                     "ssl-target-name-override": "peer1.org2.example.com"
                 },

--- a/packages/composer-website/jekylldocs/tutorials/deploy-to-fabric-single-org.md
+++ b/packages/composer-website/jekylldocs/tutorials/deploy-to-fabric-single-org.md
@@ -123,8 +123,7 @@ A connection profile specifies all of the information required to locate and con
 
             "peers": {
                 "peer0.org1.example.com": {
-                    "url": "grpc://localhost:7051",
-                    "eventUrl": "grpc://localhost:7053"
+                    "url": "grpc://localhost:7051"
                 }
             },
 
@@ -220,8 +219,7 @@ Here we are specifying that we are in `Org1`. The timeouts are used to determine
             "version": "1.0.0",
             "peers": {
                 "peer0.org1.example.com": {
-                    "url": "grpc://localhost:7051",
-                    "eventUrl": "grpc://localhost:7053"
+                    "url": "grpc://localhost:7051"
                 }
             },
             "certificateAuthorities": {


### PR DESCRIPTION
It's not used now we have moved to channel event hubs. And the support is disappearing in 1.2 and 1.3 of fabric.
Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
