### PR TITLE
[0.19.x] Experimental override chaincode version

### DIFF
--- a/packages/composer-connector-hlfv1/test/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/test/hlfconnection.js
@@ -692,6 +692,42 @@ describe('HLFConnection', () => {
             return connection.install(mockSecurityContext, mockBusinessNetwork, {npmrcFile: '/some/file'})
                 .then(() => {
                     sinon.assert.calledWith(connection.fs.copy, '/some/file', sinon.match(/\/.npmrc$/));
+                    sinon.assert.calledOnce(mockClient.installChaincode);
+                    sinon.assert.calledWith(mockClient.installChaincode, {
+                        chaincodeType: 'node',
+                        chaincodePath: sinon.match.string,
+                        metadataPath: sinon.match.string,
+                        chaincodeVersion: mockBusinessNetwork.getVersion(),
+                        chaincodeId: mockBusinessNetwork.getName(),
+                        txId: mockTransactionID,
+                        targets: [mockPeer1]
+                    });
+                });
+        });
+
+        it('should change the chaincode version if requested', () => {
+            // This is the install proposal and response (from the peers).
+            const proposalResponses = [{
+                response: {
+                    status: 200
+                }
+            }];
+            const proposal = { proposal: 'i do' };
+            const header = { header: 'gooooal' };
+            mockClient.installChaincode.resolves([ proposalResponses, proposal, header ]);
+            sandbox.stub(connection, '_validatePeerResponses').returns({ignoredErrors: 0, validResponses: proposalResponses});
+            return connection.install(mockSecurityContext, mockBusinessNetwork, {chaincodeVersion: '123.456'})
+                .then(() => {
+                    sinon.assert.calledOnce(mockClient.installChaincode);
+                    sinon.assert.calledWith(mockClient.installChaincode, {
+                        chaincodeType: 'node',
+                        chaincodePath: sinon.match.string,
+                        metadataPath: sinon.match.string,
+                        chaincodeVersion: '123.456',
+                        chaincodeId: mockBusinessNetwork.getName(),
+                        txId: mockTransactionID,
+                        targets: [mockPeer1]
+                    });
                 });
         });
 

--- a/packages/composer-connector-hlfv1/test/hlftxeventhandler.js
+++ b/packages/composer-connector-hlfv1/test/hlftxeventhandler.js
@@ -165,32 +165,32 @@ describe('HLFTxEventHandler', () => {
     });
 
     describe('#waitForEvents', () => {
-        it('Should do nothing if no events hubs', () => {
+        it('Should do nothing if no events hubs', async () => {
             let evHandler = new HLFTxEventHandler(null, null, null);
-            evHandler.waitForEvents().should.eventually.be.resolved;
+            await evHandler.waitForEvents().should.be.resolved;
             sinon.assert.calledOnce(logWarnSpy);
             evHandler = new HLFTxEventHandler([], '1234', 100);
-            evHandler.waitForEvents().should.eventually.be.resolved;
+            evHandler.waitForEvents().should.be.resolved;
             sinon.assert.calledTwice(logWarnSpy);
         });
 
-        it('Should do wait for 1 event', () => {
+        it('Should do wait for 1 event', async () => {
             sandbox.stub(global, 'setTimeout');
             eventhub1.isconnected.returns(true);
             let evHandler = new HLFTxEventHandler([eventhub1], '1234', 31);
             evHandler.startListening();
             evHandler.listenerPromises[0].should.be.instanceOf(Promise);
             evHandler.listenerPromises[0] = Promise.resolve();
-            evHandler.waitForEvents().should.eventually.be.resolved;
+            await evHandler.waitForEvents().should.be.resolved;
 
             evHandler = new HLFTxEventHandler([eventhub1], '1234', 31);
             evHandler.startListening();
             evHandler.listenerPromises[0].should.be.instanceOf(Promise);
             evHandler.listenerPromises[0] = Promise.reject();
-            evHandler.waitForEvents().should.eventually.be.rejected;
+            await evHandler.waitForEvents().should.be.rejected;
         });
 
-        it('Should do wait more than 1 event', () => {
+        it('Should do wait more than 1 event', async () => {
             sandbox.stub(global, 'setTimeout');
             eventhub1.isconnected.returns(true);
             eventhub2.isconnected.returns(true);
@@ -200,7 +200,7 @@ describe('HLFTxEventHandler', () => {
             evHandler.listenerPromises[0] = Promise.resolve();
             evHandler.listenerPromises[1].should.be.instanceOf(Promise);
             evHandler.listenerPromises[1] = Promise.reject();
-            evHandler.waitForEvents().should.eventually.be.rejected;
+            await evHandler.waitForEvents().should.be.rejected;
         });
 
         it('Should handle timeout for an event', () => {
@@ -209,7 +209,7 @@ describe('HLFTxEventHandler', () => {
             eventhub2.isconnected.returns(true);
             let evHandler = new HLFTxEventHandler([eventhub1, eventhub2], '1234', 31);
             evHandler.startListening();
-            evHandler.waitForEvents().should.eventually.be.rejectedWith(/commit notification/)
+            return evHandler.waitForEvents().should.eventually.be.rejectedWith(/commit notification/)
                 .then(() => {
                     sinon.assert.calledOnce(eventhub1.unregisterTxEvent);
                     sinon.assert.calledWith(eventhub1.unregisterTxEvent, '1234');
@@ -229,7 +229,7 @@ describe('HLFTxEventHandler', () => {
             eventhub2.isconnected.returns(true);
             let evHandler = new HLFTxEventHandler([eventhub1, eventhub2], '1234', 31);
             evHandler.startListening();
-            evHandler.waitForEvents()
+            return evHandler.waitForEvents()
                 .then(() => {
                     sinon.assert.calledOnce(eventhub1.unregisterTxEvent);
                     sinon.assert.calledWith(eventhub1.unregisterTxEvent, '1234');
@@ -253,7 +253,7 @@ describe('HLFTxEventHandler', () => {
             eventhub2.isconnected.returns(true);
             let evHandler = new HLFTxEventHandler([eventhub1, eventhub2], '1234', 31);
             evHandler.startListening();
-            evHandler.waitForEvents().should.eventually.be.rejectedWith(/rejected transaction/)
+            return evHandler.waitForEvents().should.eventually.be.rejectedWith(/rejected transaction/)
                 .then(() => {
                     sinon.assert.calledOnce(eventhub1.unregisterTxEvent);
                     sinon.assert.calledWith(eventhub1.unregisterTxEvent, '1234');


### PR DESCRIPTION
This is an experimental feature and meant for advanced and knowledgable composer
users who have multiple channels running the same bna and are looking to provide
scaling through multiple chaincode instances due to lack of capability currently in
hyperledger fabric.

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
