### PR TITLE
fix - use next peer for channel init

### DIFF
--- a/packages/composer-connector-hlfv1/lib/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/lib/hlfconnection.js
@@ -629,10 +629,11 @@ class HLFConnection extends Connection {
         });
 
         let ledgerPeerIndex = 0;
+        let targetPeer = ledgerPeers[0];
 
         while (!this.initialized) {
             try {
-                await this.channel.initialize();
+                await this.channel.initialize({ target: targetPeer });
                 this.initialized = true;
             } catch(error) {
                 LOG.warn(method, `error trying to initialize channel. Error returned ${error}`);
@@ -641,10 +642,8 @@ class HLFConnection extends Connection {
                 }
                 ledgerPeerIndex++;
                 const nextPeer = ledgerPeers[ledgerPeerIndex];
-                LOG.info(method, `Moving ${nextPeer.getName()} to top of queue`);
-                const peerIndex = this.channel.getPeers().indexOf(nextPeer);
-                this.channel.getPeers().splice(peerIndex, 1);
-                this.channel.getPeers().unshift(nextPeer);
+                LOG.info(method, `Try next peer ${nextPeer.getName()}`);
+                targetPeer = ledgerPeers[ledgerPeerIndex];
             }
         }
 

--- a/packages/composer-connector-hlfv1/test/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/test/hlfconnection.js
@@ -2570,11 +2570,8 @@ describe('HLFConnection', () => {
             mockChannel.initialize.onCall(1).resolves();
             await connection._initializeChannel();
             sinon.assert.calledTwice(mockChannel.initialize);
-            peerArray.length.should.equal(5);
-            const expectedIndexOrder = [3, 1, 2, 4, 5];
-            for (let i = 0; i < peerArray.length; i++) {
-                peerArray[i].index.should.equal(expectedIndexOrder[i]);
-            }
+            sinon.assert.calledWith(mockChannel.initialize, { target: mockPeer1 });
+            sinon.assert.calledWith(mockChannel.initialize, { target: mockPeer3 });
         });
 
         it('should fail if all peers fail', async () => {
@@ -2589,12 +2586,10 @@ describe('HLFConnection', () => {
                 error = _error;
             }
             error.should.match(/connect failed again/);
-            sinon.assert.calledThrice(mockChannel.initialize);
-            const expectedIndexOrder = [4, 3, 1, 2, 5];
-            peerArray.length.should.equal(5);
-            for (let i = 0; i < peerArray.length; i++) {
-                peerArray[i].index.should.equal(expectedIndexOrder[i]);
-            }
+            sinon.assert.callCount(mockChannel.initialize, 3);
+            sinon.assert.calledWith(mockChannel.initialize, { target: mockPeer1 });
+            sinon.assert.calledWith(mockChannel.initialize, { target: mockPeer3 });
+            sinon.assert.calledWith(mockChannel.initialize, { target: mockPeer3 });
         });
     });
 


### PR DESCRIPTION
Fix for issue described in 
https://github.com/hyperledger/composer/issues/4528

It doesn't have optimization (does not remember which peer worked last name) but it resolves the issue.