### PR TITLE
[0.19.x] Experimental Performance option within runtime

### DIFF
--- a/packages/composer-common/api.txt
+++ b/packages/composer-common/api.txt
@@ -258,6 +258,13 @@ class ModelManager {
    + DecoratorFactory[] getDecoratorFactories() 
    + void addDecoratorFactory(DecoratorFactory) 
 }
+class ReadOnlyDecorator extends Decorator {
+   + void constructor(Object) throws IllegalModelException
+   + boolean getValue() 
+}
+class ReadOnlyDecoratorFactory extends DecoratorFactory {
+   + Decorator newDecorator(Object) 
+}
 class ReturnsDecorator extends Decorator {
    + void constructor(Object) throws IllegalModelException
    + string getType() 
@@ -272,7 +279,7 @@ class ReturnsDecoratorFactory extends DecoratorFactory {
 class Serializer {
    + void constructor(Factory,ModelManager) 
    + void setDefaultOptions(Object) 
-   + Object toJSON(Resource,Object,boolean,boolean,boolean,boolean) throws Error
+   + Object toJSON(Resource,Object,boolean,boolean,boolean,boolean,boolean) throws Error
    + Resource fromJSON(Object,Object,boolean,boolean) 
 }
 class Wallet {

--- a/packages/composer-common/changelog.txt
+++ b/packages/composer-common/changelog.txt
@@ -24,6 +24,9 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
+Version 0.19.20 {5ff216eab17b2d990c43636c51a585b5} 2018-12-18
+- Add readonly decorator factory
+
 Version 0.19.11 {765772c9b73656c289a15398bccc76fd} 2018-06-29
 - Add decorator factories
 - Add returns decorator factory

--- a/packages/composer-common/index.js
+++ b/packages/composer-common/index.js
@@ -92,6 +92,7 @@ module.exports.Query = require('./lib/query/query');
 module.exports.QueryAnalyzer = require('./lib/query/queryanalyzer.js');
 module.exports.QueryFile = require('./lib/query/queryfile');
 module.exports.QueryManager = require('./lib/querymanager');
+module.exports.ReadOnlyDecoratorFactory = require('./lib/readonlydecoratorfactory');
 module.exports.Relationship = require('./lib/model/relationship');
 module.exports.RelationshipDeclaration = require('./lib/introspect/relationshipdeclaration');
 module.exports.Resource = require('./lib/model/resource');

--- a/packages/composer-common/lib/businessnetworkdefinition.js
+++ b/packages/composer-common/lib/businessnetworkdefinition.js
@@ -27,6 +27,7 @@ const minimatch = require('minimatch');
 const ModelManager = require('./modelmanager');
 const QueryFile = require('./query/queryfile');
 const QueryManager = require('./querymanager');
+const ReadOnlyDecoratorFactory = require('./readonlydecoratorfactory');
 const ReturnsDecoratorFactory = require('./returnsdecoratorfactory');
 const ScriptManager = require('./scriptmanager');
 const semver = require('semver');
@@ -117,6 +118,7 @@ class BusinessNetworkDefinition {
 
         this.modelManager = new ModelManager();
         this.modelManager.addDecoratorFactory(new CommitDecoratorFactory());
+        this.modelManager.addDecoratorFactory(new ReadOnlyDecoratorFactory());
         this.modelManager.addDecoratorFactory(new ReturnsDecoratorFactory());
         this.factory = this.modelManager.getFactory();
         this.serializer = this.modelManager.getSerializer();

--- a/packages/composer-common/lib/introspect/property.js
+++ b/packages/composer-common/lib/introspect/property.js
@@ -124,25 +124,35 @@ class Property extends Decorated {
      * @return {string} the fully qualified type of this property
      */
     getFullyQualifiedTypeName() {
+
         if(this.isPrimitive()) {
             return this.type;
         }
 
-        const parent = this.getParent();
-        if(!parent) {
-            throw new Error('Property ' + this.name + ' does not have a parent.');
-        }
-        const modelFile = parent.getModelFile();
-        if(!modelFile) {
-            throw new Error('Parent of property ' + this.name + ' does not have a ModelFile!');
+        if (this.fullyQualifiedTypeName){
+            return this.fullyQualifiedTypeName;
+        } else {
+            const parent = this.getParent();
+            if(!parent) {
+                throw new Error('Property ' + this.name + ' does not have a parent.');
+            }
+            const modelFile = parent.getModelFile();
+            if(!modelFile) {
+                throw new Error('Parent of property ' + this.name + ' does not have a ModelFile!');
+            }
+
+            const result = modelFile.getFullyQualifiedTypeName(this.type);
+
+            if(!result) {
+                throw new Error('Failed to find fully qualified type name for property ' + this.name + ' with type ' + this.type );
+            }
+
+            this.fullyQualifiedTypeName = result;
+            Object.defineProperty(this, 'fullyQualifiedTypeName', { enumerable: false });
+
+            return result;
         }
 
-        const result = modelFile.getFullyQualifiedTypeName(this.type);
-        if(!result) {
-            throw new Error('Failed to find fully qualified type name for property ' + this.name + ' with type ' + this.type );
-        }
-
-        return result;
     }
 
     /**

--- a/packages/composer-common/lib/readonlydecorator.js
+++ b/packages/composer-common/lib/readonlydecorator.js
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Decorator = require('./introspect/decorator');
+const IllegalModelException = require('./introspect/illegalmodelexception');
+
+/**
+ * Specialised decorator implementation for the @readonly decorator.
+ */
+class ReadOnlyDecorator extends Decorator {
+
+    /**
+     * Create a Decorator.
+     * @param {ClassDeclaration | Property} parent - the owner of this property
+     * @param {Object} ast - The AST created by the parser
+     * @throws {IllegalModelException}
+     */
+    constructor(parent, ast) {
+        super(parent, ast);
+    }
+
+    /**
+     * Process the AST and build the model
+     * @throws {IllegalModelException}
+     * @private
+     */
+    process() {
+        super.process();
+        const args = this.getArguments();
+        if (args.length !== 1) {
+            throw new IllegalModelException(`@readonly decorator expects 1 argument, but ${args.length} arguments were specified.`, this.parent.getModelFile(), this.ast.location);
+        }
+        const arg = args[0];
+        if (typeof arg !== 'boolean') {
+            throw new IllegalModelException(`@readonly decorator expects a boolean argument, but an argument of type ${typeof arg} was specified.`, this.parent.getModelFile(), this.ast.location);
+        }
+        this.value = arg;
+    }
+
+    /**
+     * Get the value of this commit decorator.
+     * @return {boolean} The value of this commit decorator.
+     */
+    getValue() {
+        return this.value;
+    }
+
+}
+
+module.exports = ReadOnlyDecorator;

--- a/packages/composer-common/lib/readonlydecoratorfactory.js
+++ b/packages/composer-common/lib/readonlydecoratorfactory.js
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const DecoratorFactory = require('./introspect/decoratorfactory');
+const ReadOnlyDecorator = require('./readonlydecorator');
+
+/**
+ * A decorator factory for the @readonly decorator.
+ */
+class ReadOnlyDecoratorFactory extends DecoratorFactory {
+
+    /**
+     * Process the decorator, and return a specific implementation class for that
+     * decorator, or return null if this decorator is not handled by this processor.
+     * @abstract
+     * @param {ClassDeclaration | Property} parent - the owner of this property
+     * @param {Object} ast - The AST created by the parser
+     * @return {Decorator} The decorator.
+     */
+    newDecorator(parent, ast) {
+        if (ast.name !== 'readonly') {
+            return null;
+        }
+        return new ReadOnlyDecorator(parent, ast);
+    }
+
+}
+
+module.exports = ReadOnlyDecoratorFactory;

--- a/packages/composer-common/lib/serializer.js
+++ b/packages/composer-common/lib/serializer.js
@@ -68,6 +68,22 @@ class Serializer {
         this.defaultOptions = Object.assign({}, baseDefaultOptions, newDefaultOptions);
     }
 
+
+    /**
+     * Generate validation parameters for a Resource
+     * @private
+     * @param {Resource} resource - The instance being worked
+     * @returns {Object} parameters used for validation
+     */
+    validationParameters(resource){
+        const parameters = {};
+        parameters.stack = new TypedStack(resource);
+        parameters.modelManager = this.modelManager;
+        parameters.seenResources = new Set();
+        parameters.dedupeResources = new Set();
+        return parameters;
+    }
+
     /**
      * <p>
      * Convert a {@link Resource} to a JavaScript object suitable for long-term
@@ -84,6 +100,9 @@ class Serializer {
      * @param {boolean} [options.deduplicateResources] - Generate $id for resources and
      * if a resources appears multiple times in the object graph only the first instance is
      * serialized in full, subsequent instances are replaced with a reference to the $id
+     * @param {boolean} [options.useOriginal] - shortcut the generation of the JSON structure from
+     * the resource and directly return the $original if present from the creation of the resource
+     * through the fromJSON method
      * @return {Object} - The Javascript Object that represents the resource
      * @throws {Error} - throws an exception if resource is not an instance of
      * Resource or fails validation.
@@ -94,15 +113,18 @@ class Serializer {
             throw new Error(Globalize.formatMessage('serializer-tojson-notcobject'));
         }
 
-        const parameters = {};
-        parameters.stack = new TypedStack(resource);
-        parameters.modelManager = this.modelManager;
-        parameters.seenResources = new Set();
-        parameters.dedupeResources = new Set();
+        // Assign options
+        options = options ? Object.assign({}, this.defaultOptions, options) : this.defaultOptions;
+
+        // Enable shortcut retrieval of original JSON stored during serializer.fromJSON() method call
+        if (resource.$original && options.useOriginal) {
+            return resource.$original;
+        }
+
+        const parameters = this.validationParameters(resource);
         const classDeclaration = this.modelManager.getType( resource.getFullyQualifiedType() );
 
-        // validate the resource against the model
-        options = options ? Object.assign({}, this.defaultOptions, options) : this.defaultOptions;
+        // conditionally validate the resource against the model
         if(options.validate) {
             const validator = new ResourceValidator(options);
             classDeclaration.accept(validator, parameters);
@@ -120,6 +142,7 @@ class Serializer {
         // this performs the conversion of the resouce into a standard JSON object
         let result = classDeclaration.accept(generator, parameters);
         return result;
+
     }
 
     /**
@@ -183,6 +206,11 @@ class Serializer {
         if(options.validate) {
             resource.validate();
         }
+
+        // Store the original JSON object to enable consditional retrieval later
+        delete jsonObject.$networkId;
+        resource.$original = jsonObject;
+        Object.defineProperty(resource, '$original', { enumerable: false });
 
         return resource;
     }

--- a/packages/composer-common/lib/serializer/instancegenerator.js
+++ b/packages/composer-common/lib/serializer/instancegenerator.js
@@ -17,7 +17,6 @@
 const ClassDeclaration = require('../introspect/classdeclaration');
 const EnumDeclaration = require('../introspect/enumdeclaration');
 const Field = require('../introspect/field');
-// const leftPad = require('left-pad');
 const padStart = require('lodash.padstart');
 const ModelUtil = require('../modelutil');
 const RelationshipDeclaration = require('../introspect/relationshipdeclaration');

--- a/packages/composer-common/lib/serializer/jsonpopulator.js
+++ b/packages/composer-common/lib/serializer/jsonpopulator.js
@@ -39,21 +39,25 @@ function isSystemProperty(name) {
  * @private
  */
 function getAssignableProperties(resourceData) {
-    return Object.keys(resourceData).filter((property) => {
-        return !isSystemProperty(property) && !Util.isNull(resourceData[property]);
-    });
+    const assignable = [];
+    for (const property in resourceData){
+        if(!isSystemProperty(property) && !Util.isNull(resourceData[property])){
+            assignable.push(property);
+        }
+    }
+    return assignable;
 }
 
 /**
  * Assert that all resource properties exist in a given class declaration.
- * @param {Array} properties Property names.
+ * @param {Array} propertyNames Property names.
  * @param {ClassDeclaration} classDeclaration class declaration.
  * @throws {ValidationException} if any properties are not defined by the class declaration.
  * @private
  */
-function validateProperties(properties, classDeclaration) {
+function validateProperties(propertyNames, classDeclaration) {
     const expectedProperties = classDeclaration.getProperties().map((property) => property.getName());
-    const invalidProperties = properties.filter((property) => !expectedProperties.includes(property));
+    const invalidProperties = propertyNames.filter((property) => !expectedProperties.includes(property));
     if (invalidProperties.length > 0) {
         const errorText = `Unexpected properties for type ${classDeclaration.getFullyQualifiedName()}: ` +
             invalidProperties.join(', ');
@@ -117,12 +121,12 @@ class JSONPopulator {
         const properties = getAssignableProperties(jsonObj);
         validateProperties(properties, classDeclaration);
 
-        properties.forEach((property) => {
+        for (const property of properties) {
             const value = jsonObj[property];
             parameters.jsonStack.push(value);
             const classProperty = classDeclaration.getProperty(property);
-            resourceObj[property] = classProperty.accept(this,parameters);
-        });
+            resourceObj[property] = classProperty.accept(this, parameters);
+        }
 
         return resourceObj;
     }
@@ -194,7 +198,7 @@ class JSONPopulator {
             classDeclaration.accept(this, parameters);
         }
         else {
-            result = this.convertToObject(field,jsonItem);
+            result = this.convertToObject(field, jsonItem);
         }
 
         return result;

--- a/packages/composer-common/lib/util.js
+++ b/packages/composer-common/lib/util.js
@@ -116,7 +116,6 @@ class Util {
         if (transaction instanceof Resource){
             transaction.setIdentifier(txId.idStr);
             json = serializer.toJSON(transaction);
-
         } else {
             transaction.transactionId = txId.idStr;
             json=transaction;

--- a/packages/composer-common/test/businessnetworkdefinition.js
+++ b/packages/composer-common/test/businessnetworkdefinition.js
@@ -23,6 +23,7 @@ const moxios = require('moxios');
 const nodeUtil = require('util');
 const os = require('os');
 const path = require('path');
+const ReadOnlyDecorator = require('../lib/readonlydecorator');
 const ReturnsDecorator = require('../lib/returnsdecorator');
 const rimraf = nodeUtil.promisify(require('rimraf'));
 
@@ -514,6 +515,18 @@ describe('BusinessNetworkDefinition', () => {
             const conceptDeclaration = modelManager.getType('org.acme.C');
             const decorator = conceptDeclaration.getDecorator('returns');
             decorator.should.be.an.instanceOf(ReturnsDecorator);
+        });
+
+        it('should install the decorator processor for @readonly', () => {
+            const bnd = new BusinessNetworkDefinition('id@1.0.0', 'description', null, 'readme');
+            const modelManager = bnd.getModelManager();
+            modelManager.addModelFile(`
+            namespace org.acme
+            @readonly(true)
+            transaction T{ }`);
+            const transactionDeclaration = modelManager.getType('org.acme.T');
+            const decorator = transactionDeclaration.getDecorator('readonly');
+            decorator.should.be.an.instanceOf(ReadOnlyDecorator);
         });
 
     });

--- a/packages/composer-common/test/introspect/property_ex.js
+++ b/packages/composer-common/test/introspect/property_ex.js
@@ -53,7 +53,7 @@ describe('Property', function () {
             const field = person.getProperty('owner');
             // stub the getType method to return null
             sinon.stub(field, 'getParent', function(){return null;});
-
+            field.fullyQualifiedTypeName = null;
             (function () {
                 field.getFullyQualifiedTypeName();
             }).should.throw(/Property owner does not have a parent./);
@@ -63,7 +63,7 @@ describe('Property', function () {
             const field = person.getProperty('owner');
             // stub the getType method to return null
             sinon.stub(person, 'getModelFile', function(){return null;});
-
+            field.fullyQualifiedTypeName = null;
             (function () {
                 field.getFullyQualifiedTypeName();
             }).should.throw(/Parent of property owner does not have a ModelFile!/);
@@ -73,7 +73,7 @@ describe('Property', function () {
             const field = person.getProperty('owner');
             // stub the getType method to return null
             sinon.stub(person.getModelFile(), 'getFullyQualifiedTypeName', function(){return null;});
-
+            field.fullyQualifiedTypeName = null;
             (function () {
                 field.getFullyQualifiedTypeName();
             }).should.throw(/Failed to find fully qualified type name for property owner with type Person/);
@@ -83,5 +83,6 @@ describe('Property', function () {
             const field = person.getProperty('owner');
             field.toString().should.equal('RelationshipDeclaration {name=owner, type=org.acme.l1.Person, array=false, optional=false}');
         });
+
     });
 });

--- a/packages/composer-common/test/readonlydecorator.js
+++ b/packages/composer-common/test/readonlydecorator.js
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const ReadOnlyDecorator = require('../lib/readonlydecorator');
+const ReadOnlyDecoratorDecoratorFactory = require('../lib/readonlydecoratorfactory');
+const ModelManager = require('../lib/modelmanager');
+
+require('chai').should();
+
+describe('RaedOnlyDecorator', () => {
+
+    let modelManager;
+    let transactionDeclaration;
+
+    beforeEach(() => {
+        modelManager = new ModelManager();
+        modelManager.addDecoratorFactory(new ReadOnlyDecoratorDecoratorFactory());
+        modelManager.addModelFile(`
+        namespace org.acme
+        transaction T { }
+        `);
+        transactionDeclaration = modelManager.getType('org.acme.T');
+    });
+
+    describe('#process', () => {
+
+        it('should throw if no arguments are specified', () => {
+            (() => {
+                new ReadOnlyDecorator(transactionDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'readonly', arguments: { list: [] } });
+            }).should.throw(/@readonly decorator expects 1 argument, but 0 arguments were specified. Line 1 column 1, to line 1 column 23./);
+        });
+
+        it('should throw if two arguments are specified', () => {
+            (() => {
+                new ReadOnlyDecorator(transactionDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'readonly', arguments: { list: [ { value: true }, { value: false } ] } });
+            }).should.throw(/@readonly decorator expects 1 argument, but 2 arguments were specified. Line 1 column 1, to line 1 column 23./);
+        });
+
+        it('should throw if a an incorrectly typed argument is specified', () => {
+            (() => {
+                new ReadOnlyDecorator(transactionDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'readonly', arguments: { list: [ { value: 'hello world' } ] } });
+            }).should.throw(/@readonly decorator expects a boolean argument, but an argument of type string was specified. Line 1 column 1, to line 1 column 23./);
+        });
+
+    });
+
+    describe('#getValue', () => {
+
+        it('should return true if the argument is true', () => {
+            const decorator = new ReadOnlyDecorator(transactionDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'readonly', arguments: { list: [ { value: true } ] } });
+            decorator.getValue().should.be.true;
+        });
+
+        it('should return false if the argument is false', () => {
+            const decorator = new ReadOnlyDecorator(transactionDeclaration, { location: { start: { offset: 0, line: 1, column: 1 }, end: { offset: 22, line: 1, column: 23 } }, name: 'readonly', arguments: { list: [ { value: false } ] } });
+            decorator.getValue().should.be.false;
+        });
+
+    });
+
+});

--- a/packages/composer-common/test/readonlydecoratorfactory.js
+++ b/packages/composer-common/test/readonlydecoratorfactory.js
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const ReadOnlyDecorator = require('../lib/readonlydecorator');
+const ReadOnlyDecoratorDecoratorFactory = require('../lib/readonlydecoratorfactory');
+const ModelManager = require('../lib/modelmanager');
+
+const should = require('chai').should();
+
+describe('ReadOnlyDecoratorDecoratorFactory', () => {
+
+    let modelManager;
+    let transactionDeclaration;
+    let factory;
+
+    beforeEach(() => {
+        modelManager = new ModelManager();
+        modelManager.addModelFile(`
+        namespace org.acme
+        transaction T { }
+        `);
+        transactionDeclaration = modelManager.getType('org.acme.T');
+        factory = new ReadOnlyDecoratorDecoratorFactory();
+    });
+
+    describe('#process', () => {
+
+        it('should return null for a @foobar decorator', () => {
+            should.equal(factory.newDecorator(transactionDeclaration, { name: 'foobar' }), null);
+        });
+
+        it('should return a readonly decorator instance for a @readonly decorator', () => {
+            const decorator = factory.newDecorator(transactionDeclaration, { name: 'readonly', arguments: { list: [ { value: false } ] } });
+            decorator.should.be.an.instanceOf(ReadOnlyDecorator);
+        });
+
+    });
+
+});

--- a/packages/composer-runtime/lib/registry.js
+++ b/packages/composer-runtime/lib/registry.js
@@ -131,7 +131,7 @@ class Registry extends EventEmitter {
             let object = await this.dataCollection.get(id);
             object = Registry.removeInternalProperties(object);
             try {
-                const resource = this.serializer.fromJSON(object);
+                const resource = this.serializer.fromJSON(object, {validate: false});
                 await this.accessController.check(resource, 'READ');
                 this.objectMap.set(id, object);
                 return true;

--- a/packages/composer-runtime/lib/registrymanager.js
+++ b/packages/composer-runtime/lib/registrymanager.js
@@ -293,7 +293,7 @@ class RegistryManager extends EventEmitter {
             // go to the sysregistries datacollection and get the 'resource' for the registry we are interested in
             const json = await this.sysregistries.get(collectionID);
             // do we have permission to be looking at this??
-            const resource = this.serializer.fromJSON(json);
+            const resource = this.serializer.fromJSON(json, {validate: false});
             await this.accessController.check(resource, 'READ');
             // if we got here then, we the accessController.check was OK, get the dataCollection with the actual information
             // for the require registry
@@ -330,7 +330,7 @@ class RegistryManager extends EventEmitter {
                     return this.sysregistries.get(collectionID)
                         .then((result) => {
                             // do we REALLY have permission to be looking at this??
-                            resource = this.serializer.fromJSON(result);
+                            resource = this.serializer.fromJSON(result, {validate: false});
                             return this.accessController.check(resource, 'READ');
                         })
                         .then(() => {

--- a/packages/composer-runtime/lib/transactionlogger.js
+++ b/packages/composer-runtime/lib/transactionlogger.js
@@ -66,11 +66,13 @@ class TransactionLogger {
 
         // Serialize both the old and new resources.
         let oldJSON = this.serializer.toJSON(event.oldResource, {
-            convertResourcesToRelationships: true
+            convertResourcesToRelationships: true,
+            validate: false
         });
         LOG.debug(method, 'Serialized old resource');
         let newJSON = this.serializer.toJSON(event.newResource, {
-            convertResourcesToRelationships: true
+            convertResourcesToRelationships: true,
+            validate: false
         });
         LOG.debug(method, 'Serialized new resource');
 

--- a/packages/composer-runtime/test/api.js
+++ b/packages/composer-runtime/test/api.js
@@ -296,46 +296,38 @@ describe('Api', () => {
             });
         });
 
-        it('should perform a query using a named query', () => {
-            return api.query(queryID)
-                .should.eventually.be.deep.equal(resources)
-                .then(() => {
-                    sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
-                    sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryID);
-                    sinon.assert.callCount(mockAccessController.check, 5);
-                });
+        it('should perform a query using a named query', async () => {
+            const result = await api.query(queryID);
+            result.should.deep.equal(resources);
+            sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
+            sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryID);
+            sinon.assert.callCount(mockAccessController.check, 5);
         });
 
-        it('should perform a query using a named query and parameters', () => {
-            return api.query(queryID, queryParams)
-                .should.eventually.be.deep.equal(resources)
-                .then(() => {
-                    sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
-                    sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryID, queryParams);
-                    sinon.assert.callCount(mockAccessController.check, 5);
-                });
+        it('should perform a query using a named query and parameters', async () => {
+            const result = await api.query(queryID, queryParams);
+            result.should.deep.equal(resources);
+            sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
+            sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryID, queryParams);
+            sinon.assert.callCount(mockAccessController.check, 5);
         });
 
-        it('should perform a query using a built query', () => {
+        it('should perform a query using a built query', async () => {
             const query = new Query(queryHash);
-            return api.query(query)
-                .should.eventually.be.deep.equal(resources)
-                .then(() => {
-                    sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
-                    sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryHash);
-                    sinon.assert.callCount(mockAccessController.check, 5);
-                });
+            const result = await api.query(query);
+            result.should.deep.equal(resources);
+            sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
+            sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryHash);
+            sinon.assert.callCount(mockAccessController.check, 5);
         });
 
-        it('should perform a query using a built query and parameters', () => {
+        it('should perform a query using a built query and parameters', async () => {
             const query = new Query(queryHash);
-            return api.query(query, queryParams)
-                .should.eventually.be.deep.equal(resources)
-                .then(() => {
-                    sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
-                    sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryHash, queryParams);
-                    sinon.assert.callCount(mockAccessController.check, 5);
-                });
+            const result = await api.query(query, queryParams);
+            result.should.deep.equal(resources);
+            sinon.assert.calledOnce(mockCompiledQueryBundle.execute);
+            sinon.assert.calledWith(mockCompiledQueryBundle.execute, mockDataService, queryHash, queryParams);
+            sinon.assert.callCount(mockAccessController.check, 5);
         });
 
     });

--- a/packages/composer-tests-functional/systest/accesscontrols.js
+++ b/packages/composer-tests-functional/systest/accesscontrols.js
@@ -173,18 +173,11 @@ describe('Access control system tests', function() {
     });
 
 
-    it('should be able to enforce read access permissions on an asset registry via client getAll', () => {
-        return Promise.resolve()
-            .then(() => {
-                // Alice should only be able to read Alice's car.
-                return aliceAssetRegistry.getAll()
-                    .should.eventually.be.deep.equal([aliceCar]);
-            })
-            .then(() => {
-                // Bob should only be able to read Bob's car.
-                return bobAssetRegistry.getAll()
-                    .should.eventually.be.deep.equal([bobCar]);
-            });
+    it('should be able to enforce read access permissions on an asset registry via client getAll', async () => {
+        const aliceCars = await aliceAssetRegistry.getAll();
+        aliceCars.should.deep.equal([aliceCar]);
+        const bobCars = await bobAssetRegistry.getAll();
+        bobCars.should.deep.equal([bobCar]);
     });
 
     it('should be able to enforce read access permissions on an asset registry via client get', () => {


### PR DESCRIPTION
Performance fixes within runtime to enable skipping JSON generation within serializer if a flag is passed, and enabling the use of this flag in TPFs
-Shortcut serialisation process if objects already exist in serializer and flag is passed
-Add new Decorator to model file for transactions to pass flag to serializer
-Remove unrequired validation steps
-Update tests to account for changes
-Update API text and digest

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>
