### PR TITLE
[0.19.x] Performance fixes within runtime:

### DIFF
--- a/packages/composer-common/lib/introspect/property.js
+++ b/packages/composer-common/lib/introspect/property.js
@@ -124,25 +124,35 @@ class Property extends Decorated {
      * @return {string} the fully qualified type of this property
      */
     getFullyQualifiedTypeName() {
+
         if(this.isPrimitive()) {
             return this.type;
         }
 
-        const parent = this.getParent();
-        if(!parent) {
-            throw new Error('Property ' + this.name + ' does not have a parent.');
-        }
-        const modelFile = parent.getModelFile();
-        if(!modelFile) {
-            throw new Error('Parent of property ' + this.name + ' does not have a ModelFile!');
+        if (this.fullyQualifiedTypeName){
+            return this.fullyQualifiedTypeName;
+        } else {
+            const parent = this.getParent();
+            if(!parent) {
+                throw new Error('Property ' + this.name + ' does not have a parent.');
+            }
+            const modelFile = parent.getModelFile();
+            if(!modelFile) {
+                throw new Error('Parent of property ' + this.name + ' does not have a ModelFile!');
+            }
+
+            const result = modelFile.getFullyQualifiedTypeName(this.type);
+
+            if(!result) {
+                throw new Error('Failed to find fully qualified type name for property ' + this.name + ' with type ' + this.type );
+            }
+
+            this.fullyQualifiedTypeName = result;
+            Object.defineProperty(this, 'fullyQualifiedTypeName', { enumerable: false });
+
+            return result;
         }
 
-        const result = modelFile.getFullyQualifiedTypeName(this.type);
-        if(!result) {
-            throw new Error('Failed to find fully qualified type name for property ' + this.name + ' with type ' + this.type );
-        }
-
-        return result;
     }
 
     /**

--- a/packages/composer-common/lib/serializer/instancegenerator.js
+++ b/packages/composer-common/lib/serializer/instancegenerator.js
@@ -17,7 +17,6 @@
 const ClassDeclaration = require('../introspect/classdeclaration');
 const EnumDeclaration = require('../introspect/enumdeclaration');
 const Field = require('../introspect/field');
-// const leftPad = require('left-pad');
 const padStart = require('lodash.padstart');
 const ModelUtil = require('../modelutil');
 const RelationshipDeclaration = require('../introspect/relationshipdeclaration');
@@ -63,7 +62,8 @@ class InstanceGenerator {
     visitClassDeclaration(classDeclaration, parameters) {
         const obj = parameters.stack.pop();
         const properties = classDeclaration.getProperties();
-        for (const property of properties) {
+        for (const index in properties) {
+            const property = properties[index];
             if (!parameters.includeOptionalFields && property.isOptional()) {
                 continue;
             }

--- a/packages/composer-common/lib/serializer/jsonpopulator.js
+++ b/packages/composer-common/lib/serializer/jsonpopulator.js
@@ -39,21 +39,25 @@ function isSystemProperty(name) {
  * @private
  */
 function getAssignableProperties(resourceData) {
-    return Object.keys(resourceData).filter((property) => {
-        return !isSystemProperty(property) && !Util.isNull(resourceData[property]);
-    });
+    const assignable = [];
+    for (const property in resourceData){
+        if(!isSystemProperty(property) && !Util.isNull(resourceData[property])){
+            assignable.push(property);
+        }
+    }
+    return assignable;
 }
 
 /**
  * Assert that all resource properties exist in a given class declaration.
- * @param {Array} properties Property names.
+ * @param {Array} propertyNames Property names.
  * @param {ClassDeclaration} classDeclaration class declaration.
  * @throws {ValidationException} if any properties are not defined by the class declaration.
  * @private
  */
-function validateProperties(properties, classDeclaration) {
+function validateProperties(propertyNames, classDeclaration) {
     const expectedProperties = classDeclaration.getProperties().map((property) => property.getName());
-    const invalidProperties = properties.filter((property) => !expectedProperties.includes(property));
+    const invalidProperties = propertyNames.filter((property) => !expectedProperties.includes(property));
     if (invalidProperties.length > 0) {
         const errorText = `Unexpected properties for type ${classDeclaration.getFullyQualifiedName()}: ` +
             invalidProperties.join(', ');
@@ -117,12 +121,13 @@ class JSONPopulator {
         const properties = getAssignableProperties(jsonObj);
         validateProperties(properties, classDeclaration);
 
-        properties.forEach((property) => {
+        for (const index in properties) {
+            const property = properties[index];
             const value = jsonObj[property];
             parameters.jsonStack.push(value);
             const classProperty = classDeclaration.getProperty(property);
-            resourceObj[property] = classProperty.accept(this,parameters);
-        });
+            resourceObj[property] = classProperty.accept(this, parameters);
+        }
 
         return resourceObj;
     }
@@ -194,7 +199,7 @@ class JSONPopulator {
             classDeclaration.accept(this, parameters);
         }
         else {
-            result = this.convertToObject(field,jsonItem);
+            result = this.convertToObject(field, jsonItem);
         }
 
         return result;

--- a/packages/composer-common/lib/util.js
+++ b/packages/composer-common/lib/util.js
@@ -116,7 +116,6 @@ class Util {
         if (transaction instanceof Resource){
             transaction.setIdentifier(txId.idStr);
             json = serializer.toJSON(transaction);
-
         } else {
             transaction.transactionId = txId.idStr;
             json=transaction;

--- a/packages/composer-common/test/introspect/property_ex.js
+++ b/packages/composer-common/test/introspect/property_ex.js
@@ -53,7 +53,7 @@ describe('Property', function () {
             const field = person.getProperty('owner');
             // stub the getType method to return null
             sinon.stub(field, 'getParent', function(){return null;});
-
+            field.fullyQualifiedTypeName = null;
             (function () {
                 field.getFullyQualifiedTypeName();
             }).should.throw(/Property owner does not have a parent./);
@@ -63,7 +63,7 @@ describe('Property', function () {
             const field = person.getProperty('owner');
             // stub the getType method to return null
             sinon.stub(person, 'getModelFile', function(){return null;});
-
+            field.fullyQualifiedTypeName = null;
             (function () {
                 field.getFullyQualifiedTypeName();
             }).should.throw(/Parent of property owner does not have a ModelFile!/);
@@ -73,7 +73,7 @@ describe('Property', function () {
             const field = person.getProperty('owner');
             // stub the getType method to return null
             sinon.stub(person.getModelFile(), 'getFullyQualifiedTypeName', function(){return null;});
-
+            field.fullyQualifiedTypeName = null;
             (function () {
                 field.getFullyQualifiedTypeName();
             }).should.throw(/Failed to find fully qualified type name for property owner with type Person/);
@@ -83,5 +83,6 @@ describe('Property', function () {
             const field = person.getProperty('owner');
             field.toString().should.equal('RelationshipDeclaration {name=owner, type=org.acme.l1.Person, array=false, optional=false}');
         });
+
     });
 });

--- a/packages/composer-runtime/lib/engine.transactions.js
+++ b/packages/composer-runtime/lib/engine.transactions.js
@@ -97,7 +97,7 @@ class EngineTransactions {
 
             // Store the historian record in the historian registry.
             LOG.debug(method, 'Storing Historian record in Historian registry');
-            await historian.add(historianRecord, {noTest: true});
+            await historian.add(historianRecord, {noTest: true, validate: false});
         }
 
         context.clearTransaction();
@@ -213,7 +213,7 @@ class EngineTransactions {
         const eventService = context.getEventService();
         record.eventsEmitted = [];
         eventService.getEvents().forEach((element) => {
-            const r = context.getSerializer().fromJSON(element);
+            const r = context.getSerializer().fromJSON(element, {validate: false});
             record.eventsEmitted.push(r);
         } );
 

--- a/packages/composer-runtime/lib/registry.js
+++ b/packages/composer-runtime/lib/registry.js
@@ -131,7 +131,7 @@ class Registry extends EventEmitter {
             let object = await this.dataCollection.get(id);
             object = Registry.removeInternalProperties(object);
             try {
-                const resource = this.serializer.fromJSON(object);
+                const resource = this.serializer.fromJSON(object, {validate: false});
                 await this.accessController.check(resource, 'READ');
                 this.objectMap.set(id, object);
                 return true;

--- a/packages/composer-runtime/lib/registrymanager.js
+++ b/packages/composer-runtime/lib/registrymanager.js
@@ -293,7 +293,7 @@ class RegistryManager extends EventEmitter {
             // go to the sysregistries datacollection and get the 'resource' for the registry we are interested in
             const json = await this.sysregistries.get(collectionID);
             // do we have permission to be looking at this??
-            const resource = this.serializer.fromJSON(json);
+            const resource = this.serializer.fromJSON(json, {validate: false});
             await this.accessController.check(resource, 'READ');
             // if we got here then, we the accessController.check was OK, get the dataCollection with the actual information
             // for the require registry
@@ -330,7 +330,7 @@ class RegistryManager extends EventEmitter {
                     return this.sysregistries.get(collectionID)
                         .then((result) => {
                             // do we REALLY have permission to be looking at this??
-                            resource = this.serializer.fromJSON(result);
+                            resource = this.serializer.fromJSON(result, {validate: false});
                             return this.accessController.check(resource, 'READ');
                         })
                         .then(() => {

--- a/packages/composer-runtime/lib/transactionlogger.js
+++ b/packages/composer-runtime/lib/transactionlogger.js
@@ -66,11 +66,13 @@ class TransactionLogger {
 
         // Serialize both the old and new resources.
         let oldJSON = this.serializer.toJSON(event.oldResource, {
-            convertResourcesToRelationships: true
+            convertResourcesToRelationships: true,
+            validate: false
         });
         LOG.debug(method, 'Serialized old resource');
         let newJSON = this.serializer.toJSON(event.newResource, {
-            convertResourcesToRelationships: true
+            convertResourcesToRelationships: true,
+            validate: false
         });
         LOG.debug(method, 'Serialized new resource');
 

--- a/packages/composer-runtime/test/api.js
+++ b/packages/composer-runtime/test/api.js
@@ -296,46 +296,38 @@ describe('Api', () => {
             });
         });
 
-        it('should perform a query using a named query', () => {
-            return api.query(queryID)
-                .should.eventually.be.deep.equal(resources)
-                .then(() => {
-                    sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
-                    sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryID);
-                    sinon.assert.callCount(mockAccessController.check, 5);
-                });
+        it('should perform a query using a named query', async () => {
+            const result = await api.query(queryID);
+            result.should.deep.equal(resources);
+            sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
+            sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryID);
+            sinon.assert.callCount(mockAccessController.check, 5);
         });
 
-        it('should perform a query using a named query and parameters', () => {
-            return api.query(queryID, queryParams)
-                .should.eventually.be.deep.equal(resources)
-                .then(() => {
-                    sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
-                    sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryID, queryParams);
-                    sinon.assert.callCount(mockAccessController.check, 5);
-                });
+        it('should perform a query using a named query and parameters', async () => {
+            const result = await api.query(queryID, queryParams);
+            result.should.deep.equal(resources);
+            sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
+            sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryID, queryParams);
+            sinon.assert.callCount(mockAccessController.check, 5);
         });
 
-        it('should perform a query using a built query', () => {
+        it('should perform a query using a built query', async () => {
             const query = new Query(queryHash);
-            return api.query(query)
-                .should.eventually.be.deep.equal(resources)
-                .then(() => {
-                    sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
-                    sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryHash);
-                    sinon.assert.callCount(mockAccessController.check, 5);
-                });
+            const result = await api.query(query);
+            result.should.deep.equal(resources);
+            sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
+            sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryHash);
+            sinon.assert.callCount(mockAccessController.check, 5);
         });
 
-        it('should perform a query using a built query and parameters', () => {
+        it('should perform a query using a built query and parameters', async () => {
             const query = new Query(queryHash);
-            return api.query(query, queryParams)
-                .should.eventually.be.deep.equal(resources)
-                .then(() => {
-                    sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
-                    sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryHash, queryParams);
-                    sinon.assert.callCount(mockAccessController.check, 5);
-                });
+            const result = await api.query(query, queryParams);
+            result.should.deep.equal(resources);
+            sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
+            sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryHash, queryParams);
+            sinon.assert.callCount(mockAccessController.check, 5);
         });
 
     });

--- a/packages/composer-runtime/test/engine.transactions.js
+++ b/packages/composer-runtime/test/engine.transactions.js
@@ -243,7 +243,7 @@ describe('EngineTransactions', () => {
             sinon.assert.calledOnce(mockTransactionRegistry.add);
             sinon.assert.calledWith(mockTransactionRegistry.add, sinon.match(transaction => transaction.getFullyQualifiedIdentifier() === 'org.acme.MyTransaction#TX_1'), { noTest: true });
             sinon.assert.calledOnce(mockHistorian.add);
-            sinon.assert.calledWith(mockHistorian.add, sinon.match(historianRecord => historianRecord.getFullyQualifiedIdentifier() === 'org.hyperledger.composer.system.HistorianRecord#TX_1'), { noTest: true });
+            sinon.assert.calledWith(mockHistorian.add, sinon.match(historianRecord => historianRecord.getFullyQualifiedIdentifier() === 'org.hyperledger.composer.system.HistorianRecord#TX_1'), { noTest: true, validate: false });
         });
 
         it('should execute a transaction that does not return a value and write to historian if explicitly requested', async () => {
@@ -306,7 +306,7 @@ describe('EngineTransactions', () => {
             sinon.assert.calledOnce(mockTransactionRegistry.add);
             sinon.assert.calledWith(mockTransactionRegistry.add, sinon.match(transaction => transaction.getFullyQualifiedIdentifier() === 'org.acme.MyTransactionThatReturnsString#TX_1'), { noTest: true });
             sinon.assert.calledOnce(mockHistorian.add);
-            sinon.assert.calledWith(mockHistorian.add, sinon.match(historianRecord => historianRecord.getFullyQualifiedIdentifier() === 'org.hyperledger.composer.system.HistorianRecord#TX_1'), { noTest: true });
+            sinon.assert.calledWith(mockHistorian.add, sinon.match(historianRecord => historianRecord.getFullyQualifiedIdentifier() === 'org.hyperledger.composer.system.HistorianRecord#TX_1'), { noTest: true, validate: false });
         });
 
         it('should throw if the transaction cannot be added to the transaction registry', async () => {

--- a/packages/composer-tests-functional/systest/accesscontrols.js
+++ b/packages/composer-tests-functional/systest/accesscontrols.js
@@ -173,18 +173,11 @@ describe('Access control system tests', function() {
     });
 
 
-    it('should be able to enforce read access permissions on an asset registry via client getAll', () => {
-        return Promise.resolve()
-            .then(() => {
-                // Alice should only be able to read Alice's car.
-                return aliceAssetRegistry.getAll()
-                    .should.eventually.be.deep.equal([aliceCar]);
-            })
-            .then(() => {
-                // Bob should only be able to read Bob's car.
-                return bobAssetRegistry.getAll()
-                    .should.eventually.be.deep.equal([bobCar]);
-            });
+    it('should be able to enforce read access permissions on an asset registry via client getAll', async () => {
+        const aliceCars = await aliceAssetRegistry.getAll();
+        aliceCars.should.deep.equal([aliceCar]);
+        const bobCars = await bobAssetRegistry.getAll();
+        bobCars.should.deep.equal([bobCar]);
     });
 
     it('should be able to enforce read access permissions on an asset registry via client get', () => {


### PR DESCRIPTION
-Shortcut serialisation process if objects already exist in serializer, by provision of a Proxy object that maintains the state of the Resource and will update a $isDirty flag if the resource is modified
-Remove unrequired validation steps (if resource will arrive pre-validated, or is an internal Resource)
-Update tests to account for changes

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>