### PR TITLE
[0.19.x] Rest server can be terminated by client

### DIFF
--- a/packages/composer-rest-server/server/server.js
+++ b/packages/composer-rest-server/server/server.js
@@ -192,6 +192,14 @@ module.exports = function (composer) {
                 clientTracking: true
             });
 
+            // Add a dummy error handler for a ws connection so bad websocket client
+            // doesn't kill the rest server
+            wss.on('connection', (ws) => {
+                ws.on('error', () => {
+                    // do nothing
+                });
+            });
+
             // Add a broadcast method that sends data to all connected clients.
             wss.broadcast = (data) => {
                 wss.clients.forEach((client) => {


### PR DESCRIPTION
A client listening on a web socket can terminate the rest server
if it is badly behaved and doesn’t cleanly disconnect

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
