### PR TITLE
Issue 4175

### DIFF
--- a/contrib-notes/coding-guidelines.md
+++ b/contrib-notes/coding-guidelines.md
@@ -194,7 +194,7 @@ node composer-cli/cli.js network install --card PeerAdmin@hlfv1 --archiveFile te
 ```
 - instantiate the chaincode.
 ```
-node composer-cli/cli.js network start --card PeerAdmin@hlfv1 -networkAdmin admin -networkAdminEnrollSecret adminpw
+node composer-cli/cli.js network start --card PeerAdmin@hlfv1 --networkName test-network --networkVersion 0.0.1 --networkAdmin admin --networkAdminEnrollSecret adminpw
 ```
 
 # Next step


### PR DESCRIPTION
added network name and version to composer start command in the doc

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
         #4175 
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
#4175 

## Steps to Reproduce

## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
#4175 
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->
composer start command requires network name , version flags

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
