### PR TITLE
[Master] Add checks for eventhub failure

### DIFF
--- a/packages/composer-connector-hlfv1/lib/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/lib/hlfconnection.js
@@ -1032,7 +1032,7 @@ class HLFConnection extends Connection {
             const proposal = results[1];
             const header = results[2];
 
-            eventHandler = HLFConnection.createTxEventHandler(this.eventHubs, txId.getTransactionID(), this.commitTimeout);
+            eventHandler = HLFConnection.createTxEventHandler(this.eventHubs, txId.getTransactionID(), this.commitTimeout, this.requiredEventHubs);
             eventHandler.startListening();
             LOG.debug(method, 'TxEventHandler started listening, sending valid responses to the orderer');
             LOG.perf(method, 'Total duration to prepare proposals for orderer: ', txId, t0);

--- a/packages/composer-connector-hlfv1/lib/hlftxeventhandler.js
+++ b/packages/composer-connector-hlfv1/lib/hlftxeventhandler.js
@@ -30,16 +30,20 @@ class HLFTxEventHandler {
      * @param {EventHub[]} eventHubs the event hubs to listen for tx events
      * @param {String} txId the txid that is driving the events to occur
      * @param {Integer} timeout how long (in seconds) to wait for events to occur.
+     * @param {Integer} requiredEventHubs number of required event hubs, either 0 or 1, default to 0
+     * for old composer be
      */
-    constructor(eventHubs, txId, timeout) {
+    constructor(eventHubs, txId, timeout, requiredEventHubs = 1) {
         const method = 'constructor';
         // Don't log the eventHub objects they are too large
-        LOG.entry(method, txId, timeout);
+        LOG.entry(method, txId, timeout, requiredEventHubs);
         this.eventHubs = eventHubs || [];
         this.txId = txId || '';
         this.listenerPromises = [];
         this.timeoutHandles = [];
         this.timeout = timeout || 0;
+        this.responseCount = 0;
+        this.requiredEventHubs = requiredEventHubs;
         LOG.exit(method);
     }
 
@@ -66,6 +70,7 @@ class HLFTxEventHandler {
 
                     eh.registerTxEvent(this.txId,
                         (tx, code) => {
+                            this.responseCount++;
                             clearTimeout(handle);
                             eh.unregisterTxEvent(this.txId);
                             if (code !== 'VALID') {
@@ -90,23 +95,35 @@ class HLFTxEventHandler {
                 this.timeoutHandles.push(handle);
             }
         });
+        if (this.listenerPromises.length < this.requiredEventHubs) {
+            this.cancelListening();
+            const msg = 'No connected event hubs. It is required that at least 1 event hub has been connected to receive the commit event';
+            LOG.error(method, msg);
+            throw Error(msg);
+        }
         LOG.exit(method);
     }
 
     /**
      * wait for all event hubs to send the tx event.
-     * @returns {Promise} a promise which is resolved when all the events have been received, rejected if an error occurs.
      */
-    waitForEvents() {
+    async waitForEvents() {
         const method = 'waitForEvents';
         LOG.entry(method);
+        // don't need to check against requiredEventHubs as startListening has already checked
+        // this listenerPromises.length. This ensures the same composer behaviour if requiredEventHubs
+        // is set to 0.
         if (this.listenerPromises.length > 0) {
+            await Promise.all(this.listenerPromises);
+            if (this.responseCount < this.requiredEventHubs) {
+                const msg = 'No event hubs responded. It is required that at least 1 event hub responds with a commit event';
+                LOG.error(method, msg);
+                throw Error(msg);
+            }
             LOG.exit(method);
-            return Promise.all(this.listenerPromises);
         }
         LOG.warn(method, `No event hubs available to listen on to wait for a commit for transaction '${this.txId}'`);
         LOG.exit(method);
-        return Promise.resolve();
     }
 
     /**


### PR DESCRIPTION
Missing checks in startListening and waitForEvents to ensure we
can still get a commit notification

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
