### PR TITLE
[0.19.x] Fix TxId logging for performance logging

### DIFF
--- a/packages/composer-common/lib/log/logger.js
+++ b/packages/composer-common/lib/log/logger.js
@@ -318,6 +318,8 @@ class Logger {
         const timeTaken = (Date.now() - startTime).toFixed(2);
         if (txId && txId.getTransactionID) {
             this.intlog('verbose', method, `[${txId.getTransactionID().substring(0, 8)}] ${msg} ${timeTaken}ms`);
+        } else if (txId && txId.length > 0) {
+            this.intlog('verbose', method, `[${txId.substring(0, 8)}] ${msg} ${timeTaken}ms`);
         } else {
             this.intlog('verbose', method, `[NO TXID ] ${msg} ${timeTaken}ms`);
         }

--- a/packages/composer-common/test/log/logger.js
+++ b/packages/composer-common/test/log/logger.js
@@ -282,13 +282,20 @@ describe('Logger', () => {
             sinon.assert.calledWith(logger.intlog, 'verbose', 'Method','Message','Data');
         });
 
-        it('perf method should call verbose level, no args', () => {
+        it('perf method should call verbose level, handling a transaction id object', () => {
             logger.perf('Method', 'Perf message', {getTransactionID: () => {return 'txid';}}, new Date());
             sinon.assert.calledOnce(logger.intlog);
             sinon.assert.calledWith(logger.intlog, 'verbose', 'Method', sinon.match.string);
         });
 
-        it('perf method should call verbose level and work without a txid, no args', () => {
+        it('perf method should call verbose level, handling a transaction id string', () => {
+            logger.perf('Method', 'Perf message', 'A-TxId-value', new Date());
+            sinon.assert.calledOnce(logger.intlog);
+            sinon.assert.calledWith(logger.intlog, 'verbose', 'Method', sinon.match.string);
+        });
+
+
+        it('perf method should call verbose level and work without a txid', () => {
             logger.perf('Method', 'Perf message', null, new Date());
             sinon.assert.calledOnce(logger.intlog);
             sinon.assert.calledWith(logger.intlog, 'verbose', 'Method', sinon.match.string);

--- a/packages/composer-runtime-hlfv1/lib/composer.js
+++ b/packages/composer-runtime-hlfv1/lib/composer.js
@@ -97,12 +97,12 @@ class Composer {
             let nodeContext = this._createContext(engine, stub);
             await engine.init(nodeContext, fcn, params);
             LOG.exit(method);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration for txnID [' + stub.getTxID() + ']: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration for txnID [' + stub.getTxID() + ']: ', stub.getTxID(), t0);
             return shim.success();
         }
         catch(err) {
             LOG.error(method, err);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration for txnID [' + stub.getTxID() + ']: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration for txnID [' + stub.getTxID() + ']: ', stub.getTxID(), t0);
             return shim.error(err);
         }
     }
@@ -127,16 +127,16 @@ class Composer {
             let payload = await engine.invoke(nodeContext, fcn, params);
             if (payload !== null && payload !== undefined) {
                 LOG.exit(method, payload);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration for txnID [' + stub.getTxID() + ']: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration for txnID [' + stub.getTxID() + ']: ', stub.getTxID(), t0);
                 return shim.success(Buffer.from(JSON.stringify(payload)));
             }
             LOG.exit(method);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration for txnID [' + stub.getTxID() + ']: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration for txnID [' + stub.getTxID() + ']: ', stub.getTxID(), t0);
             return shim.success();
         }
         catch(err) {
             LOG.error(method, err);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration for txnID [' + stub.getTxID() + ']: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration for txnID [' + stub.getTxID() + ']: ', stub.getTxID(), t0);
             return shim.error(err);
         }
     }

--- a/packages/composer-runtime-hlfv1/lib/nodecontext.js
+++ b/packages/composer-runtime-hlfv1/lib/nodecontext.js
@@ -43,6 +43,7 @@ class NodeContext extends Context {
         this.stub = stub;
         this.dataService = new NodeDataService(this.stub);
         this.identityService = new NodeIdentityService(this.stub);
+        this.setContextId(stub.getTxID());
         LOG.exit(method);
     }
 

--- a/packages/composer-runtime-hlfv1/lib/nodedatacollection.js
+++ b/packages/composer-runtime-hlfv1/lib/nodedatacollection.js
@@ -50,9 +50,9 @@ class NodeDataCollection extends DataCollection {
         const t0 = Date.now();
 
         let iterator = await this.stub.getStateByPartialCompositeKey(this.collectionID, []);
-        let results = await NodeUtils.getAllResults(iterator);
+        let results = await NodeUtils.getAllResults(iterator, this.stub);
         LOG.exit(method, results);
-        LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+        LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
         return results;
     }
 
@@ -72,12 +72,12 @@ class NodeDataCollection extends DataCollection {
         if (value.length === 0) {
             const newErr = new Error(`Object with ID '${id}' in collection with ID '${this.collectionID}' does not exist`);
             LOG.error(method, newErr);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
             throw newErr;
         }
         let retVal = JSON.parse(value.toString('utf8'));
         LOG.exit(method, retVal);
-        LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+        LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
         return retVal;
     }
 
@@ -96,7 +96,7 @@ class NodeDataCollection extends DataCollection {
         let value = await this.stub.getState(key);
         let retVal = value.length !== 0;
         LOG.exit(method, retVal);
-        LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+        LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
         return retVal;
     }
 
@@ -120,14 +120,14 @@ class NodeDataCollection extends DataCollection {
             if (value.length !== 0) {
                 const newErr =  new Error(`Failed to add object with ID '${id}' in collection with ID '${this.collectionID}' as the object already exists`);
                 LOG.error(method, newErr);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
                 throw newErr;
             }
         }
         await this.stub.putState(key, Buffer.from(JSON.stringify(object)));
 
         LOG.exit(method);
-        LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+        LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
     }
 
     /**
@@ -148,12 +148,12 @@ class NodeDataCollection extends DataCollection {
         if (value.length === 0) {
             const newErr = new Error(`Failed to update object with ID '${id}' in collection with ID '${this.collectionID}' as the object does not exist`);
             LOG.error(method, newErr);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
             throw newErr;
         }
         await this.stub.putState(key, Buffer.from(JSON.stringify(object)));
         LOG.exit(method);
-        LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+        LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
     }
 
     /**
@@ -170,12 +170,12 @@ class NodeDataCollection extends DataCollection {
         if (value.length === 0) {
             const newErr = new Error(`Failed to delete object with ID '${id}' in collection with ID '${this.collectionID}' as the object does not exist`);
             LOG.error(method, newErr);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
             throw newErr;
         }
         await this.stub.deleteState(key);
         LOG.exit(method);
-        LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+        LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
     }
 }
 

--- a/packages/composer-runtime-hlfv1/lib/nodedataservice.js
+++ b/packages/composer-runtime-hlfv1/lib/nodedataservice.js
@@ -57,17 +57,17 @@ class NodeDataService extends DataService {
             if (value.length === 0) {
                 let result = await this._storeCollection(key, id);
                 LOG.exit(method, result);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
                 return result;
             }
             else {
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
                 throw new Error(`Failed to create collection with ID ${id} as it already exists`);
             }
         } else {
             let result = await this._storeCollection(key, id);
             LOG.exit(method, result);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
             return result;
         }
     }
@@ -88,7 +88,7 @@ class NodeDataService extends DataService {
         await this.stub.putState(key, Buffer.from(JSON.stringify({'id': id})));
         let retVal = new NodeDataCollection(this, this.stub, id);
         LOG.exit(method, retVal);
-        LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+        LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
         return retVal;
     }
 
@@ -104,13 +104,13 @@ class NodeDataService extends DataService {
         let key = this.stub.createCompositeKey(collectionObjectType, [id]);
         let exists = await this.existsCollection(id);
         if (!exists) {
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
             throw new Error(`Collection with ID ${id} does not exist`);
         }
         await this.clearCollection(id);
         await this.stub.deleteState(key);
         LOG.exit(method);
-        LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+        LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
     }
 
    /**
@@ -128,18 +128,18 @@ class NodeDataService extends DataService {
         if (bypass) {
             let retVal = new NodeDataCollection(this, this.stub, id);
             LOG.exit(method, retVal);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
             return retVal;
         } else {
             let key = this.stub.createCompositeKey(collectionObjectType, [id]);
             let value = await this.stub.getState(key);
             if (value.length === 0) {
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
                 throw new Error(`Collection with ID ${id} does not exist`);
             }
             let retVal = new NodeDataCollection(this, this.stub, id);
             LOG.exit(method, retVal);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
             return retVal;
         }
     }
@@ -159,7 +159,7 @@ class NodeDataService extends DataService {
         let value = await this.stub.getState(key);
         let retVal = value.length !== 0;
         LOG.exit(method, retVal);
-        LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+        LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
         return retVal;
     }
 
@@ -176,9 +176,9 @@ class NodeDataService extends DataService {
         const t0 = Date.now();
 
         let iterator = await this.stub.getQueryResult(query);
-        let results = await NodeUtils.getAllResults(iterator);
+        let results = await NodeUtils.getAllResults(iterator, this.stub);
         LOG.exit(method, results);
-        LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+        LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
         return results;
     }
 
@@ -194,7 +194,7 @@ class NodeDataService extends DataService {
         let iterator = await this.stub.getStateByPartialCompositeKey(id, []);
         await NodeUtils.deleteAllResults(iterator, this.stub);
         LOG.exit(method);
-        LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+        LOG.perf(method, 'Total (ms) duration: ', this.stub.getTxID(), t0);
     }
 }
 

--- a/packages/composer-runtime-hlfv1/lib/nodeutils.js
+++ b/packages/composer-runtime-hlfv1/lib/nodeutils.js
@@ -28,9 +28,10 @@ class NodeUtils {
      *
      * @static
      * @param {any} iterator the chaincode iterator
+     * @param {any} stub the stub for this invocation
      * @returns {promise} a promise that is resolved with the results or rejected or error
      */
-    static async getAllResults(iterator) {
+    static async getAllResults(iterator, stub) {
         const method = 'getAllResults';
         LOG.entry(method, iterator);
         const t0 = Date.now();
@@ -56,7 +57,7 @@ class NodeUtils {
                     LOG.warn(warnMsg);
                 }
                 LOG.exit(method);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', stub.getTxID(), t0);
                 return results;
             }
         }
@@ -94,7 +95,7 @@ class NodeUtils {
                     LOG.warn(warnMsg);
                 }
                 LOG.exit(method);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', stub.getTxID(), t0);
                 return results;
             }
         }

--- a/packages/composer-runtime-hlfv1/test/nodecontext.js
+++ b/packages/composer-runtime-hlfv1/test/nodecontext.js
@@ -22,6 +22,7 @@ const NodeDataService = require('../lib/nodedataservice');
 const NodeEventService = require('../lib/nodeeventservice');
 const NodeHTTPService = require('../lib/nodehttpservice');
 const NodeIdentityService = require('../lib/nodeidentityservice');
+const ChaincodeStub = require('fabric-shim/lib/stub');
 
 require('chai').should();
 const sinon = require('sinon');
@@ -31,6 +32,7 @@ describe('NodeContext', () => {
     let mockNodeContainer;
     let mockEngine;
     let context;
+    let mockStub;
 
     let cert = '-----BEGIN CERTIFICATE-----\
 MIICGjCCAcCgAwIBAgIRANuOnVN+yd/BGyoX7ioEklQwCgYIKoZIzj0EAwIwczEL\
@@ -46,15 +48,11 @@ rRLkwKmqpmSecIaOOr0CF6Mi2J5H4aauMAoGCCqGSM49BAMCA0gAMEUCIQC4sKQ6\
 CEgqbTYe48az95W9/hnZ+7DI5eSnWUwV9vCd/gIgS5K6omNJydoFoEpaEIwM97uS\
 XVMHPa0iyC497vdNURA=\
 -----END CERTIFICATE-----';
-    let mockStub = {
-        creator : cert,
-        getCreator: () => {
-            return mockStub.creator;
-        }
-    };
-
 
     beforeEach(() => {
+        mockStub = sinon.createStubInstance(ChaincodeStub);
+        mockStub.getCreator.returns(cert);
+        mockStub.getTxID.returns('12345abcdefg');
         mockNodeContainer = sinon.createStubInstance(NodeContainer);
         mockEngine = sinon.createStubInstance(Engine);
         mockEngine.getContainer.returns(mockNodeContainer);

--- a/packages/composer-runtime-hlfv1/test/nodeloggingservice.js
+++ b/packages/composer-runtime-hlfv1/test/nodeloggingservice.js
@@ -125,26 +125,18 @@ describe('NodeLoggingService', () => {
 
     describe('#initLogging', async  () => {
 
-        it('should set the logging state to the current logger config', async () => {
+        it('should set the logging state to the current logger config, on first call only', async () => {
             sandbox.stub(Logger, 'setLoggerCfg');
             sandbox.stub(loggingService, 'getLoggerCfg').returns('some config');
             await loggingService.initLogging(mockStub);
             sinon.assert.calledOnce(Logger.setLoggerCfg);
             sinon.assert.calledWith(Logger.setLoggerCfg, 'some config', true);
-        });
 
-        it('should register a callback to supplement the logging output', async () => {
-            sandbox.stub(Logger, 'setLoggerCfg');
-            sandbox.stub(Logger, 'setCallBack').callsArgWith(0, 'debug');
-            sandbox.stub(loggingService, 'getLoggerCfg').returns('some config');
+            // call it again
             await loggingService.initLogging(mockStub);
-            sinon.assert.calledOnce(Logger.setCallBack);
-            sinon.assert.calledWith(Logger.setCallBack, sinon.match.func);
-            sinon.assert.calledOnce(mockStub.getTxID);
+            sinon.assert.calledOnce(Logger.setLoggerCfg);
+            sinon.assert.calledWith(Logger.setLoggerCfg, 'some config', true);
         });
-
-
-
     });
 
     describe('#mapCfg', async ()=>{

--- a/packages/composer-runtime-hlfv1/test/nodeutils.js
+++ b/packages/composer-runtime-hlfv1/test/nodeutils.js
@@ -36,6 +36,7 @@ describe('NodeUtils', () => {
         mockIterator = sinon.createStubInstance(StateQueryIterator);
         mockIterator.close.resolves();
         mockStub = sinon.createStubInstance(ChaincodeStub);
+        mockStub.getTxID.returns('abcdefg135845');
         const LOG = Logger.getLog('NodeUtils');
         logWarnSpy = sandbox.spy(LOG, 'warn');
 
@@ -48,7 +49,7 @@ describe('NodeUtils', () => {
     describe('#getAllResults', () => {
         it('should handle empty iterator', async () => {
             mockIterator.next.onFirstCall().resolves({done: true});
-            let results = await NodeUtils.getAllResults(mockIterator);
+            let results = await NodeUtils.getAllResults(mockIterator, mockStub);
             sinon.assert.calledOnce(mockIterator.next);
             sinon.assert.calledOnce(mockIterator.close);
             results.length.should.equal(0);
@@ -63,7 +64,7 @@ describe('NodeUtils', () => {
             };
             mockIterator.next.onFirstCall().resolves(data);
             mockIterator.next.onSecondCall().resolves({done: true});
-            let results = await NodeUtils.getAllResults(mockIterator);
+            let results = await NodeUtils.getAllResults(mockIterator, mockStub);
             sinon.assert.calledTwice(mockIterator.next);
             sinon.assert.calledOnce(mockIterator.close);
             results.should.deep.equal([JSON.parse(data.value.value)]);
@@ -77,7 +78,7 @@ describe('NodeUtils', () => {
                 done: true
             };
             mockIterator.next.onFirstCall().resolves(data);
-            let results = await NodeUtils.getAllResults(mockIterator);
+            let results = await NodeUtils.getAllResults(mockIterator, mockStub);
             sinon.assert.calledOnce(mockIterator.next);
             sinon.assert.calledOnce(mockIterator.close);
             results.should.deep.equal([JSON.parse(data.value.value)]);
@@ -99,7 +100,7 @@ describe('NodeUtils', () => {
 
             mockIterator.next.onFirstCall().resolves(data1);
             mockIterator.next.onSecondCall().resolves(data2);
-            let results = await NodeUtils.getAllResults(mockIterator);
+            let results = await NodeUtils.getAllResults(mockIterator, mockStub);
             sinon.assert.calledTwice(mockIterator.next);
             sinon.assert.calledOnce(mockIterator.close);
             results.should.deep.equal([JSON.parse(data1.value.value), JSON.parse(data2.value.value)]);
@@ -122,7 +123,7 @@ describe('NodeUtils', () => {
             mockIterator.next.onFirstCall().resolves(data1);
             mockIterator.next.onSecondCall().resolves(data2);
             mockIterator.next.onThirdCall().resolves({done: true});
-            let results = await NodeUtils.getAllResults(mockIterator);
+            let results = await NodeUtils.getAllResults(mockIterator, mockStub);
             sinon.assert.calledThrice(mockIterator.next);
             sinon.assert.calledOnce(mockIterator.close);
             results.should.deep.equal([JSON.parse(data1.value.value), JSON.parse(data2.value.value)]);
@@ -136,7 +137,7 @@ describe('NodeUtils', () => {
                 done: true
             };
             mockIterator.next.onFirstCall().resolves(data);
-            let results = await NodeUtils.getAllResults(mockIterator);
+            let results = await NodeUtils.getAllResults(mockIterator, mockStub);
             sinon.assert.calledOnce(mockIterator.next);
             sinon.assert.calledOnce(mockIterator.close);
             results.length.should.equal(0);
@@ -144,7 +145,7 @@ describe('NodeUtils', () => {
 
         it('should handle next throwing an error', async () => {
             mockIterator.next.onFirstCall().rejects(new Error('NextError'));
-            await NodeUtils.getAllResults(mockIterator)
+            await NodeUtils.getAllResults(mockIterator, mockStub)
                 .should.be.rejectedWith(/NextError/);
         });
 
@@ -157,7 +158,7 @@ describe('NodeUtils', () => {
             };
             mockIterator.next.onFirstCall().resolves(data);
             mockIterator.close.rejects(new Error('CloseError'));
-            let results = await NodeUtils.getAllResults(mockIterator);
+            let results = await NodeUtils.getAllResults(mockIterator, mockStub);
             sinon.assert.calledOnce(mockIterator.next);
             sinon.assert.calledOnce(mockIterator.close);
             results.should.deep.equal([{data: 'some-value'}]);

--- a/packages/composer-runtime/lib/accesscontroller.js
+++ b/packages/composer-runtime/lib/accesscontroller.js
@@ -94,7 +94,7 @@ class AccessController {
         // enforcement is not enabled.
         let participant = this.participant;
         if (!participant) {
-            LOG.verbose('@PERF ' + method, 'NO PARTICIPANT: Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'NO PARTICIPANT: Total (ms) duration: ', this.context.getContextId(), t0);
             LOG.exit(method);
             return Promise.resolve();
         }
@@ -106,7 +106,7 @@ class AccessController {
         // enforcement is not enabled.
         let aclManager = this.context.getAclManager();
         if (!aclManager.getAclFile()) {
-            LOG.verbose('@PERF ' + method, 'NO ACL FILE: Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'NO ACL FILE: Total (ms) duration: ', this.context.getContextId(), t0);
             LOG.exit(method);
             return Promise.resolve();
         }
@@ -136,7 +136,7 @@ class AccessController {
                 // If a ACL rule permitted the action, return.
                 if (result) {
                     LOG.exit(method);
-                    LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                    LOG.perf(method, 'Total (ms) duration: ', this.context.getContextId(), t0);
                     return;
                 }
 
@@ -146,7 +146,7 @@ class AccessController {
             })
             .catch((error) => {
                 LOG.error(method, error);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', this.context.getContextId(), t0);
                 throw error;
             });
     }

--- a/packages/composer-runtime/lib/context.js
+++ b/packages/composer-runtime/lib/context.js
@@ -24,6 +24,7 @@ const RegistryManager = require('./registrymanager');
 const ResourceManager = require('./resourcemanager');
 const Resolver = require('./resolver');
 const TransactionLogger = require('./transactionlogger');
+const uuid = require('uuid');
 
 const LOG = Logger.getLog('Context');
 
@@ -47,6 +48,7 @@ class Context {
         this.engine = engine;
         this.installedBusinessNetwork = installedBusinessNetwork;
         this.eventNumber = 0;
+        this.contextId = uuid.v4();
     }
 
     /**
@@ -598,6 +600,22 @@ class Context {
      */
     getNativeAPI() {
         throw new Error('abstract function called');
+    }
+
+    /**
+     * return the current context id
+     * @returns {string} the context id
+     */
+    getContextId() {
+        return this.contextId;
+    }
+
+    /**
+     * set the current context id
+     * @param {string} contextId The contextId
+     */
+    setContextId(contextId) {
+        this.contextId = contextId;
     }
 
 }

--- a/packages/composer-runtime/lib/engine.queries.js
+++ b/packages/composer-runtime/lib/engine.queries.js
@@ -41,7 +41,7 @@ class EngineQueries {
 
         if (args.length !== 3) {
             LOG.error(method, 'Invalid arguments', args);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
             throw new Error(util.format('Invalid arguments "%j" to function "%s", expecting "%j"', args, 'executeQuery', ['queryType', 'query', 'parameters']));
         }
 
@@ -95,7 +95,7 @@ class EngineQueries {
             })
             .then((objects) => {
                 LOG.exit(method, objects);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
                 return objects;
             });
 

--- a/packages/composer-runtime/lib/engine.registries.js
+++ b/packages/composer-runtime/lib/engine.registries.js
@@ -40,7 +40,7 @@ class EngineRegistries {
 
         if (args.length !== 2) {
             LOG.error(method, 'Invalid arguments', args);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
             throw new Error(util.format('Invalid arguments "%j" to function "%s", expecting "%j"', args, 'getAllRegistries', ['registryType','includeSystem']));
         }
         let registryType = args[0];
@@ -48,7 +48,7 @@ class EngineRegistries {
         return context.getRegistryManager().getAll(registryType,includeSystem)
             .then((result) => {
                 LOG.exit(method, result);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
                 return result;
             });
     }
@@ -67,7 +67,7 @@ class EngineRegistries {
 
         if (args.length !== 2) {
             LOG.error(method, 'Invalid arguments', args);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
             throw new Error(util.format('Invalid arguments "%j" to function "%s", expecting "%j"', args, 'getRegistry', ['registryType', 'registryId']));
         }
         let registryType = args[0];
@@ -75,7 +75,7 @@ class EngineRegistries {
         return context.getRegistryManager().get(registryType, registryId)
             .then((result) => {
                 LOG.exit(method, result);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
                 return result;
             });
     }
@@ -94,7 +94,7 @@ class EngineRegistries {
 
         if (args.length !== 2) {
             LOG.error(method, 'Invalid arguments', args);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
             throw new Error(util.format('Invalid arguments "%j" to function "%s", expecting "%j"', args, 'existsRegistry', ['registryType', 'registryId']));
         }
         let registryType = args[0];
@@ -102,7 +102,7 @@ class EngineRegistries {
         return context.getRegistryManager().exists(registryType, registryId)
             .then((result) => {
                 LOG.exit(method, result);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
                 return result;
             });
     }
@@ -121,7 +121,7 @@ class EngineRegistries {
 
         if (args.length !== 3) {
             LOG.error(method, 'Invalid arguments', args);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
             throw new Error(util.format('Invalid arguments "%j" to function "%s", expecting "%j"', args, 'addRegistry', ['registryType', 'registryId', 'registryName']));
         }
         let registryType = args[0];
@@ -131,7 +131,7 @@ class EngineRegistries {
         return context.getRegistryManager().add(registryType, registryId, registryName)
             .then(() => {
                 LOG.exit(method);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
             });
     }
 

--- a/packages/composer-runtime/lib/engine.resources.js
+++ b/packages/composer-runtime/lib/engine.resources.js
@@ -40,7 +40,7 @@ class EngineResources {
 
         if (args.length !== 2) {
             LOG.error(method, 'Invalid arguments', args);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
             throw new Error(util.format('Invalid arguments "%j" to function "%s", expecting "%j"', args, 'getAllResourcesInRegistry', ['registryType', 'registryId']));
         }
         let registryType = args[0];
@@ -56,7 +56,7 @@ class EngineResources {
             })
             .then((result) => {
                 LOG.exit(method, result);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
                 return result;
             });
     }
@@ -75,7 +75,7 @@ class EngineResources {
 
         if (args.length !== 3) {
             LOG.error(method, 'Invalid arguments', args);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
             throw new Error(util.format('Invalid arguments "%j" to function "%s", expecting "%j"', args, 'getResourceInRegistry', ['registryType', 'registryId', 'resourceId']));
         }
         let registryType = args[0];
@@ -90,7 +90,7 @@ class EngineResources {
             })
             .then((result) => {
                 LOG.exit(method, result);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
                 return result;
             });
     }
@@ -109,7 +109,7 @@ class EngineResources {
 
         if (args.length !== 3) {
             LOG.error(method, 'Invalid arguments', args);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
             throw new Error(util.format('Invalid arguments "%j" to function "%s", expecting "%j"', args, 'existsResourceInRegistry', ['registryType', 'registryId', 'resourceId']));
         }
         let registryType = args[0];
@@ -121,7 +121,7 @@ class EngineResources {
             })
             .then((result) => {
                 LOG.exit(method, result);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
                 return result;
             });
     }
@@ -141,7 +141,7 @@ class EngineResources {
 
         if (args.length !== 2) {
             LOG.error(method, 'Invalid arguments', args);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
             throw new Error(util.format('Invalid arguments "%j" to function "%s", expecting "%j"', args, 'resolveAllResourcesInRegistry', ['registryType', 'registryId']));
         }
         let registryType = args[0];
@@ -170,7 +170,7 @@ class EngineResources {
             })
             .then((result) => {
                 LOG.exit(method, result);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
                 return result;
             });
     }
@@ -190,7 +190,7 @@ class EngineResources {
 
         if (args.length !== 3) {
             LOG.error(method, 'Invalid arguments', args);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
             throw new Error(util.format('Invalid arguments "%j" to function "%s", expecting "%j"', args, 'resolveResourceInRegistry', ['registryType', 'registryId', 'resourceId']));
         }
         let registryType = args[0];
@@ -210,7 +210,7 @@ class EngineResources {
             })
             .then((result) => {
                 LOG.exit(method, result);
-                LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+                LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
                 return result;
             });
     }

--- a/packages/composer-runtime/lib/engine.transactions.js
+++ b/packages/composer-runtime/lib/engine.transactions.js
@@ -40,7 +40,7 @@ class EngineTransactions {
 
         if (args.length !== 1) {
             LOG.error(method, 'Invalid arguments', args);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
             throw new Error(util.format('Invalid arguments "%j" to function "%s", expecting "%j"', args, 'submitTransaction', [ 'serializedResource']));
         }
 
@@ -95,7 +95,7 @@ class EngineTransactions {
 
         context.clearTransaction();
         LOG.exit(method, returnValue);
-        LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+        LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
         return returnValue;
     }
 
@@ -129,13 +129,13 @@ class EngineTransactions {
         if (totalExecuted === 0) {
             const error = new Error(`Could not find any functions to execute for transaction ${resolvedTransaction.getFullyQualifiedIdentifier()}`);
             LOG.error(method, error);
-            LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+            LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
             throw error;
         }
 
         // Handle the return values.
         const returnValue = this._processReturnValues(context, transaction, returnValues);
-        LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+        LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
         LOG.exit(method, returnValue);
         return returnValue;
     }
@@ -190,7 +190,7 @@ class EngineTransactions {
         }
 
         LOG.exit(method);
-        LOG.verbose('@PERF ' + method, 'Total (ms) duration: ' + (Date.now() - t0).toFixed(2));
+        LOG.perf(method, 'Total (ms) duration: ', context.getContextId(), t0);
         return record;
     }
 

--- a/packages/composer-runtime/package.json
+++ b/packages/composer-runtime/package.json
@@ -91,7 +91,8 @@
     "request-promise-any": "1.0.5",
     "semver": "5.3.0",
     "sha.js": "2.4.8",
-    "source-map": "0.5.6"
+    "source-map": "0.5.6",
+    "uuid": "3.0.1"
   },
   "nyc": {
     "exclude": [

--- a/packages/composer-runtime/test/context.js
+++ b/packages/composer-runtime/test/context.js
@@ -880,4 +880,21 @@ describe('Context', () => {
         });
     });
 
+    describe('#getContextId', () => {
+        it('should return an auto generated contextId', () => {
+            const id = context.getContextId();
+            id.should.be.a('string');
+        });
+    });
+
+
+    describe('#setContextId', () => {
+        it('should return an the given contextId', () => {
+            context.setContextId('myContext');
+            const id = context.getContextId();
+            id.should.equal('myContext');
+        });
+    });
+
+
 });


### PR DESCRIPTION
This doesn’t fix it for any other logging as all trace points
in composer-runtime will need to be changed, also somehow
the context would have to be passed to apis in composer-common
as well.

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
