### PR TITLE
[Master] Clarifying Node versions

### DIFF
--- a/packages/composer-website/jekylldocs/installing/installing-prereqs.md
+++ b/packages/composer-website/jekylldocs/installing/installing-prereqs.md
@@ -24,7 +24,7 @@ The following are prerequisites for installing the required development tools:
 - Operating Systems: Ubuntu Linux 14.04 / 16.04 LTS (both 64-bit), or Mac OS 10.12
 - Docker Engine: Version 17.03 or higher
 - Docker-Compose: Version 1.8 or higher
-- Node: 8.9 or higher (note version 9 is not supported)
+- Node: 8.9 or higher (note version 9 and higher is not supported)
 - npm: v5.x
 - git: 2.9.x or higher
 - Python: 2.7.x
@@ -110,16 +110,16 @@ nvm —-version
 
 ## Install Node
 
-Install the latest (long term support) version of Node:
+Install Node: 8.9 or higher (note version 9 and higher is not supported)
 
 ```
-nvm install --lts
+nvm install v8
 ```
 
-Switch to the LTS version of Node:
+Switch to the latest version 8 of Node:
 
 ```
-nvm use --lts
+nvm use 8
 ```
 
 Check that Node is installed:


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->
Clarifying that the versions of Node must be between 8.9 and 9. Anything equal to 9 or higher will cause the composer libraries to fail to install.

## Checklist
 - [x]  Documentation - any JSDoc, website, or Stackoverflow answers?
