### PR TITLE
[Master] Clarify when events are emitted in the docs

### DIFF
--- a/packages/composer-website/jekylldocs/business-network/publishing-events.md
+++ b/packages/composer-website/jekylldocs/business-network/publishing-events.md
@@ -10,7 +10,7 @@ excerpt: Emitting Events from Transaction Processor Functions
 
 # Emitting Events
 
-Events can be emitted by {{site.data.conrefs.composer_full}} and subscribed to by external applications. Events are defined in the model file of a business network definition, and are emitted by transaction JavaScript in the transaction processor functions file.
+Events can be emitted by {{site.data.conrefs.composer_full}} and subscribed to by external applications. Events are defined in the model file of a business network definition, and are emitted by transaction JavaScript in the transaction processor functions file. Note that although the code to emit the event is inside a transaction processor function, the event is not emitted immediately when this code is run. Instead, event emissions are performed once the transaction has been committed.
 
 ## Before you begin
 


### PR DESCRIPTION
The docs in their current state are vague when it comes to when events are emitted. After digging around, I found [the events entry in the Composer Knowledge Wiki](https://github.com/hyperledger/composer-knowledge-wiki/blob/latest/knowledge.md#information_source--events-consumedsubscribed-to-by-applications-emitted-by-tps) and paired with [this diagram explaining the flow of transactions](https://hyperledger-fabric.readthedocs.io/en/release-1.2/arch-deep-dive.html#swimlane), which explain this in more detail.

I've added a couple of sentences to the docs to clarify this to future users.