### PR TITLE
[0.19.x] Changed 'betwork' to 'network' in Playground version 0.19.x

### DIFF
--- a/packages/composer-playground/src/app/editor/upgrade/upgrade.component.html
+++ b/packages/composer-playground/src/app/editor/upgrade/upgrade.component.html
@@ -12,7 +12,7 @@
  limitations under the License.
 -->
 <div class="modal-header">
-    <h1>Upgrade business betwork</h1>
+    <h1>Upgrade business network</h1>
     <button id="upgrade-file_exit" class="icon modal-exit" (click)="activeModal.dismiss()">
         <svg class="ibm-icon" aria-hidden="true">
             <use xlink:href="#icon-close_new"></use>


### PR DESCRIPTION
Fixes issue: https://github.com/hyperledger/composer/issues/4422

